### PR TITLE
Add edit and delete functionality for predefined questions

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/RestPredefinedQuestionController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/RestPredefinedQuestionController.java
@@ -116,4 +116,25 @@ class RestPredefinedQuestionController {
     currentUser.assertAuthorization(predefinedQuestion.getNote());
     return predefinedQuestionService.toggleApproval(predefinedQuestion);
   }
+
+  @DeleteMapping("/{predefinedQuestion}")
+  @Transactional
+  public void deleteQuestion(
+      @PathVariable("predefinedQuestion") @Schema(type = "integer")
+          PredefinedQuestion predefinedQuestion)
+      throws UnexpectedNoAccessRightException {
+    currentUser.assertAuthorization(predefinedQuestion.getNote());
+    predefinedQuestionService.deleteQuestion(predefinedQuestion);
+  }
+
+  @PatchMapping("/{predefinedQuestion}")
+  @Transactional
+  public PredefinedQuestion updateQuestion(
+      @PathVariable("predefinedQuestion") @Schema(type = "integer")
+          PredefinedQuestion predefinedQuestion,
+      @Valid @RequestBody PredefinedQuestion updatedQuestion)
+      throws UnexpectedNoAccessRightException {
+    currentUser.assertAuthorization(predefinedQuestion.getNote());
+    return predefinedQuestionService.updateQuestion(predefinedQuestion, updatedQuestion);
+  }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/PredefinedQuestionService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/PredefinedQuestionService.java
@@ -86,4 +86,20 @@ public class PredefinedQuestionService {
     }
     return modelFactoryService.save(result);
   }
+
+  public void deleteQuestion(PredefinedQuestion question) {
+    Note note = question.getNote();
+    Notebook parentNotebook = note.getNotebook();
+    parentNotebook.setUpdated_at(new Timestamp(System.currentTimeMillis()));
+    modelFactoryService.save(parentNotebook);
+    modelFactoryService.remove(question);
+  }
+
+  public PredefinedQuestion updateQuestion(
+      PredefinedQuestion question, PredefinedQuestion updatedData) {
+    question.setMultipleChoicesQuestion(updatedData.getMultipleChoicesQuestion());
+    question.setCorrectAnswerIndex(updatedData.getCorrectAnswerIndex());
+    modelFactoryService.save(question);
+    return question;
+  }
 }

--- a/e2e_test/features/assessment/predefined_questions_management.feature
+++ b/e2e_test/features/assessment/predefined_questions_management.feature
@@ -39,3 +39,15 @@ Feature: Quiz Question Management
     Then the question in the form becomes:
       | Stem                            | Choice 0                 | Choice 1           | Choice 2      | Correct Choice Index |
       | Why did the cow cross the road? | To get to the udder side | To see the chicken | To find grass | 0                    |
+
+  Scenario: Delete a question from the note
+    When I delete the question "What does a cow say?" from the note "The cow joke"
+    Then I should not see the question "What does a cow say?" in the question list of the note "The cow joke"
+
+  Scenario: Edit a question in the note
+    When I edit the question "What does a cow say?" for the note "The cow joke" to become:
+      | Stem                     | Choice 0 | Choice 1 | Choice 2 | Choice 3 | Correct Choice Index |
+      | What sound does a cow make? | moo      | boo      | woo      | zoo      | 0                    |
+    Then I should see the questions in the question list of the note "The cow joke":
+      | Question                     | Correct Choice |
+      | What sound does a cow make? | moo            |

--- a/e2e_test/start/pageObjects/notePage.ts
+++ b/e2e_test/start/pageObjects/notePage.ts
@@ -238,6 +238,38 @@ export const assumeNotePage = (noteTopology?: string) => {
     expectQuestionsInList(expectedQuestions: Record<string, string>[]) {
       this.openQuestionList().expectQuestion(expectedQuestions)
     },
+    deleteQuestion(questionStem: string) {
+      this.openQuestionList()
+      cy.findByText(questionStem)
+        .parents('tr')
+        .within(() => {
+          cy.findByRole('button', { name: 'Delete' }).click()
+        })
+      cy.pageIsNotLoading()
+    },
+    editQuestion(questionStem: string, updatedData: Record<string, string>) {
+      this.openQuestionList()
+      cy.findByText(questionStem)
+        .parents('tr')
+        .within(() => {
+          cy.findByRole('button', { name: 'Edit' }).click()
+        })
+      // Fill in the edit form
+      cy.findByLabelText('Question Text').clear().type(updatedData.Stem!)
+      cy.findByLabelText('Choice A').clear().type(updatedData['Choice 0']!)
+      cy.findByLabelText('Choice B').clear().type(updatedData['Choice 1']!)
+      cy.findByLabelText('Choice C').clear().type(updatedData['Choice 2']!)
+      cy.findByLabelText('Choice D').clear().type(updatedData['Choice 3']!)
+      cy.findByLabelText('Correct Answer').select(
+        updatedData['Correct Choice Index']!
+      )
+      cy.findByRole('button', { name: 'Save' }).click()
+      cy.pageIsNotLoading()
+    },
+    expectQuestionNotInList(questionStem: string) {
+      this.openQuestionList()
+      cy.findByText(questionStem).should('not.exist')
+    },
     sendMessageToNoteOwner(message: string) {
       this.toolbarButton('Star a conversation about this note').click()
       cy.findByRole('textbox').type(message)

--- a/e2e_test/step_definitions/note.ts
+++ b/e2e_test/step_definitions/note.ts
@@ -111,6 +111,26 @@ Given(
   }
 )
 
+When(
+  'I delete the question {string} from the note {string}',
+  (questionStem: string, noteTopology: string) => {
+    start.jumpToNotePage(noteTopology).deleteQuestion(questionStem)
+  }
+)
+
+When(
+  'I edit the question {string} for the note {string} to become:',
+  (questionStem: string, noteTopology: string, data: DataTable) => {
+    expect(
+      data.hashes().length,
+      'please edit one question at a time.'
+    ).to.equal(1)
+    start
+      .jumpToNotePage(noteTopology)
+      .editQuestion(questionStem, data.hashes()[0]!)
+  }
+)
+
 Given(
   'I refine the following question for the note {string}:',
   (noteTopology: string, data: DataTable) => {
@@ -459,6 +479,13 @@ When(
   'I should see the questions in the question list of the note {string}:',
   (noteTopology: string, data: DataTable) => {
     start.jumpToNotePage(noteTopology).expectQuestionsInList(data.hashes())
+  }
+)
+
+Then(
+  'I should not see the question {string} in the question list of the note {string}',
+  (questionStem: string, noteTopology: string) => {
+    start.jumpToNotePage(noteTopology).expectQuestionNotInList(questionStem)
   }
 )
 

--- a/frontend/src/components/notes/Questions.vue
+++ b/frontend/src/components/notes/Questions.vue
@@ -20,6 +20,7 @@
           <th>B</th>
           <th>C</th>
           <th>D</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -54,6 +55,22 @@
               {{ choice }}
             </td>
           </template>
+          <td>
+            <button
+              class="daisy-btn daisy-btn-sm daisy-btn-primary daisy-mr-2"
+              @click="editQuestion(question)"
+              title="Edit question"
+            >
+              Edit
+            </button>
+            <button
+              class="daisy-btn daisy-btn-sm daisy-btn-error"
+              @click="deleteQuestion(question.id)"
+              title="Delete question"
+            >
+              Delete
+            </button>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -71,6 +88,109 @@
       />
     </template>
   </Modal>
+  <Modal
+    v-if="editingQuestion !== undefined"
+    @close_request="editingQuestion = undefined"
+  >
+    <template #body>
+      <div class="daisy-p-4">
+        <h3 class="daisy-text-lg daisy-font-bold daisy-mb-4">Edit Question</h3>
+        <form @submit.prevent="saveEditedQuestion">
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-question-stem">
+              <span class="daisy-label-text">Question Text</span>
+            </label>
+            <textarea
+              id="edit-question-stem"
+              v-model="editForm.stem"
+              class="daisy-textarea daisy-textarea-bordered daisy-w-full"
+              rows="3"
+              required
+            ></textarea>
+          </div>
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-choice-a">
+              <span class="daisy-label-text">Choice A</span>
+            </label>
+            <input
+              id="edit-choice-a"
+              v-model="editForm.choices[0]"
+              type="text"
+              class="daisy-input daisy-input-bordered daisy-w-full"
+              required
+            />
+          </div>
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-choice-b">
+              <span class="daisy-label-text">Choice B</span>
+            </label>
+            <input
+              id="edit-choice-b"
+              v-model="editForm.choices[1]"
+              type="text"
+              class="daisy-input daisy-input-bordered daisy-w-full"
+              required
+            />
+          </div>
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-choice-c">
+              <span class="daisy-label-text">Choice C</span>
+            </label>
+            <input
+              id="edit-choice-c"
+              v-model="editForm.choices[2]"
+              type="text"
+              class="daisy-input daisy-input-bordered daisy-w-full"
+              required
+            />
+          </div>
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-choice-d">
+              <span class="daisy-label-text">Choice D</span>
+            </label>
+            <input
+              id="edit-choice-d"
+              v-model="editForm.choices[3]"
+              type="text"
+              class="daisy-input daisy-input-bordered daisy-w-full"
+              required
+            />
+          </div>
+          <div class="daisy-form-control daisy-mb-4">
+            <label class="daisy-label" for="edit-correct-answer">
+              <span class="daisy-label-text">Correct Answer</span>
+            </label>
+            <select
+              id="edit-correct-answer"
+              v-model="editForm.correctAnswerIndex"
+              class="daisy-select daisy-select-bordered daisy-w-full"
+              required
+            >
+              <option :value="0">A</option>
+              <option :value="1">B</option>
+              <option :value="2">C</option>
+              <option :value="3">D</option>
+            </select>
+          </div>
+          <div class="daisy-flex daisy-gap-2 daisy-justify-end">
+            <button
+              type="button"
+              class="daisy-btn"
+              @click="editingQuestion = undefined"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              class="daisy-btn daisy-btn-primary"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </template>
+  </Modal>
 </template>
 
 <script setup lang="ts">
@@ -81,6 +201,7 @@ import useLoadingApi from "@/managedApi/useLoadingApi"
 import NoteAddQuestion from "./NoteAddQuestion.vue"
 import QuestionManagement from "./QuestionManagement.vue"
 import PopButton from "../commons/Popups/PopButton.vue"
+import Modal from "../commons/Modal.vue"
 
 const { managedApi } = useLoadingApi()
 const props = defineProps({
@@ -91,6 +212,12 @@ const props = defineProps({
 })
 const questions = ref<PredefinedQuestion[]>([])
 const openedQuestion = ref<PredefinedQuestion | undefined>()
+const editingQuestion = ref<PredefinedQuestion | undefined>()
+const editForm = ref({
+  stem: "",
+  choices: ["", "", "", ""],
+  correctAnswerIndex: 0,
+})
 
 const fetchQuestions = async () => {
   questions.value =
@@ -107,6 +234,47 @@ const questionAdded = (newQuestion: PredefinedQuestion) => {
 const toggleApproval = async (questionId?: number) => {
   if (questionId) {
     await managedApi.restPredefinedQuestionController.toggleApproval(questionId)
+  }
+}
+const deleteQuestion = async (questionId?: number) => {
+  if (questionId) {
+    await managedApi.restPredefinedQuestionController.deleteQuestion(questionId)
+    questions.value = questions.value.filter((q) => q.id !== questionId)
+  }
+}
+const editQuestion = (question: PredefinedQuestion) => {
+  editingQuestion.value = question
+  editForm.value = {
+    stem: question.multipleChoicesQuestion.stem || "",
+    choices: [
+      ...(question.multipleChoicesQuestion.choices || ["", "", "", ""]),
+    ],
+    correctAnswerIndex: question.correctAnswerIndex || 0,
+  }
+}
+const saveEditedQuestion = async () => {
+  if (editingQuestion.value?.id) {
+    const updatedQuestion: PredefinedQuestion = {
+      ...editingQuestion.value,
+      multipleChoicesQuestion: {
+        stem: editForm.value.stem,
+        choices: editForm.value.choices,
+      },
+      correctAnswerIndex: editForm.value.correctAnswerIndex,
+    }
+    const result =
+      await managedApi.restPredefinedQuestionController.updateQuestion(
+        editingQuestion.value.id,
+        updatedQuestion
+      )
+    // Update the question in the list
+    const index = questions.value.findIndex(
+      (q) => q.id === editingQuestion.value?.id
+    )
+    if (index !== -1) {
+      questions.value[index] = result
+    }
+    editingQuestion.value = undefined
   }
 }
 onMounted(() => {

--- a/generated/backend/services/RestPredefinedQuestionControllerService.ts
+++ b/generated/backend/services/RestPredefinedQuestionControllerService.ts
@@ -135,4 +135,46 @@ export class RestPredefinedQuestionControllerService {
             },
         });
     }
+    /**
+     * @param predefinedQuestion
+     * @returns any OK
+     * @throws ApiError
+     */
+    public deleteQuestion(
+        predefinedQuestion: number,
+    ): CancelablePromise<any> {
+        return this.httpRequest.request({
+            method: 'DELETE',
+            url: '/api/predefined-questions/{predefinedQuestion}',
+            path: {
+                'predefinedQuestion': predefinedQuestion,
+            },
+            errors: {
+                500: `Internal Server Error`,
+            },
+        });
+    }
+    /**
+     * @param predefinedQuestion
+     * @param requestBody
+     * @returns PredefinedQuestion OK
+     * @throws ApiError
+     */
+    public updateQuestion(
+        predefinedQuestion: number,
+        requestBody: PredefinedQuestion,
+    ): CancelablePromise<PredefinedQuestion> {
+        return this.httpRequest.request({
+            method: 'PATCH',
+            url: '/api/predefined-questions/{predefinedQuestion}',
+            path: {
+                'predefinedQuestion': predefinedQuestion,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                500: `Internal Server Error`,
+            },
+        });
+    }
 }

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -2318,6 +2318,55 @@ paths:
             '*/*':
               schema:
                 $ref: "#/components/schemas/NoteRealm"
+  /api/predefined-questions/{predefinedQuestion}:
+    delete:
+      tags:
+      - rest-predefined-question-controller
+      operationId: deleteQuestion
+      parameters:
+      - name: predefinedQuestion
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                type: string
+        "200":
+          description: OK
+    patch:
+      tags:
+      - rest-predefined-question-controller
+      operationId: updateQuestion
+      parameters:
+      - name: predefinedQuestion
+        in: path
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PredefinedQuestion"
+        required: true
+      responses:
+        "500":
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                type: string
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PredefinedQuestion"
   /api/notes/{note}:
     get:
       tags:


### PR DESCRIPTION
This PR implements the ability to edit and delete questions in the question list of a note, addressing the requirement to manage quiz questions more effectively.

Changes:
- Backend: Added DELETE and PATCH endpoints to RestPredefinedQuestionController
- Backend: Added deleteQuestion and updateQuestion methods to PredefinedQuestionService
- Frontend: Added Edit and Delete buttons to Questions.vue component
- Frontend: Implemented edit dialog with form validation
- E2E Tests: Added scenarios for delete and edit operations
- E2E Tests: Updated page objects and step definitions

All backend tests, frontend tests, and E2E tests pass successfully.