### PR TITLE
Fix null choices in question evaluation

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/ai/QuestionEvaluation.java
+++ b/backend/src/main/java/com/odde/doughnut/services/ai/QuestionEvaluation.java
@@ -39,24 +39,29 @@ public class QuestionEvaluation {
     QuestionContestResult result = new QuestionContestResult();
     result.advice = "";
     if (!indisputableAnswer(correctChoiceIndex)) {
+      var choices = mcqWithAnswer.getMultipleChoicesQuestion().getChoices();
       String correctChoicesStr =
-          correctChoices == null
+          correctChoices == null || choices == null
               ? "none"
               : Arrays.stream(correctChoices)
                   .mapToObj(
                       i ->
-                          i
-                              + " (\""
-                              + mcqWithAnswer.getMultipleChoicesQuestion().getChoices().get(i)
-                              + "\")")
+                          i < 0 || i >= choices.size()
+                              ? i + " (out of range)"
+                              : i + " (\"" + choices.get(i) + "\")")
                   .collect(Collectors.joining(", "));
+
+      String originalChoiceStr =
+          choices == null || correctChoiceIndex < 0 || correctChoiceIndex >= choices.size()
+              ? "(unavailable)"
+              : "(\"" + choices.get(correctChoiceIndex) + "\")";
 
       result.advice =
           "Unclear answer detected. The original question assume one correct choice index (0-based) of "
               + correctChoiceIndex
-              + " (\""
-              + mcqWithAnswer.getMultipleChoicesQuestion().getChoices().get(correctChoiceIndex)
-              + "\"). however, the re-evaluation of the question shows that "
+              + " "
+              + originalChoiceStr
+              + ". however, the re-evaluation of the question shows that "
               + correctChoicesStr
               + " are correct to the question.\n"
               + "Please make sure the correct answer is correct and unique.\n\n";

--- a/backend/src/test/java/com/odde/doughnut/services/ai/QuestionEvaluationTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/ai/QuestionEvaluationTest.java
@@ -62,4 +62,20 @@ class QuestionEvaluationTest {
     QuestionContestResult result = questionEvaluation.getQuestionContestResult(mcqWithAnswer);
     assertEquals("This seems to be a legitimate question. Please answer it.", result.advice);
   }
+
+  @Test
+  void shouldHandleNullChoicesGracefully() {
+    // Reproduce the NullPointerException scenario
+    MCQWithAnswer mcqWithNullChoices = new MCQWithAnswer();
+    mcqWithNullChoices.setMultipleChoicesQuestion(new MultipleChoicesQuestion("What is the capital?", null));
+    mcqWithNullChoices.setCorrectChoiceIndex(0);
+
+    questionEvaluation.feasibleQuestion = true;
+    questionEvaluation.correctChoices = new int[] {1};
+    questionEvaluation.improvementAdvices = "Please fix the choices";
+
+    // This should not throw NullPointerException
+    QuestionContestResult result = questionEvaluation.getQuestionContestResult(mcqWithNullChoices);
+    assertThat(result.advice, containsString("Please fix the choices"));
+  }
 }


### PR DESCRIPTION
Fix NullPointerException in `QuestionEvaluation` when `MultipleChoicesQuestion` has null choices.

The original code did not handle cases where `MultipleChoicesQuestion.getChoices()` returned null, leading to a `NullPointerException` when attempting to access elements from a null list. This PR adds null checks for `choices` and `correctChoices`, along with bounds checking for choice indices, to prevent the NPE and provide more robust advice messages.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1762644827518899?thread_ts=1762644827.518899&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-47d2722a-8cc5-476e-9fc9-c3bc356cdbc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-47d2722a-8cc5-476e-9fc9-c3bc356cdbc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

