### PR TITLE
Fix pop-up overflow on narrow screens

### DIFF
--- a/frontend/src/components/navigation/NavigationItem.vue
+++ b/frontend/src/components/navigation/NavigationItem.vue
@@ -20,7 +20,7 @@
       <span class="label">{{ label }}</span>
     </router-link>
 
-    <details v-if="hasDropdown" ref="dropdownTrigger" class="daisy-dropdown daisy-dropdown-end lg:daisy-dropdown-right">
+    <details v-if="hasDropdown" ref="dropdownTrigger" class="daisy-dropdown daisy-dropdown-bottom daisy-dropdown-end lg:daisy-dropdown-top lg:daisy-dropdown-right">
       <summary
         tabindex="0"
         role="button"


### PR DESCRIPTION
Fix user options popup overflow on narrow screens by adjusting dropdown positioning.

On narrow screens, the dropdown was opening upwards and getting cut off by the browser's top edge. This change makes the dropdown open downwards on narrow screens (`daisy-dropdown-bottom`) and revert to opening upwards on larger screens (`lg:daisy-dropdown-top`).

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1762644574740009?thread_ts=1762644574.740009&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-d0daddf0-d807-471a-a02c-4d5c0a6292e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0daddf0-d807-471a-a02c-4d5c0a6292e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

