### PR TITLE
Bump spotless to 6.7.2 and remove the workaround

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'java'
   // Spotless for the code style
-  id "com.diffplug.spotless" version "6.6.1"
+  id "com.diffplug.spotless" version "6.7.2"
 }
 
 apply plugin: 'cz.habarta.typescript-generator'

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,7 +1,0 @@
-# Spotless JDK16+ workaround
-# https://github.com/diffplug/spotless/issues/834#issuecomment-819118761
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
no more workaround required after 6.7.1

ref: https://github.com/diffplug/spotless/issues/834