### PR TITLE
Fix end-to-end tests for notebook features

### DIFF
--- a/e2e_test/config/ci.ts
+++ b/e2e_test/config/ci.ts
@@ -11,6 +11,6 @@ export default defineConfig({
   watchForFileChanges: false,
   e2e: {
     ...commonConfig.e2e,
-    baseUrl: 'http://localhost:9081',
+    baseUrl: 'http://localhost:5173',
   },
 })


### PR DESCRIPTION
Update Cypress `baseUrl` in e2e tests to correctly load the frontend from the dev server.

The backend does not serve static frontend files, causing connection issues when Cypress attempts to load the application from the backend's `baseUrl`. This change directs Cypress to the frontend dev server for initial page loads, while API calls continue to use the `backendBaseUrl`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a85ca01-a120-4f9f-9467-9fb79c3a008b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a85ca01-a120-4f9f-9467-9fb79c3a008b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

