### PR TITLE
fix/port-for-local-dev

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -52,7 +52,7 @@ dum i && dum frontend:build
 dum sut
 ```
 
-Open your browser to visit http://localhost:5173
+Open your browser to visit http://localhost:9081
 
 Run E2E profile with backend server & frontend in dev mode & Cypress IDE (frontend app on port 5173; backend app on port 9081)
 For MS Windows users, you need to ensure your WSL2 Linux has `xvfb` installed. This is not managed by Nix!


### PR DESCRIPTION
realised that after following the steps, i can only reach 9081.

`dum sut` only starts the backend

`dum frontend:sut` starts the frontend

so the instruction to visit port 5173 should only come after `dum frontend:sut`