### PR TITLE
Configure cloud agent for frontend unit tests

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -30,11 +30,42 @@ This command starts:
 
 ## Running Commands in Terminal
 
-**CRITICAL: This project uses nix to manage the development environment.**
+### For Cloud Agents (Cursor Background Agent)
+
+**Cloud agents run in a pre-configured virtual machine with the correct Node.js and pnpm versions already installed.**
+
+The cloud environment includes:
+- Node.js v22.21.1
+- pnpm 10.22.0
+
+**Cloud agents should run commands DIRECTLY without nix:**
+
+#### Running Tests on Cloud Agent
+
+**Frontend unit test:**
+```bash
+pnpm frontend:test
+```
+
+**Backend unit test:**
+```bash
+pnpm backend:verify
+```
+
+**E2E test** (assumes services are already running):
+```bash
+pnpm cypress run --spec e2e_test/features/ai_generated_recall_questions/question_contest.feature
+```
+
+**Note:** Cloud agents do NOT need the `CURSOR_DEV=true nix develop -c` prefix.
+
+### For Local Development (Human Developers)
+
+**CRITICAL: This project uses nix to manage the development environment locally.**
 
 There is a bug in Cursor IDE that prevents detection of `nix develop` completion in agent mode. 
 
-**YOU MUST ALWAYS prefix commands with `CURSOR_DEV=true` when running them through `nix develop -c`:**
+**When running as a local agent, YOU MUST ALWAYS prefix commands with `CURSOR_DEV=true` when running them through `nix develop -c`:**
 
 ```bash
 CURSOR_DEV=true nix develop -c <command>
@@ -42,7 +73,7 @@ CURSOR_DEV=true nix develop -c <command>
 
 **DO NOT run commands without the `CURSOR_DEV=true` prefix!** Without it, the terminal will hang and not return control to the agent.
 
-### Running Tests
+#### Running Tests for Local Development
 
 **Backend unit test:**
 ```bash
@@ -59,7 +90,7 @@ CURSOR_DEV=true nix develop -c pnpm frontend:test
 CURSOR_DEV=true nix develop -c pnpm cypress run --spec e2e_test/features/ai_generated_recall_questions/question_contest.feature
 ```
 
-**Note:** ALL commands that need to run in the nix development environment MUST use `CURSOR_DEV=true nix develop -c` prefix.
+**Note:** ALL commands in local development that need to run in the nix development environment MUST use `CURSOR_DEV=true nix develop -c` prefix.
 
 # Development preferences
 

--- a/docs/cloud_agent_setup.md
+++ b/docs/cloud_agent_setup.md
@@ -1,0 +1,78 @@
+# Cursor Cloud Agent Setup for Frontend Unit Tests
+
+## Investigation Summary
+
+This document outlines how Cursor's cloud agents (background agents running on Cursor's virtual machines) can run frontend unit tests without requiring nix.
+
+## Key Findings
+
+### Cloud Agent Environment
+
+The Cursor cloud agent virtual machine comes pre-configured with:
+- **Node.js**: v22.21.1 ✅ (meets project requirement: >=22)
+- **pnpm**: 10.22.0 ✅ (meets project requirement: >=10.22.0)
+- **No nix**: Not available (nor needed)
+
+### Local Development Environment
+
+Local development uses:
+- **nix flake**: Manages development environment with specific versions
+- **Node.js**: v22 (via nix)
+- **pnpm**: v10.22.0 (via nix)
+- Commands must be prefixed with `CURSOR_DEV=true nix develop -c`
+
+## Solution
+
+### For Cloud Agents
+
+Cloud agents can run commands **directly** without nix:
+
+```bash
+# Frontend unit tests
+pnpm frontend:test
+
+# Backend unit tests  
+pnpm backend:verify
+
+# E2E tests (requires services running)
+pnpm cypress run --spec e2e_test/features/<feature-file>.feature
+```
+
+### For Local Development
+
+Local agents/developers must use the nix wrapper:
+
+```bash
+# Frontend unit tests
+CURSOR_DEV=true nix develop -c pnpm frontend:test
+
+# Backend unit tests
+CURSOR_DEV=true nix develop -c pnpm backend:verify
+
+# E2E tests
+CURSOR_DEV=true nix develop -c pnpm cypress run --spec e2e_test/features/<feature-file>.feature
+```
+
+## Test Results
+
+Frontend unit tests were successfully executed on the cloud agent:
+- **354 tests passed**
+- **3 tests skipped**
+- **Duration**: ~40 seconds
+- **Exit code**: 0 (success)
+
+TypeScript/vue-tsc linting errors were reported but did not prevent test execution.
+
+## Configuration Changes
+
+Updated `/workspace/.cursor/rules/general.mdc` to include:
+1. Dedicated section for cloud agents with direct command execution
+2. Clear distinction between cloud and local development environments
+3. Specific test commands for each environment
+
+## Conclusion
+
+✅ **No additional setup required** for cloud agents to run frontend unit tests  
+✅ **Environment is pre-configured** with correct Node.js and pnpm versions  
+✅ **Tests run successfully** without nix  
+✅ **Documentation updated** in cursor rules for future reference


### PR DESCRIPTION
Document how to run frontend unit tests on Cursor cloud agents by leveraging their pre-configured environment, removing the need for Nix.

The investigation revealed that Cursor cloud agents already have the necessary Node.js and pnpm versions, allowing frontend tests to be run directly with `pnpm frontend:test`. This PR updates the Cursor rules (`.cursor/rules/general.mdc`) and adds a new documentation file (`docs/cloud_agent_setup.md`) to clearly distinguish between cloud agent commands (direct execution) and local development commands (Nix-wrapped).

---
<a href="https://cursor.com/background-agent?bcId=bc-dc48d413-3897-489c-9654-cc53a0693b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc48d413-3897-489c-9654-cc53a0693b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document running tests on Cursor cloud agents without nix and update `.cursor/rules/general.mdc` to distinguish cloud vs local nix-wrapped commands.
> 
> - **Docs**:
>   - **New guide**: Add `docs/cloud_agent_setup.md` detailing cloud agent environment (Node/pnpm versions) and direct test commands (`pnpm frontend:test`, `pnpm backend:verify`, Cypress E2E), plus local nix-wrapped equivalents.
> - **Developer Rules** (`.cursor/rules/general.mdc`):
>   - Add dedicated cloud agent section with direct commands and note that nix is not needed.
>   - Clarify local development requires `CURSOR_DEV=true nix develop -c <command>`; provide test command examples.
>   - Reiterate services auto-reload; do not instruct restarting `pnpm sut`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 374789872da09b1a5abbd3d111285439d5451d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->