### PR TITLE
Extract helper and then inline the helper

### DIFF
--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -5,7 +5,7 @@ const loginOrRegister = () => {
   window.location = `/users/identify?from=${window.location.href}`;
 };
 
-const restRequest = async (url, params) => {
+const request = async (url, params) => {
   try {
     const res = await fetch(url, params)
     if (res.status === 200 || res.status === 400) {
@@ -26,6 +26,8 @@ const restRequest = async (url, params) => {
     throw error
   }
 }
+
+const restRequest = async (url, params) => request(url, params)
 
 const restRequestWithHtmlResponse = async (url, params) => {
   try {

--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -34,25 +34,10 @@ const request = async (url, params) => {
 const restRequest = (url, params) => request(url, params).then(jsonResponseHelper)
 
 const restRequestWithHtmlResponse = async (url, params) => {
-  try {
-    const res = await fetch(url, params);
-    if (res.status === 200 || res.status === 400) {
-      const html = await res.text();
-      if (res.status === 400) throw Error("BadRequest", html);
-      return html;
-    }
-    throw new HttpResponseError(res.status);
-  }
-  catch(error) {
-    if (error.status === 204) {
-      return null;
-    }
-    if (error.status === 401) {
-      loginOrRegister();
-      return null;
-    }
-    throw error
-  }
+  const response = request(url, params)
+  const html = await response.text();
+  if (response.status === 400) throw Error("BadRequest", html);
+  return html;
 }
 
 const restGet = (url) => restRequest(url, {});

--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -15,7 +15,7 @@ const request = async (url, params) => {
   try {
     const res = await fetch(url, params)
     if (res.status === 200 || res.status === 400) {
-      return await jsonResponseHelper(res);
+      return res;
     }
     throw new HttpResponseError(res.status);
   }
@@ -31,7 +31,7 @@ const request = async (url, params) => {
   }
 }
 
-const restRequest = async (url, params) => request(url, params)
+const restRequest = (url, params) => request(url, params).then(jsonResponseHelper)
 
 const restRequestWithHtmlResponse = async (url, params) => {
   try {

--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -5,12 +5,6 @@ const loginOrRegister = () => {
   window.location = `/users/identify?from=${window.location.href}`;
 };
 
-const jsonResponseHelper = async (response) => {
-  const jsonResponse = await response.json()
-  if (response.status === 400) throw new BadRequestError(jsonResponse.errors);
-  return jsonResponse;
-}
-
 const request = async (url, params) => {
   try {
     const res = await fetch(url, params)
@@ -31,10 +25,15 @@ const request = async (url, params) => {
   }
 }
 
-const restRequest = (url, params) => request(url, params).then(jsonResponseHelper)
+const restRequest = async (url, params) => {
+  const response = await request(url, params);
+  const jsonResponse = await response.json()
+  if (response.status === 400) throw new BadRequestError(jsonResponse.errors);
+  return jsonResponse;
+}
 
 const restRequestWithHtmlResponse = async (url, params) => {
-  const response = request(url, params)
+  const response = await request(url, params)
   const html = await response.text();
   if (response.status === 400) throw Error("BadRequest", html);
   return html;

--- a/frontend/src/restful/restful.js
+++ b/frontend/src/restful/restful.js
@@ -5,13 +5,17 @@ const loginOrRegister = () => {
   window.location = `/users/identify?from=${window.location.href}`;
 };
 
+const jsonResponseHelper = async (response) => {
+  const jsonResponse = await response.json()
+  if (response.status === 400) throw new BadRequestError(jsonResponse.errors);
+  return jsonResponse;
+}
+
 const request = async (url, params) => {
   try {
     const res = await fetch(url, params)
     if (res.status === 200 || res.status === 400) {
-      const jsonResponse = await res.json()
-      if (res.status === 400) throw new BadRequestError(jsonResponse.errors);
-      return jsonResponse;
+      return await jsonResponseHelper(res);
     }
     throw new HttpResponseError(res.status);
   }


### PR DESCRIPTION
This might be an example for https://tidyfirst.substack.com/p/tidying-extract-helper?s=r

The difference is the "stuff that needs to change" is already made by my friend, and it ends up being duplicate code (`restRequest` and `restRequestWithHtmlResponse`). I used the extract helper method to remove the duplicate, and at last, I inlined the helper because it's not useful anymore.

By extracting the changing part to a helper function, it was clear to me that this changing part depends on the HttpResponse object, returns a JSON object, and potentially throws an exception. It gave me confidence when making the following changes.
