### PR TITLE
visit blank page in between tests

### DIFF
--- a/cypress/step_definitions/common/hook.ts
+++ b/cypress/step_definitions/common/hook.ts
@@ -27,7 +27,9 @@ Before({ tags: "@stopTime" }, () => {
 // the next test resets the DB while the current page refreshes
 // itself. So, here it visits the blank page at the end of each test.
 After({ tags: "@stopTime" }, () => {
-  cy.visit('about:blank')
+  cy.window().then((win) => {
+    win.location.href = 'about:blank'
+  })
 })
 
 Before({ tags: "@featureToggle" }, () => {

--- a/cypress/step_definitions/common/hook.ts
+++ b/cypress/step_definitions/common/hook.ts
@@ -21,6 +21,15 @@ Before({ tags: "@stopTime" }, () => {
   cy.clock()
 })
 
+// If a test needs to stop the timer, perhaps the tested
+// page refreshes automatically. The mocked timer is restored
+// between tests. It may cause a hard-to-trace problem when
+// the next test resets the DB while the current page refreshes
+// itself. So, here it visits the blank page at the end of each test.
+After({ tags: "@stopTime" }, () => {
+  cy.visit('about:blank')
+})
+
 Before({ tags: "@featureToggle" }, () => {
   cy.enableFeatureToggle(true)
 })


### PR DESCRIPTION
A seemingly unnecessary action after the @stopTime test will prevent flaky tests.