### PR TITLE
Investigate and fix index out of bounds exception

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
@@ -47,8 +47,7 @@ record ClozeReplacement(
     final String internalPronunciationReplacement = "__p_r_o_n_u_n_c__";
     final Pattern pattern =
         Pattern.compile(
-            "/[^\\s/][^/\\n]*/(?!\\w)",
-            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+            "/[^\\s/][^/\\n]*/(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
     String pronunciationsReplaced =
         pattern.matcher(originalContent1).replaceAll(internalPronunciationReplacement);
     return noteTitles1.stream()

--- a/backend/src/main/java/com/odde/doughnut/services/ai/QuestionEvaluation.java
+++ b/backend/src/main/java/com/odde/doughnut/services/ai/QuestionEvaluation.java
@@ -39,16 +39,18 @@ public class QuestionEvaluation {
     QuestionContestResult result = new QuestionContestResult();
     result.advice = "";
     if (!indisputableAnswer(correctChoiceIndex)) {
+      var choices = mcqWithAnswer.getMultipleChoicesQuestion().getChoices();
       String correctChoicesStr =
           correctChoices == null
               ? "none"
               : Arrays.stream(correctChoices)
                   .mapToObj(
-                      i ->
-                          i
-                              + " (\""
-                              + mcqWithAnswer.getMultipleChoicesQuestion().getChoices().get(i)
-                              + "\")")
+                      i -> {
+                        if (i < 0 || i >= choices.size()) {
+                          return i + " (invalid index)";
+                        }
+                        return i + " (\"" + choices.get(i) + "\")";
+                      })
                   .collect(Collectors.joining(", "));
 
       result.advice =

--- a/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
@@ -93,12 +93,14 @@ class ClozeDescriptionTest {
   @Test
   void clozeShouldWorkWithSlashInTitleAndUrlsInDetails() {
     String title = "archenemy / arch-enemy";
-    String details = "In literature, an **archenemy** (sometimes spelled as **arch-enemy**) or **nemesis** is the main [enemy](https://en.wikipedia.org/wiki/Enemy) of the [protagonist](https://en.wikipedia.org/wiki/Protagonist)—or sometimes, one of the other main characters—appearing as the most prominent and most-known enemy of the [hero](https://en.wikipedia.org/wiki/Hero)";
-    String result = new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
-    
+    String details =
+        "In literature, an **archenemy** (sometimes spelled as **arch-enemy**) or **nemesis** is the main [enemy](https://en.wikipedia.org/wiki/Enemy) of the [protagonist](https://en.wikipedia.org/wiki/Protagonist)—or sometimes, one of the other main characters—appearing as the most prominent and most-known enemy of the [hero](https://en.wikipedia.org/wiki/Hero)";
+    String result =
+        new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
+
     // The word "archenemy" and "arch-enemy" should be clozed
     assertThat(result, containsString("[...]"));
-    
+
     // URLs should not be affected
     assertThat(result, containsString("https://en.wikipedia.org/wiki/Enemy"));
     assertThat(result, containsString("https://en.wikipedia.org/wiki/Protagonist"));
@@ -112,7 +114,8 @@ class ClozeDescriptionTest {
     "archenemy / arch-enemy, the archenemy and arch-enemy are, the [...] and [...] are",
   })
   void clozeShouldHandleTitleWithSlash(String title, String details, String expected) {
-    String result = new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
+    String result =
+        new ClozedString(clozeReplacement, details).hide(new NoteTitle(title)).clozeDetails();
     assertThat(result, containsString(expected));
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/services/ai/QuestionEvaluationTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/ai/QuestionEvaluationTest.java
@@ -62,4 +62,19 @@ class QuestionEvaluationTest {
     QuestionContestResult result = questionEvaluation.getQuestionContestResult(mcqWithAnswer);
     assertEquals("This seems to be a legitimate question. Please answer it.", result.advice);
   }
+
+  @Test
+  void shouldHandleOutOfBoundsIndicesInCorrectChoices() {
+    questionEvaluation.feasibleQuestion = true;
+    // AI returns index 3, but question only has 3 choices (indices 0-2)
+    questionEvaluation.correctChoices = new int[] {3};
+    QuestionContestResult result = questionEvaluation.getQuestionContestResult(mcqWithAnswer);
+    assertThat(result.advice, containsString("Unclear answer detected"));
+    assertThat(
+        result.advice,
+        containsString(
+            "original question assume one correct choice index (0-based) of 0 (\"Paris\")"));
+    // Should handle the out of bounds index gracefully
+    assertThat(result.advice, containsString("3 (invalid index)"));
+  }
 }


### PR DESCRIPTION
Adds bounds checking to `QuestionEvaluation` to prevent `IndexOutOfBoundsException` when AI returns invalid choice indices.

The `IndexOutOfBoundsException` occurred because the AI's `QuestionEvaluation` could return `correctChoices` indices that were out of bounds of the actual choices list. This fix validates the AI's response by checking if the `correctChoiceIndex` is within the bounds of the available choices before attempting to retrieve the choice, preventing crashes and providing clear feedback for invalid indices.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1762645541466509?thread_ts=1762645541.466509&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-a7c427eb-b512-4b39-9467-9141bec94767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7c427eb-b512-4b39-9467-9141bec94767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

