### PR TITLE
Retry failed operation

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
@@ -47,7 +47,7 @@ record ClozeReplacement(
     final String internalPronunciationReplacement = "__p_r_o_n_u_n_c__";
     final Pattern pattern =
         Pattern.compile(
-            "/[^\\s^/][^/\\n]*/(?!\\w)",
+            "/[^\\s/][^/\\n]*/(?!\\w)",
             Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     String pronunciationsReplaced =
         pattern.matcher(originalContent1).replaceAll(internalPronunciationReplacement);

--- a/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
@@ -89,4 +89,30 @@ class ClozeDescriptionTest {
         new ClozedString(clozeReplacement, "abc").hide(new NoteTitle("abc")).clozeDetails(),
         containsString("/.../"));
   }
+
+  @Test
+  void clozeShouldWorkWithSlashInTitleAndUrlsInDetails() {
+    String title = "archenemy / arch-enemy";
+    String details = "In literature, an **archenemy** (sometimes spelled as **arch-enemy**) or **nemesis** is the main [enemy](https://en.wikipedia.org/wiki/Enemy) of the [protagonist](https://en.wikipedia.org/wiki/Protagonist)—or sometimes, one of the other main characters—appearing as the most prominent and most-known enemy of the [hero](https://en.wikipedia.org/wiki/Hero)";
+    String result = new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
+    
+    // The word "archenemy" and "arch-enemy" should be clozed
+    assertThat(result, containsString("[...]"));
+    
+    // URLs should not be affected
+    assertThat(result, containsString("https://en.wikipedia.org/wiki/Enemy"));
+    assertThat(result, containsString("https://en.wikipedia.org/wiki/Protagonist"));
+    assertThat(result, containsString("https://en.wikipedia.org/wiki/Hero"));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "archenemy / arch-enemy, an archenemy here, an [...] here",
+    "archenemy / arch-enemy, an arch-enemy here, an [...] here",
+    "archenemy / arch-enemy, the archenemy and arch-enemy are, the [...] and [...] are",
+  })
+  void clozeShouldHandleTitleWithSlash(String title, String details, String expected) {
+    String result = new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
+    assertThat(result, containsString(expected));
+  }
 }


### PR DESCRIPTION
Fixes a bug in the cloze mask algorithm that prevented correct cloze replacement for note titles containing slashes.

The pronunciation pattern regex `/[^\s^/][^/\n]*/(?!\w)` in `ClozeReplacement.java` incorrectly interpreted the second `^` in `[^\s^/]` as a literal character, leading to an ambiguous pattern that failed to properly cloze words like "arch-enemy" when the note title was "archenemy / arch-enemy". The fix simplifies this to `/[^\s/][^/\n]*/(?!\w)` for correct matching.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1762642470253499?thread_ts=1762642470.253499&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-6d10eeab-73d2-4704-9228-18d539924208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d10eeab-73d2-4704-9228-18d539924208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the pronunciation-masking regex and adds tests ensuring cloze works with titles containing slashes and does not affect URLs.
> 
> - **Backend (Cloze masking)**
>   - Update pronunciation regex in `ClozeReplacement.java` from `/[^\s^/][^/\n]*/(?!\w)` to `/[^\s/][^/\n]*/(?!\w)` to correctly handle `/` and avoid caret misinterpretation.
> - **Tests**
>   - Add tests in `ClozeDescriptionTest.java` verifying cloze with titles containing slashes (e.g., `archenemy / arch-enemy`).
>   - Ensure URLs in details remain unchanged while target words are clozed.
>   - Add parameterized cases covering variations (`archenemy`, `arch-enemy`) and combined occurrences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd39b2bbcde0fe0ed50b872a445c03e081b24be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->