### PR TITLE
invert guard clause

### DIFF
--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -30,12 +30,12 @@ const restRequest = async (url, params) => {
 const restRequestWithHtmlResponse = async (url, params) => {
   try {
     const res = await fetch(url, params);
-    if (res.status !== 200 && res.status !== 400) {
-      throw new HttpResponseError(res.status);
+    if (res.status === 200 || res.status === 400) {
+      const html = await res.text();
+      if (res.status === 400) throw Error("BadRequest", html);
+      return html;
     }
-    const html = await res.text();
-    if (res.status === 200) return html;
-    if (res.status === 400) throw Error("BadRequest", html);
+    throw new HttpResponseError(res.status);
   }
   catch(error) {
     if (error.status === 204) {


### PR DESCRIPTION
This is an example of removing dead code, and perhaps also an example of not using the guard clause.

Because the guard clause already excludes the possibility of non 200 or 400 status, therefore one of the later ifs are always true.

And due to the partially overlapped if conditions, perhaps nested ifs is better than a guard clause in this situation.
