### PR TITLE
Remove Rest prefix from RestControllers

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/AiAudioController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/AiAudioController.java
@@ -17,12 +17,12 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/audio")
-class RestAiAudioController {
+class AiAudioController {
 
   OtherAiServices otherAiServices;
   private final ModelFactoryService modelFactoryService;
 
-  public RestAiAudioController(
+  public AiAudioController(
       OtherAiServices otherAiServices, ModelFactoryService modelFactoryService) {
     this.otherAiServices = otherAiServices;
     this.modelFactoryService = modelFactoryService;

--- a/backend/src/main/java/com/odde/doughnut/controllers/AiController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/AiController.java
@@ -17,13 +17,13 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/ai")
-public class RestAiController {
+public class AiController {
 
   private final OtherAiServices otherAiServices;
   private final UserModel currentUser;
   private final NotebookAssistantForNoteServiceFactory notebookAssistantForNoteServiceFactory;
 
-  public RestAiController(
+  public AiController(
       NotebookAssistantForNoteServiceFactory notebookAssistantForNoteServiceFactory,
       OtherAiServices otherAiServices,
       UserModel currentUser) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/AssessmentController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/AssessmentController.java
@@ -16,14 +16,14 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/assessment")
-class RestAssessmentController {
+class AssessmentController {
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
 
   private final UserModel currentUser;
   private final AssessmentService assessmentService;
 
-  public RestAssessmentController(
+  public AssessmentController(
       ModelFactoryService modelFactoryService,
       TestabilitySettings testabilitySettings,
       UserModel currentUser) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/BazaarController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/BazaarController.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/bazaar")
-class RestBazaarController {
+class BazaarController {
   private final ModelFactoryService modelFactoryService;
   private UserModel currentUser;
 
-  public RestBazaarController(ModelFactoryService modelFactoryService, UserModel currentUser) {
+  public BazaarController(ModelFactoryService modelFactoryService, UserModel currentUser) {
     this.modelFactoryService = modelFactoryService;
     this.currentUser = currentUser;
   }

--- a/backend/src/main/java/com/odde/doughnut/controllers/CertificateController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/CertificateController.java
@@ -10,13 +10,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/certificate")
-public class RestCertificateController {
+public class CertificateController {
 
   private final UserModel currentUser;
 
   private final ModelFactoryService modelFactoryService;
 
-  public RestCertificateController(UserModel currentUser, ModelFactoryService modelFactoryService) {
+  public CertificateController(UserModel currentUser, ModelFactoryService modelFactoryService) {
     this.currentUser = currentUser;
     this.modelFactoryService = modelFactoryService;
   }

--- a/backend/src/main/java/com/odde/doughnut/controllers/CircleController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/CircleController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/circles")
-class RestCircleController {
+class CircleController {
   private final ModelFactoryService modelFactoryService;
 
   @Resource(name = "testabilitySettings")
@@ -33,7 +33,7 @@ class RestCircleController {
 
   private UserModel currentUser;
 
-  public RestCircleController(
+  public CircleController(
       ModelFactoryService modelFactoryService,
       TestabilitySettings testabilitySettings,
       UserModel currentUser) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/ConversationMessageController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/ConversationMessageController.java
@@ -19,12 +19,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequestMapping("/api/conversation")
-public class RestConversationMessageController {
+public class ConversationMessageController {
   private final ConversationService conversationService;
   private final UserModel currentUser;
   private final ChatCompletionConversationService chatCompletionConversationService;
 
-  public RestConversationMessageController(
+  public ConversationMessageController(
       UserModel currentUser,
       ConversationService conversationService,
       ChatCompletionConversationService chatCompletionConversationService) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/CurrentUserInfoController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/CurrentUserInfoController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
-record RestCurrentUserInfoController(CurrentUserFetcher currentUserFetcher) {
+record CurrentUserInfoController(CurrentUserFetcher currentUserFetcher) {
   @GetMapping("/current-user-info")
   public CurrentUserInfo currentUserInfo() {
     CurrentUserInfo currentUserInfo = new CurrentUserInfo();

--- a/backend/src/main/java/com/odde/doughnut/controllers/FailureReportController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/FailureReportController.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/failure-reports")
-class RestFailureReportController {
+class FailureReportController {
   private final ModelFactoryService modelFactoryService;
   private final GithubService realGithubService;
   private UserModel currentUser;
 
-  public RestFailureReportController(
+  public FailureReportController(
       ModelFactoryService modelFactoryService,
       GithubService realGithubService,
       UserModel currentUser) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/FineTuningDataController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/FineTuningDataController.java
@@ -19,13 +19,13 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/fine-tuning")
-class RestFineTuningDataController {
+class FineTuningDataController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
   private final FineTuningService fineTuningService;
   private final OtherAiServices otherAiServices;
 
-  public RestFineTuningDataController(
+  public FineTuningDataController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       OpenAiApi openAiApi,

--- a/backend/src/main/java/com/odde/doughnut/controllers/GlobalSettingsController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/GlobalSettingsController.java
@@ -14,7 +14,7 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/settings")
-public class RestGlobalSettingsController {
+public class GlobalSettingsController {
 
   private final GlobalSettingsService globalSettingsService;
 
@@ -23,7 +23,7 @@ public class RestGlobalSettingsController {
 
   private UserModel currentUser;
 
-  public RestGlobalSettingsController(
+  public GlobalSettingsController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/HealthCheckController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/HealthCheckController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
-class RestHealthCheckController {
+class HealthCheckController {
   @Autowired private Environment environment;
 
   @Autowired private UserModel currentUser;

--- a/backend/src/main/java/com/odde/doughnut/controllers/LinkController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/LinkController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/links")
-class RestLinkController {
+class LinkController {
   private final ModelFactoryService modelFactoryService;
 
   @Resource(name = "testabilitySettings")
@@ -34,7 +34,7 @@ class RestLinkController {
 
   private UserModel currentUser;
 
-  public RestLinkController(
+  public LinkController(
       ModelFactoryService modelFactoryService,
       TestabilitySettings testabilitySettings,
       UserModel currentUser) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/MemoryTrackerController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/MemoryTrackerController.java
@@ -21,7 +21,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/memory-trackers")
-class RestMemoryTrackerController {
+class MemoryTrackerController {
   private final ModelFactoryService modelFactoryService;
   private final MemoryTrackerService memoryTrackerService;
   private UserModel currentUser;
@@ -29,7 +29,7 @@ class RestMemoryTrackerController {
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
 
-  public RestMemoryTrackerController(
+  public MemoryTrackerController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/NoteController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NoteController.java
@@ -34,14 +34,14 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/notes")
-class RestNoteController {
+class NoteController {
 
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
   private final WikidataService wikidataService;
   private final TestabilitySettings testabilitySettings;
 
-  public RestNoteController(
+  public NoteController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       HttpClientAdapter httpClientAdapter,

--- a/backend/src/main/java/com/odde/doughnut/controllers/NoteCreationController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NoteCreationController.java
@@ -19,12 +19,12 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/notes")
-class RestNoteCreationController {
+class NoteCreationController {
   private final UserModel currentUser;
   private final WikidataService wikidataService;
   private final NoteConstructionService noteConstructionService;
 
-  public RestNoteCreationController(
+  public NoteCreationController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       HttpClientAdapter httpClientAdapter,

--- a/backend/src/main/java/com/odde/doughnut/controllers/NotebookCertificateApprovalController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NotebookCertificateApprovalController.java
@@ -14,14 +14,14 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/notebook_certificate_approvals")
-class RestNotebookCertificateApprovalController {
+class NotebookCertificateApprovalController {
   private final ModelFactoryService modelFactoryService;
   private UserModel currentUser;
 
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
 
-  public RestNotebookCertificateApprovalController(
+  public NotebookCertificateApprovalController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/NotebookController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NotebookController.java
@@ -33,7 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @SessionScope
 @RequestMapping("/api/notebooks")
-class RestNotebookController {
+class NotebookController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
 
@@ -43,7 +43,7 @@ class RestNotebookController {
   private final ObsidianFormatService obsidianFormatService;
   private final NotebookIndexingService notebookIndexingService;
 
-  public RestNotebookController(
+  public NotebookController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings,

--- a/backend/src/main/java/com/odde/doughnut/controllers/PredefinedQuestionController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/PredefinedQuestionController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/predefined-questions")
-class RestPredefinedQuestionController {
+class PredefinedQuestionController {
   private final ModelFactoryService modelFactoryService;
   private final PredefinedQuestionService predefinedQuestionService;
 
@@ -33,7 +33,7 @@ class RestPredefinedQuestionController {
 
   private final AiQuestionGenerator aiQuestionGenerator;
 
-  public RestPredefinedQuestionController(
+  public PredefinedQuestionController(
       @Qualifier("testableOpenAiApi") OpenAiApi openAiApi,
       ModelFactoryService modelFactoryService,
       UserModel currentUser,

--- a/backend/src/main/java/com/odde/doughnut/controllers/RecallPromptController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/RecallPromptController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/recall-prompts")
-class RestRecallPromptController {
+class RecallPromptController {
   private final UserModel currentUser;
 
   @Resource(name = "testabilitySettings")
@@ -28,7 +28,7 @@ class RestRecallPromptController {
 
   private final RecallQuestionService recallQuestionService;
 
-  public RestRecallPromptController(
+  public RecallPromptController(
       @Qualifier("testableOpenAiApi") OpenAiApi openAiApi,
       ModelFactoryService modelFactoryService,
       UserModel currentUser,

--- a/backend/src/main/java/com/odde/doughnut/controllers/RecallsController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/RecallsController.java
@@ -19,14 +19,14 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/recalls")
-class RestRecallsController {
+class RecallsController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
 
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
 
-  public RestRecallsController(
+  public RecallsController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/SearchController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/SearchController.java
@@ -20,12 +20,12 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/notes")
-class RestSearchController {
+class SearchController {
 
   private final UserModel currentUser;
   private final NoteSearchService noteSearchService;
 
-  public RestSearchController(UserModel currentUser, NoteSearchService noteSearchService) {
+  public SearchController(UserModel currentUser, NoteSearchService noteSearchService) {
     this.currentUser = currentUser;
     this.noteSearchService = noteSearchService;
   }

--- a/backend/src/main/java/com/odde/doughnut/controllers/SubscriptionController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/SubscriptionController.java
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/subscriptions")
-class RestSubscriptionController {
+class SubscriptionController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
 
-  public RestSubscriptionController(
+  public SubscriptionController(
       ModelFactoryService modelFactoryService, UserModel currentUser) {
     this.modelFactoryService = modelFactoryService;
     this.currentUser = currentUser;

--- a/backend/src/main/java/com/odde/doughnut/controllers/TextContentController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/TextContentController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/text_content")
-class RestTextContentController {
+class TextContentController {
   private final ModelFactoryService modelFactoryService;
 
   private UserModel currentUser;
@@ -27,7 +27,7 @@ class RestTextContentController {
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
 
-  public RestTextContentController(
+  public TextContentController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/UserController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/UserController.java
@@ -20,12 +20,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user")
-class RestUserController {
+class UserController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
   private final TestabilitySettings testabilitySettings;
 
-  public RestUserController(
+  public UserController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings) {

--- a/backend/src/main/java/com/odde/doughnut/controllers/WikidataController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/WikidataController.java
@@ -19,11 +19,11 @@ import org.springframework.web.context.annotation.SessionScope;
 @RestController
 @SessionScope
 @RequestMapping("/api/wikidata")
-public class RestWikidataController {
+public class WikidataController {
 
   WikidataService wikidataService;
 
-  public RestWikidataController(
+  public WikidataController(
       TestabilitySettings testabilitySettings, HttpClientAdapter httpClientAdapter) {
     wikidataService =
         new WikidataService(httpClientAdapter, testabilitySettings.getWikidataServiceUrl());

--- a/backend/src/test/java/com/odde/doughnut/controllers/AssessmentControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/AssessmentControllerTests.java
@@ -26,10 +26,10 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-public class RestAssessmentControllerTests {
+public class AssessmentControllerTests {
   @Autowired MakeMe makeMe;
   private UserModel currentUser;
-  private RestAssessmentController controller;
+  private AssessmentController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   private AssessmentService assessmentService;
@@ -39,7 +39,7 @@ public class RestAssessmentControllerTests {
     testabilitySettings.timeTravelTo(makeMe.aTimestamp().please());
     currentUser = makeMe.aUser().toModelPlease();
     controller =
-        new RestAssessmentController(makeMe.modelFactoryService, testabilitySettings, currentUser);
+        new AssessmentController(makeMe.modelFactoryService, testabilitySettings, currentUser);
     assessmentService = new AssessmentService(makeMe.modelFactoryService, testabilitySettings);
   }
 
@@ -55,7 +55,7 @@ public class RestAssessmentControllerTests {
     @Test
     void whenNotLogin() {
       controller =
-          new RestAssessmentController(
+          new AssessmentController(
               makeMe.modelFactoryService, testabilitySettings, makeMe.aNullUserModelPlease());
       assertThrows(
           ResponseStatusException.class, () -> controller.generateAssessmentQuestions(notebook));
@@ -104,7 +104,7 @@ public class RestAssessmentControllerTests {
     @Test
     void shouldNotBeAbleToAccessNotebookWhenUserHasNoPermission() {
       controller =
-          new RestAssessmentController(
+          new AssessmentController(
               makeMe.modelFactoryService, testabilitySettings, makeMe.aUser().toModelPlease());
       assertThrows(
           UnexpectedNoAccessRightException.class,

--- a/backend/src/test/java/com/odde/doughnut/controllers/CertificateControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/CertificateControllerTests.java
@@ -20,11 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-public class RestCertificateControllerTests {
+public class CertificateControllerTests {
   public static final int oneYearInHours = 8760;
   @Autowired MakeMe makeMe;
   private UserModel currentUser;
-  private RestCertificateController controller;
+  private CertificateController controller;
   Timestamp currentTime;
   TestabilitySettings testabilitySettings = new TestabilitySettings();
 
@@ -33,7 +33,7 @@ public class RestCertificateControllerTests {
     currentTime = makeMe.aTimestamp().please();
     testabilitySettings.timeTravelTo(currentTime);
     currentUser = makeMe.aUser().toModelPlease();
-    controller = new RestCertificateController(currentUser, makeMe.modelFactoryService);
+    controller = new CertificateController(currentUser, makeMe.modelFactoryService);
   }
 
   @Nested

--- a/backend/src/test/java/com/odde/doughnut/controllers/ConversationMessageControllerAiReplyTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/ConversationMessageControllerAiReplyTests.java
@@ -43,12 +43,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-public class RestConversationMessageControllerAiReplyTests {
+public class ConversationMessageControllerAiReplyTests {
 
   @Mock private OpenAiApi openAiApi;
 
   @Autowired MakeMe makeMe;
-  RestConversationMessageController controller;
+  ConversationMessageController controller;
   UserModel currentUser;
   Note note;
   TestabilitySettings testabilitySettings = new TestabilitySettings();
@@ -76,7 +76,7 @@ public class RestConversationMessageControllerAiReplyTests {
         new ConversationService(
             testabilitySettings, makeMe.modelFactoryService, chatCompletionConversationService);
     controller =
-        new RestConversationMessageController(
+        new ConversationMessageController(
             currentUser, conversationService, chatCompletionConversationService);
   }
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestAiAudioControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestAiAudioControllerTests.java
@@ -34,9 +34,9 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestAiAudioControllerTests {
+class AiAudioControllerTests {
   @Autowired MakeMe makeMe;
-  RestAiAudioController controller;
+  AiAudioController controller;
   @Mock OpenAiApiExtended openAiApi;
   OpenAIChatCompletionMock openAIChatCompletionMock;
 
@@ -48,7 +48,7 @@ class RestAiAudioControllerTests {
 
   private void initializeController() {
     controller =
-        new RestAiAudioController(new OtherAiServices(openAiApi), makeMe.modelFactoryService);
+        new AiAudioController(new OtherAiServices(openAiApi), makeMe.modelFactoryService);
   }
 
   private void setupMocks() {

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestAiControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestAiControllerTest.java
@@ -40,8 +40,8 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestAiControllerTest {
-  RestAiController controller;
+class AiControllerTest {
+  AiController controller;
   UserModel currentUser;
 
   Note note;
@@ -59,7 +59,7 @@ class RestAiControllerTest {
     currentUser = makeMe.aUser().toModelPlease();
     note = makeMe.aNote().please();
     controller =
-        new RestAiController(
+        new AiController(
             notebookAssistantForNoteServiceFactory, new OtherAiServices(openAiApi), currentUser);
   }
 
@@ -81,7 +81,7 @@ class RestAiControllerTest {
       assertThrows(
           ResponseStatusException.class,
           () ->
-              new RestAiController(
+              new AiController(
                       notebookAssistantForNoteServiceFactory,
                       new OtherAiServices(openAiApi),
                       makeMe.aNullUserModelPlease())
@@ -181,7 +181,7 @@ class RestAiControllerTest {
     @Test
     void shouldRequireUserToBeLoggedIn() {
       controller =
-          new RestAiController(
+          new AiController(
               notebookAssistantForNoteServiceFactory,
               new OtherAiServices(openAiApi),
               makeMe.aNullUserModelPlease());

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestBazaarControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestBazaarControllerTest.java
@@ -22,11 +22,11 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestBazaarControllerTest {
+class BazaarControllerTest {
   @Autowired private MakeMe makeMe;
   private UserModel adminUser;
   private UserModel notebookOwner;
-  private RestBazaarController controller;
+  private BazaarController controller;
   private Note topNote;
   private Notebook notebook;
   private BazaarNotebook bazaarNotebook;
@@ -38,7 +38,7 @@ class RestBazaarControllerTest {
     topNote = makeMe.aNote().creatorAndOwner(notebookOwner).please();
     notebook = topNote.getNotebook();
     bazaarNotebook = makeMe.aBazaarNotebook(notebook).please();
-    controller = new RestBazaarController(makeMe.modelFactoryService, adminUser);
+    controller = new BazaarController(makeMe.modelFactoryService, adminUser);
   }
 
   @Nested
@@ -46,7 +46,7 @@ class RestBazaarControllerTest {
     @Test
     void otherPeopleCannot() {
       controller =
-          new RestBazaarController(makeMe.modelFactoryService, makeMe.aUser().toModelPlease());
+          new BazaarController(makeMe.modelFactoryService, makeMe.aUser().toModelPlease());
       assertThrows(
           UnexpectedNoAccessRightException.class,
           () -> controller.removeFromBazaar(bazaarNotebook));
@@ -55,7 +55,7 @@ class RestBazaarControllerTest {
 
     @Test
     void notebookOwnerCan() throws UnexpectedNoAccessRightException {
-      controller = new RestBazaarController(makeMe.modelFactoryService, notebookOwner);
+      controller = new BazaarController(makeMe.modelFactoryService, notebookOwner);
       controller.removeFromBazaar(bazaarNotebook);
     }
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestCircleControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestCircleControllerTest.java
@@ -28,18 +28,18 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestCircleControllerTest {
+class CircleControllerTest {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
   private UserModel userModel;
-  RestCircleController controller;
+  CircleController controller;
   private TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
-    controller = new RestCircleController(modelFactoryService, testabilitySettings, userModel);
+    controller = new CircleController(modelFactoryService, testabilitySettings, userModel);
   }
 
   @Nested
@@ -47,7 +47,7 @@ class RestCircleControllerTest {
     @Test
     void itShouldNotAllowNonMemberToSeeACircle() {
       controller =
-          new RestCircleController(
+          new CircleController(
               modelFactoryService, testabilitySettings, makeMe.aNullUserModelPlease());
       assertThrows(
           ResponseStatusException.class,
@@ -75,7 +75,7 @@ class RestCircleControllerTest {
     @Test
     void itShouldCircleForUserViewIfAuthorized() throws UnexpectedNoAccessRightException {
       UserModel user = makeMe.aUser().toModelPlease();
-      controller = new RestCircleController(modelFactoryService, testabilitySettings, user);
+      controller = new CircleController(modelFactoryService, testabilitySettings, user);
 
       Circle circle = makeMe.aCircle().please();
       circle.setName("Some circle");
@@ -99,7 +99,7 @@ class RestCircleControllerTest {
     void itShouldAskToLoginOfVisitorIsNotLogin() {
       Circle circle = makeMe.aCircle().please();
       controller =
-          new RestCircleController(
+          new CircleController(
               modelFactoryService, testabilitySettings, makeMe.aNullUserModelPlease());
       assertThrows(
           ResponseStatusException.class,

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestConversationMessageControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestConversationMessageControllerTest.java
@@ -33,12 +33,12 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestConversationMessageControllerTest {
+class ConversationMessageControllerTest {
 
   @Autowired ConversationService conversationService;
   @Autowired MakeMe makeMe;
   private UserModel currentUser;
-  RestConversationMessageController controller;
+  ConversationMessageController controller;
 
   @Autowired ModelFactoryService modelFactoryService;
   AssessmentQuestionInstance assessmentQuestionInstance;
@@ -54,7 +54,7 @@ class RestConversationMessageControllerTest {
         new ChatCompletionConversationService(
             openAiApiHandler, globalSettingsService, objectMapper);
     controller =
-        new RestConversationMessageController(
+        new ConversationMessageController(
             currentUser, conversationService, chatCompletionConversationService);
     Notebook notebook = makeMe.aNotebook().please();
     AssessmentAttempt assessmentAttempt =
@@ -123,7 +123,7 @@ class RestConversationMessageControllerTest {
   }
 
   @Nested
-  class RestConversationMessageControllerUnreadCountTest {
+  class ConversationMessageControllerUnreadCountTest {
     Conversation conversation;
 
     @BeforeEach
@@ -141,7 +141,7 @@ class RestConversationMessageControllerTest {
           new ChatCompletionConversationService(
               openAiApiHandler, globalSettingsService, objectMapper);
       controller =
-          new RestConversationMessageController(
+          new ConversationMessageController(
               makeMe.aNullUserModelPlease(),
               conversationService,
               chatCompletionConversationService);
@@ -440,7 +440,7 @@ class RestConversationMessageControllerTest {
           new ChatCompletionConversationService(
               openAiApiHandler, globalSettingsService, objectMapper);
       controller =
-          new RestConversationMessageController(
+          new ConversationMessageController(
               makeMe.aNullUserModelPlease(),
               conversationService,
               chatCompletionConversationService);

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestCurrentUserInfoControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestCurrentUserInfoControllerTest.java
@@ -19,13 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestCurrentUserInfoControllerTest {
+class CurrentUserInfoControllerTest {
   @Autowired MakeMe makeMe;
 
   @Mock CurrentUserFetcher currentUserFetcher;
 
-  RestCurrentUserInfoController controller(CurrentUserFetcher currentUserFetcher) {
-    return new RestCurrentUserInfoController(currentUserFetcher);
+  CurrentUserInfoController controller(CurrentUserFetcher currentUserFetcher) {
+    return new CurrentUserInfoController(currentUserFetcher);
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestFailureReportControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestFailureReportControllerTest.java
@@ -28,12 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestFailureReportControllerTest {
+class FailureReportControllerTest {
   @Autowired MakeMe makeMe;
   private GithubService githubService = new NullGithubService();
 
-  RestFailureReportController controller(UserModel userModel) {
-    return new RestFailureReportController(makeMe.modelFactoryService, githubService, userModel);
+  FailureReportController controller(UserModel userModel) {
+    return new FailureReportController(makeMe.modelFactoryService, githubService, userModel);
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestGlobalSettingsControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestGlobalSettingsControllerTest.java
@@ -21,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestGlobalSettingsControllerTest {
-  RestGlobalSettingsController controller;
+class GlobalSettingsControllerTest {
+  GlobalSettingsController controller;
   UserModel currentUser;
 
   @Autowired MakeMe makeMe;
@@ -39,7 +39,7 @@ class RestGlobalSettingsControllerTest {
     currentUser = makeMe.anAdmin().toModelPlease();
     globalSettingsService = new GlobalSettingsService(makeMe.modelFactoryService);
     controller =
-        new RestGlobalSettingsController(
+        new GlobalSettingsController(
             makeMe.modelFactoryService, currentUser, testabilitySettings);
   }
 
@@ -80,7 +80,7 @@ class RestGlobalSettingsControllerTest {
     @Test
     void authentication() {
       controller =
-          new RestGlobalSettingsController(
+          new GlobalSettingsController(
               makeMe.modelFactoryService, makeMe.aUser().toModelPlease(), testabilitySettings);
       assertThrows(
           UnexpectedNoAccessRightException.class,

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestLinkControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestLinkControllerTests.java
@@ -28,7 +28,7 @@ import org.springframework.validation.BindException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestLinkControllerTests {
+class LinkControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
@@ -39,8 +39,8 @@ class RestLinkControllerTests {
     userModel = makeMe.aUser().toModelPlease();
   }
 
-  RestLinkController controller() {
-    return new RestLinkController(modelFactoryService, new TestabilitySettings(), userModel);
+  LinkController controller() {
+    return new LinkController(modelFactoryService, new TestabilitySettings(), userModel);
   }
 
   @Nested

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestMemoryTrackerControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestMemoryTrackerControllerTest.java
@@ -33,19 +33,19 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestMemoryTrackerControllerTest {
+class MemoryTrackerControllerTest {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
 
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   private UserModel userModel;
-  RestMemoryTrackerController controller;
+  MemoryTrackerController controller;
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     controller =
-        new RestMemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
+        new MemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
   }
 
   @Nested
@@ -73,7 +73,7 @@ class RestMemoryTrackerControllerTest {
     void shouldRequireUserToBeLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
       controller =
-          new RestMemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
+          new MemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
       MemoryTracker memoryTracker =
           makeMe.aMemoryTrackerBy(makeMe.aUser().toModelPlease()).please();
       assertThrows(
@@ -219,7 +219,7 @@ class RestMemoryTrackerControllerTest {
     void shouldRequireUserToBeLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
       controller =
-          new RestMemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
+          new MemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
       assertThrows(ResponseStatusException.class, () -> controller.getRecentMemoryTrackers());
     }
   }
@@ -251,7 +251,7 @@ class RestMemoryTrackerControllerTest {
     void shouldRequireUserToBeLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
       controller =
-          new RestMemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
+          new MemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
       assertThrows(ResponseStatusException.class, () -> controller.getRecentlyReviewed());
     }
   }
@@ -315,7 +315,7 @@ class RestMemoryTrackerControllerTest {
       AnswerSpellingDTO answer = new AnswerSpellingDTO();
       userModel = makeMe.aNullUserModelPlease();
       controller =
-          new RestMemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
+          new MemoryTrackerController(modelFactoryService, userModel, testabilitySettings);
       assertThrows(
           ResponseStatusException.class, () -> controller.answerSpelling(memoryTracker, answer));
     }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerMotionTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerMotionTests.java
@@ -27,14 +27,14 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNoteControllerMotionTests {
+class NoteControllerMotionTests {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   private UserModel userModel;
-  RestNoteController controller;
+  NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   Note subject;
 
@@ -42,7 +42,7 @@ class RestNoteControllerMotionTests {
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     controller =
-        new RestNoteController(
+        new NoteController(
             modelFactoryService, userModel, httpClientAdapter, testabilitySettings);
     subject = makeMe.aNote("subject").creatorAndOwner(userModel).please();
   }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerRecentNotesTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerRecentNotesTests.java
@@ -24,20 +24,20 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNoteControllerRecentNotesTests {
+class NoteControllerRecentNotesTests {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   private UserModel userModel;
-  RestNoteController controller;
+  NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     controller =
-        new RestNoteController(
+        new NoteController(
             modelFactoryService, userModel, httpClientAdapter, testabilitySettings);
   }
 
@@ -71,7 +71,7 @@ class RestNoteControllerRecentNotesTests {
   void shouldNotAllowAccessWhenNotLoggedIn() {
     userModel = makeMe.aNullUserModelPlease();
     controller =
-        new RestNoteController(
+        new NoteController(
             modelFactoryService, userModel, httpClientAdapter, testabilitySettings);
 
     assertThrows(ResponseStatusException.class, () -> controller.getRecentNotes());

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
@@ -33,14 +33,14 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNoteControllerTests {
+class NoteControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   private UserModel userModel;
-  RestNoteController controller;
+  NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
@@ -48,7 +48,7 @@ class RestNoteControllerTests {
     userModel = makeMe.aUser().toModelPlease();
 
     controller =
-        new RestNoteController(
+        new NoteController(
             modelFactoryService, userModel, httpClientAdapter, testabilitySettings);
   }
 
@@ -286,8 +286,8 @@ class RestNoteControllerTests {
     @Test
     void shouldNotAllowSearchForLinkTargetWhenNotLoggedIn() {
       SearchTerm searchTerm = new SearchTerm();
-      RestSearchController searchController =
-          new RestSearchController(userModel, noteSearchService);
+      SearchController searchController =
+          new SearchController(userModel, noteSearchService);
       assertThrows(
           ResponseStatusException.class, () -> searchController.searchForLinkTarget(searchTerm));
     }
@@ -296,8 +296,8 @@ class RestNoteControllerTests {
     void shouldNotAllowSearchForLinkTargetWithinWhenNotLoggedIn() {
       Note note = makeMe.aNote().please();
       SearchTerm searchTerm = new SearchTerm();
-      RestSearchController searchController =
-          new RestSearchController(userModel, noteSearchService);
+      SearchController searchController =
+          new SearchController(userModel, noteSearchService);
       assertThrows(
           ResponseStatusException.class,
           () -> searchController.searchForLinkTargetWithin(note, searchTerm));

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteCreationControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteCreationControllerTests.java
@@ -34,19 +34,19 @@ import org.springframework.validation.BindException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNoteCreationControllerTests {
+class NoteCreationControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
   @Mock HttpClientAdapter httpClientAdapter;
   private UserModel userModel;
-  RestNoteCreationController controller;
+  NoteCreationController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     controller =
-        new RestNoteCreationController(
+        new NoteCreationController(
             modelFactoryService, userModel, httpClientAdapter, testabilitySettings);
   }
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNotebookCertificateApprovalControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNotebookCertificateApprovalControllerTest.java
@@ -22,19 +22,19 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNotebookCertificateApprovalControllerTest {
+class NotebookCertificateApprovalControllerTest {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
   private UserModel userModel;
-  RestNotebookCertificateApprovalController controller;
+  NotebookCertificateApprovalController controller;
   private TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     controller =
-        new RestNotebookCertificateApprovalController(
+        new NotebookCertificateApprovalController(
             modelFactoryService, userModel, testabilitySettings);
   }
 
@@ -99,7 +99,7 @@ class RestNotebookCertificateApprovalControllerTest {
       UserModel userModel = makeMe.anAdmin().toModelPlease();
       notebook = makeMe.aNotebook().creatorAndOwner(userModel).please();
       controller =
-          new RestNotebookCertificateApprovalController(
+          new NotebookCertificateApprovalController(
               modelFactoryService, userModel, testabilitySettings);
       approval = makeMe.modelFactoryService.notebookService(notebook).requestNotebookApproval();
       makeMe.refresh(notebook);

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNotebookControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNotebookControllerTest.java
@@ -41,12 +41,12 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestNotebookControllerTest {
+class NotebookControllerTest {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
   private UserModel userModel;
   private Note topNote;
-  RestNotebookController controller;
+  NotebookController controller;
   private TestabilitySettings testabilitySettings = new TestabilitySettings();
   @Autowired NotebookIndexingService notebookIndexingService;
   @Autowired WebApplicationContext webApplicationContext;
@@ -72,7 +72,7 @@ class RestNotebookControllerTest {
     userModel = makeMe.aUser().toModelPlease();
     topNote = makeMe.aNote().creatorAndOwner(userModel).please();
     controller =
-        new RestNotebookController(
+        new NotebookController(
             modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
   }
 
@@ -101,7 +101,7 @@ class RestNotebookControllerTest {
     void whenNotLogin() {
       userModel = modelFactoryService.toUserModel(null);
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
       assertThrows(ResponseStatusException.class, () -> controller.myNotebooks());
     }
@@ -112,7 +112,7 @@ class RestNotebookControllerTest {
       userModel = modelFactoryService.toUserModel(user);
       List<Notebook> notebooks = userModel.getEntity().getOwnership().getNotebooks();
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
       assertEquals(notebooks, controller.myNotebooks().notebooks);
     }
@@ -175,7 +175,7 @@ class RestNotebookControllerTest {
     void whenNotAuthorized() {
       User anotherUser = makeMe.aUser().please();
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService,
               modelFactoryService.toUserModel(anotherUser),
               testabilitySettings,
@@ -219,7 +219,7 @@ class RestNotebookControllerTest {
     @Test
     void shouldGetEmptyListOfNotes() throws UnexpectedNoAccessRightException {
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
       List<Note> result = controller.getNotes(notebook);
       assertThat(result.get(0).getPredefinedQuestions(), hasSize(0));
@@ -228,7 +228,7 @@ class RestNotebookControllerTest {
     @Test
     void shouldGetListOfNotesWithQuestions() throws UnexpectedNoAccessRightException {
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
       PredefinedQuestionBuilder predefinedQuestionBuilder = makeMe.aPredefinedQuestion();
       predefinedQuestionBuilder.approvedQuestionOf(notebook.getNotes().get(0)).please();
@@ -349,7 +349,7 @@ class RestNotebookControllerTest {
     void whenNotAuthorized() {
       User anotherUser = makeMe.aUser().please();
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService,
               modelFactoryService.toUserModel(anotherUser),
               testabilitySettings,
@@ -446,7 +446,7 @@ class RestNotebookControllerTest {
       // Arrange
       userModel = makeMe.aNullUserModelPlease();
       controller =
-          new RestNotebookController(
+          new NotebookController(
               modelFactoryService, userModel, testabilitySettings, notebookIndexingService);
 
       // Act & Assert

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestOpenAIChatGPTFineTuningExampleControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestOpenAIChatGPTFineTuningExampleControllerTests.java
@@ -35,13 +35,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class RestOpenAIChatGPTFineTuningExampleControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
-  RestFineTuningDataController controller;
+  FineTuningDataController controller;
   @Mock private OpenAiApi openAiApi;
 
   @BeforeEach
   void setup() {
     controller =
-        new RestFineTuningDataController(
+        new FineTuningDataController(
             modelFactoryService,
             makeMe.anAdmin().toModelPlease(),
             openAiApi,
@@ -53,7 +53,7 @@ public class RestOpenAIChatGPTFineTuningExampleControllerTests {
     @Test
     void authentication() {
       controller =
-          new RestFineTuningDataController(
+          new FineTuningDataController(
               modelFactoryService,
               makeMe.aUser().toModelPlease(),
               openAiApi,
@@ -106,7 +106,7 @@ public class RestOpenAIChatGPTFineTuningExampleControllerTests {
     @Test
     void shouldThrowExceptionIfUserDoesNotHaveReadingAuth_whenCallGetGoodTrainingData() {
       controller =
-          new RestFineTuningDataController(
+          new FineTuningDataController(
               modelFactoryService,
               makeMe.aNullUserModelPlease(),
               openAiApi,
@@ -147,7 +147,7 @@ public class RestOpenAIChatGPTFineTuningExampleControllerTests {
     @Test
     void itShouldNotAllowNonAdmin() {
       controller =
-          new RestFineTuningDataController(
+          new FineTuningDataController(
               modelFactoryService,
               makeMe.aUser().toModelPlease(),
               openAiApi,
@@ -186,7 +186,7 @@ public class RestOpenAIChatGPTFineTuningExampleControllerTests {
     @Test
     void itShouldNotAllowNonAdmin() {
       controller =
-          new RestFineTuningDataController(
+          new FineTuningDataController(
               modelFactoryService,
               makeMe.aUser().toModelPlease(),
               openAiApi,
@@ -214,7 +214,7 @@ public class RestOpenAIChatGPTFineTuningExampleControllerTests {
     @Test
     void itShouldNotAllowNonAdmin() {
       controller =
-          new RestFineTuningDataController(
+          new FineTuningDataController(
               modelFactoryService,
               makeMe.aUser().toModelPlease(),
               openAiApi,

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestPredefinedQuestionControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestPredefinedQuestionControllerTests.java
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestPredefinedQuestionControllerTests {
+class PredefinedQuestionControllerTests {
   @Mock OpenAiApi openAiApi;
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
@@ -41,14 +41,14 @@ class RestPredefinedQuestionControllerTests {
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   OpenAIChatCompletionMock openAIChatCompletionMock;
 
-  RestPredefinedQuestionController controller;
+  PredefinedQuestionController controller;
 
   @BeforeEach
   void setup() {
     openAIChatCompletionMock = new OpenAIChatCompletionMock(openAiApi);
     currentUser = makeMe.aUser().toModelPlease();
     controller =
-        new RestPredefinedQuestionController(
+        new PredefinedQuestionController(
             openAiApi,
             modelFactoryService,
             currentUser,
@@ -56,8 +56,8 @@ class RestPredefinedQuestionControllerTests {
             getTestObjectMapper());
   }
 
-  RestPredefinedQuestionController nullUserController() {
-    return new RestPredefinedQuestionController(
+  PredefinedQuestionController nullUserController() {
+    return new PredefinedQuestionController(
         openAiApi,
         modelFactoryService,
         makeMe.aNullUserModelPlease(),

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestRecallPromptControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestRecallPromptControllerTests.java
@@ -39,7 +39,7 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestRecallPromptControllerTests {
+class RecallPromptControllerTests {
   @Mock OpenAiApi openAiApi;
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
@@ -47,7 +47,7 @@ class RestRecallPromptControllerTests {
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   OpenAIChatCompletionMock openAIChatCompletionMock;
 
-  RestRecallPromptController controller;
+  RecallPromptController controller;
 
   @BeforeEach
   void setup() {
@@ -64,7 +64,7 @@ class RestRecallPromptControllerTests {
     openAIChatCompletionMock.mockChatCompletionAndReturnJsonSchema(evaluation);
 
     controller =
-        new RestRecallPromptController(
+        new RecallPromptController(
             openAiApi,
             makeMe.modelFactoryService,
             currentUser,
@@ -72,8 +72,8 @@ class RestRecallPromptControllerTests {
             getTestObjectMapper());
   }
 
-  RestRecallPromptController nullUserController() {
-    return new RestRecallPromptController(
+  RecallPromptController nullUserController() {
+    return new RecallPromptController(
         openAiApi,
         modelFactoryService,
         makeMe.aNullUserModelPlease(),
@@ -190,8 +190,8 @@ class RestRecallPromptControllerTests {
       assertThrows(
           ResponseStatusException.class,
           () -> {
-            RestRecallPromptController restAiController =
-                new RestRecallPromptController(
+            RecallPromptController restAiController =
+                new RecallPromptController(
                     openAiApi,
                     makeMe.modelFactoryService,
                     makeMe.aNullUserModelPlease(),
@@ -275,8 +275,8 @@ class RestRecallPromptControllerTests {
       assertThrows(
           ResponseStatusException.class,
           () -> {
-            RestRecallPromptController restAiController =
-                new RestRecallPromptController(
+            RecallPromptController restAiController =
+                new RecallPromptController(
                     openAiApi,
                     makeMe.modelFactoryService,
                     makeMe.aNullUserModelPlease(),

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestRecallsControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestRecallsControllerTests.java
@@ -26,22 +26,22 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestRecallsControllerTests {
+class RecallsControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
   private UserModel currentUser;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
-  RestRecallsController controller;
+  RecallsController controller;
 
   @BeforeEach
   void setup() {
     currentUser = makeMe.aUser().toModelPlease();
-    controller = new RestRecallsController(modelFactoryService, currentUser, testabilitySettings);
+    controller = new RecallsController(modelFactoryService, currentUser, testabilitySettings);
   }
 
-  RestRecallsController nullUserController() {
-    return new RestRecallsController(
+  RecallsController nullUserController() {
+    return new RecallsController(
         modelFactoryService, makeMe.aNullUserModelPlease(), testabilitySettings);
   }
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestSearchControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestSearchControllerTests.java
@@ -22,17 +22,17 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestSearchControllerTests {
+class SearchControllerTests {
   @Autowired MakeMe makeMe;
   @Autowired NoteSearchService noteSearchService;
 
   private UserModel userModel;
-  private RestSearchController controller;
+  private SearchController controller;
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
-    controller = new RestSearchController(userModel, noteSearchService);
+    controller = new SearchController(userModel, noteSearchService);
   }
 
   @Nested
@@ -111,7 +111,7 @@ class RestSearchControllerTests {
     @Test
     void shouldNotAllowSearchWhenNotLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
-      controller = new RestSearchController(userModel, noteSearchService);
+      controller = new SearchController(userModel, noteSearchService);
 
       SearchTerm searchTerm = new SearchTerm();
       searchTerm.setSearchKey("test");
@@ -181,7 +181,7 @@ class RestSearchControllerTests {
     @Test
     void shouldNotAllowSearchWhenNotLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
-      controller = new RestSearchController(userModel, noteSearchService);
+      controller = new SearchController(userModel, noteSearchService);
 
       SearchTerm searchTerm = new SearchTerm();
       searchTerm.setSearchKey("test");

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestSemanticSearchControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestSemanticSearchControllerTests.java
@@ -37,12 +37,12 @@ class RestSemanticSearchControllerTests {
   OpenAiApi openAiApi;
 
   private UserModel userModel;
-  private RestSearchController controller;
+  private SearchController controller;
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
-    controller = new RestSearchController(userModel, noteSearchService);
+    controller = new SearchController(userModel, noteSearchService);
     // Default: return empty embedding data so semantic search falls back to literal search
     EmbeddingResult empty = new EmbeddingResult();
     empty.setData(java.util.List.of());
@@ -68,7 +68,7 @@ class RestSemanticSearchControllerTests {
     @Test
     void shouldNotAllowSearchWhenNotLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
-      controller = new RestSearchController(userModel, noteSearchService);
+      controller = new SearchController(userModel, noteSearchService);
 
       SearchTerm searchTerm = new SearchTerm();
       searchTerm.setSearchKey("test");
@@ -105,7 +105,7 @@ class RestSemanticSearchControllerTests {
     @Test
     void shouldNotAllowSearchWhenNotLoggedIn() {
       userModel = makeMe.aNullUserModelPlease();
-      controller = new RestSearchController(userModel, noteSearchService);
+      controller = new SearchController(userModel, noteSearchService);
 
       SearchTerm searchTerm = new SearchTerm();
       searchTerm.setSearchKey("test");

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestSubscriptionControllerTest.java
@@ -25,13 +25,13 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestSubscriptionControllerTest {
+class SubscriptionControllerTest {
   @Autowired private MakeMe makeMe;
   @Autowired private SubscriptionRepository subscriptionRepository;
   private UserModel userModel;
   private Note topNote;
   private Notebook notebook;
-  private RestSubscriptionController controller;
+  private SubscriptionController controller;
 
   @BeforeEach
   void setup() {
@@ -39,7 +39,7 @@ class RestSubscriptionControllerTest {
     topNote = makeMe.aNote().creatorAndOwner(userModel).please();
     notebook = topNote.getNotebook();
     makeMe.aBazaarNotebook(topNote.getNotebook()).please();
-    controller = new RestSubscriptionController(makeMe.modelFactoryService, userModel);
+    controller = new SubscriptionController(makeMe.modelFactoryService, userModel);
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestTextContentControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestTextContentControllerTests.java
@@ -25,12 +25,12 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestTextContentControllerTests {
+class TextContentControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
   private UserModel userModel;
-  RestTextContentController controller;
+  TextContentController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   Note note;
 
@@ -38,7 +38,7 @@ class RestTextContentControllerTests {
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     note = makeMe.aNote("new").creatorAndOwner(userModel).please();
-    controller = new RestTextContentController(modelFactoryService, userModel, testabilitySettings);
+    controller = new TextContentController(modelFactoryService, userModel, testabilitySettings);
   }
 
   @Nested

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestUserControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestUserControllerTest.java
@@ -25,16 +25,16 @@ import org.springframework.web.server.ResponseStatusException;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class RestUserControllerTest {
+class UserControllerTest {
   @Autowired MakeMe makeMe;
   UserModel userModel;
-  RestUserController controller;
+  UserController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
   @BeforeEach
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
-    controller = new RestUserController(makeMe.modelFactoryService, userModel, testabilitySettings);
+    controller = new UserController(makeMe.modelFactoryService, userModel, testabilitySettings);
   }
 
   @Test
@@ -120,7 +120,7 @@ class RestUserControllerTest {
     ModelFactoryService modelFactoryService = makeMe.modelFactoryService;
     modelFactoryService.save(userToken2);
 
-    controller = new RestUserController(makeMe.modelFactoryService, userModel, testabilitySettings);
+    controller = new UserController(makeMe.modelFactoryService, userModel, testabilitySettings);
 
     assertThrows(ResponseStatusException.class, () -> controller.deleteToken(userToken2.getId()));
   }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestWikiDataControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestWikiDataControllerTests.java
@@ -23,8 +23,8 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.validation.BindException;
 
-class RestWikidataControllerTests {
-  RestWikidataController controller;
+class WikidataControllerTests {
+  WikidataController controller;
   @Mock HttpClientAdapter httpClientAdapter;
   TestabilitySettings testabilitySettings = new TestabilitySettings();
 
@@ -33,7 +33,7 @@ class RestWikidataControllerTests {
   @BeforeEach
   void Setup() {
     MockitoAnnotations.openMocks(this);
-    controller = new RestWikidataController(testabilitySettings, httpClientAdapter);
+    controller = new WikidataController(testabilitySettings, httpClientAdapter);
   }
 
   @Nested

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -8,7 +8,7 @@ paths:
   /api/user:
     get:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: getUserProfile
       responses:
         "500":
@@ -25,7 +25,7 @@ paths:
                 $ref: "#/components/schemas/User"
     post:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: createUser
       requestBody:
         content:
@@ -49,7 +49,7 @@ paths:
   /api/user/generate-token:
     post:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: generateToken
       requestBody:
         content:
@@ -453,7 +453,7 @@ paths:
   /api/subscriptions/{subscription}:
     post:
       tags:
-      - rest-subscription-controller
+      - subscription-controller
       operationId: update
       parameters:
       - name: subscription
@@ -483,7 +483,7 @@ paths:
   /api/subscriptions/{subscription}/delete:
     post:
       tags:
-      - rest-subscription-controller
+      - subscription-controller
       operationId: destroySubscription
       parameters: []
       responses:
@@ -505,7 +505,7 @@ paths:
   /api/subscriptions/notebooks/{notebook}/subscribe:
     post:
       tags:
-      - rest-subscription-controller
+      - subscription-controller
       operationId: createSubscription
       parameters:
       - name: notebook
@@ -535,7 +535,7 @@ paths:
   /api/settings/current-model-version:
     get:
       tags:
-      - rest-global-settings-controller
+      - global-settings-controller
       operationId: getCurrentModelVersions
       responses:
         "500":
@@ -552,7 +552,7 @@ paths:
                 $ref: "#/components/schemas/GlobalAiModelSettings"
     post:
       tags:
-      - rest-global-settings-controller
+      - global-settings-controller
       operationId: setCurrentModelVersions
       requestBody:
         content:
@@ -576,7 +576,7 @@ paths:
   /api/recall-prompts/{recallPrompt}/regenerate:
     post:
       tags:
-      - rest-recall-prompt-controller
+      - recall-prompt-controller
       operationId: regenerate
       parameters:
       - name: recallPrompt
@@ -606,7 +606,7 @@ paths:
   /api/recall-prompts/{recallPrompt}/contest:
     post:
       tags:
-      - rest-recall-prompt-controller
+      - recall-prompt-controller
       operationId: contest
       parameters:
       - name: recallPrompt
@@ -630,7 +630,7 @@ paths:
   /api/recall-prompts/{recallPrompt}/answer:
     post:
       tags:
-      - rest-recall-prompt-controller
+      - recall-prompt-controller
       operationId: answerQuiz
       parameters:
       - name: recallPrompt
@@ -660,7 +660,7 @@ paths:
   /api/predefined-questions/{predefinedQuestion}/toggle-approval:
     post:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: toggleApproval
       parameters:
       - name: predefinedQuestion
@@ -684,7 +684,7 @@ paths:
   /api/predefined-questions/{predefinedQuestion}/suggest-fine-tuning:
     post:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: suggestQuestionForFineTuning
       parameters:
       - name: predefinedQuestion
@@ -714,7 +714,7 @@ paths:
   /api/predefined-questions/{note}/refine-question:
     post:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: refineQuestion
       parameters:
       - name: note
@@ -744,7 +744,7 @@ paths:
   /api/predefined-questions/{note}/note-questions:
     get:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: getAllQuestionByNote
       parameters:
       - name: note
@@ -769,7 +769,7 @@ paths:
                   $ref: "#/components/schemas/PredefinedQuestion"
     post:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: addQuestionManually
       parameters:
       - name: note
@@ -799,7 +799,7 @@ paths:
   /api/predefined-questions/generate-question-without-save:
     post:
       tags:
-      - rest-predefined-question-controller
+      - predefined-question-controller
       operationId: generateQuestionWithoutSave
       parameters:
       - name: note
@@ -823,7 +823,7 @@ paths:
   /api/notes/{referenceNote}/create-after:
     post:
       tags:
-      - rest-note-creation-controller
+      - note-creation-controller
       operationId: createNoteAfter
       parameters:
       - name: referenceNote
@@ -853,7 +853,7 @@ paths:
   /api/notes/{parentNote}/create:
     post:
       tags:
-      - rest-note-creation-controller
+      - note-creation-controller
       operationId: createNote
       parameters:
       - name: parentNote
@@ -883,7 +883,7 @@ paths:
   /api/notes/{note}/updateWikidataId:
     post:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: updateWikidataId
       parameters:
       - name: note
@@ -913,7 +913,7 @@ paths:
   /api/notes/{note}/semantic-search:
     post:
       tags:
-      - rest-search-controller
+      - search-controller
       operationId: semanticSearchWithin
       parameters:
       - name: note
@@ -945,7 +945,7 @@ paths:
   /api/notes/{note}/search:
     post:
       tags:
-      - rest-search-controller
+      - search-controller
       operationId: searchForLinkTargetWithin
       parameters:
       - name: note
@@ -977,7 +977,7 @@ paths:
   /api/notes/{note}/review-setting:
     post:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: updateRecallSetting
       parameters:
       - name: note
@@ -1007,7 +1007,7 @@ paths:
   /api/notes/{note}/delete:
     post:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: deleteNote
       parameters:
       - name: note
@@ -1033,7 +1033,7 @@ paths:
   /api/notes/semantic-search:
     post:
       tags:
-      - rest-search-controller
+      - search-controller
       operationId: semanticSearch
       requestBody:
         content:
@@ -1059,7 +1059,7 @@ paths:
   /api/notes/search:
     post:
       tags:
-      - rest-search-controller
+      - search-controller
       operationId: searchForLinkTarget
       requestBody:
         content:
@@ -1085,7 +1085,7 @@ paths:
   /api/notes/move_after/{note}/{targetNote}/{asFirstChild}:
     post:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: moveAfter
       parameters:
       - name: note
@@ -1121,7 +1121,7 @@ paths:
   /api/notebooks/{notebook}:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: get
       parameters:
       - name: notebook
@@ -1144,7 +1144,7 @@ paths:
                 $ref: "#/components/schemas/Notebook"
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: update_1
       parameters:
       - name: notebook
@@ -1174,7 +1174,7 @@ paths:
   /api/notebooks/{notebook}/update-index:
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: updateNotebookIndex
       parameters:
       - name: notebook
@@ -1194,7 +1194,7 @@ paths:
   /api/notebooks/{notebook}/share:
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: shareNotebook
       parameters:
       - name: notebook
@@ -1218,7 +1218,7 @@ paths:
   /api/notebooks/{notebook}/reset-index:
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: resetNotebookIndex
       parameters:
       - name: notebook
@@ -1238,7 +1238,7 @@ paths:
   /api/notebooks/{notebookId}/obsidian:
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       summary: Import Obsidian file
       operationId: importObsidian
       parameters:
@@ -1273,7 +1273,7 @@ paths:
   /api/notebooks/create:
     post:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: createNotebook
       requestBody:
         content:
@@ -1297,7 +1297,7 @@ paths:
   /api/notebook_certificate_approvals/{notebookCertificateApproval}/approve:
     post:
       tags:
-      - rest-notebook-certificate-approval-controller
+      - notebook-certificate-approval-controller
       operationId: approve
       parameters:
       - name: notebookCertificateApproval
@@ -1321,7 +1321,7 @@ paths:
   /api/notebook_certificate_approvals/request-approval/{notebook}:
     post:
       tags:
-      - rest-notebook-certificate-approval-controller
+      - notebook-certificate-approval-controller
       operationId: requestApprovalForNotebook
       parameters:
       - name: notebook
@@ -1345,7 +1345,7 @@ paths:
   /api/memory-trackers/{memoryTracker}/self-evaluate:
     post:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: selfEvaluate
       parameters:
       - name: memoryTracker
@@ -1375,7 +1375,7 @@ paths:
   /api/memory-trackers/{memoryTracker}/remove:
     post:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: removeFromRepeating
       parameters:
       - name: memoryTracker
@@ -1399,7 +1399,7 @@ paths:
   /api/memory-trackers/{memoryTracker}/answer-spelling:
     post:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: answerSpelling
       parameters:
       - name: memoryTracker
@@ -1453,7 +1453,7 @@ paths:
   /api/links/{link}:
     post:
       tags:
-      - rest-link-controller
+      - link-controller
       operationId: updateLink
       parameters:
       - name: link
@@ -1485,7 +1485,7 @@ paths:
   /api/links/move/{sourceNote}/{targetNote}:
     post:
       tags:
-      - rest-link-controller
+      - link-controller
       operationId: moveNote
       parameters:
       - name: sourceNote
@@ -1522,7 +1522,7 @@ paths:
   /api/links/create/{sourceNote}/{targetNote}:
     post:
       tags:
-      - rest-link-controller
+      - link-controller
       operationId: linkNoteFinalize
       parameters:
       - name: sourceNote
@@ -1559,7 +1559,7 @@ paths:
   /api/fine-tuning/{suggestedQuestion}/duplicate:
     post:
       tags:
-      - rest-fine-tuning-data-controller
+      - fine-tuning-data-controller
       operationId: duplicate
       parameters:
       - name: suggestedQuestion
@@ -1583,7 +1583,7 @@ paths:
   /api/fine-tuning/{suggestedQuestion}/delete:
     post:
       tags:
-      - rest-fine-tuning-data-controller
+      - fine-tuning-data-controller
       operationId: delete
       parameters:
       - name: suggestedQuestion
@@ -1607,7 +1607,7 @@ paths:
   /api/fine-tuning/upload-and-trigger-fine-tuning:
     post:
       tags:
-      - rest-fine-tuning-data-controller
+      - fine-tuning-data-controller
       operationId: uploadAndTriggerFineTuning
       responses:
         "500":
@@ -1621,7 +1621,7 @@ paths:
   /api/conversation/{conversationId}/send:
     post:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: replyToConversation
       parameters:
       - name: conversationId
@@ -1651,7 +1651,7 @@ paths:
   /api/conversation/{conversationId}/ai-reply:
     post:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getAiReply
       parameters:
       - name: conversationId
@@ -1675,7 +1675,7 @@ paths:
   /api/conversation/recall-prompt/{recallPrompt}:
     post:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: startConversationAboutRecallPrompt
       parameters:
       - name: recallPrompt
@@ -1699,7 +1699,7 @@ paths:
   /api/conversation/note/{note}:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getConversationsAboutNote
       parameters:
       - name: note
@@ -1724,7 +1724,7 @@ paths:
                   $ref: "#/components/schemas/Conversation"
     post:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: startConversationAboutNote
       parameters:
       - name: note
@@ -1754,7 +1754,7 @@ paths:
   /api/conversation/assessment-question/{assessmentQuestion}:
     post:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: startConversationAboutAssessmentQuestion
       parameters:
       - name: assessmentQuestion
@@ -1784,7 +1784,7 @@ paths:
   /api/circles:
     get:
       tags:
-      - rest-circle-controller
+      - circle-controller
       operationId: index
       responses:
         "500":
@@ -1803,7 +1803,7 @@ paths:
                   $ref: "#/components/schemas/Circle"
     post:
       tags:
-      - rest-circle-controller
+      - circle-controller
       operationId: createCircle
       requestBody:
         content:
@@ -1827,7 +1827,7 @@ paths:
   /api/circles/{circle}/notebooks:
     post:
       tags:
-      - rest-circle-controller
+      - circle-controller
       operationId: createNotebookInCircle
       parameters:
       - name: circle
@@ -1857,7 +1857,7 @@ paths:
   /api/circles/join:
     post:
       tags:
-      - rest-circle-controller
+      - circle-controller
       operationId: joinCircle
       requestBody:
         content:
@@ -1881,7 +1881,7 @@ paths:
   /api/certificate/{notebook}:
     get:
       tags:
-      - rest-certificate-controller
+      - certificate-controller
       operationId: getCertificate
       parameters:
       - name: notebook
@@ -1904,7 +1904,7 @@ paths:
                 $ref: "#/components/schemas/Certificate"
     post:
       tags:
-      - rest-certificate-controller
+      - certificate-controller
       operationId: claimCertificate
       parameters:
       - name: notebook
@@ -1928,7 +1928,7 @@ paths:
   /api/bazaar/{bazaarNotebook}/remove:
     post:
       tags:
-      - rest-bazaar-controller
+      - bazaar-controller
       operationId: removeFromBazaar
       parameters:
       - name: bazaarNotebook
@@ -1954,7 +1954,7 @@ paths:
   /api/audio/audio-to-text:
     post:
       tags:
-      - rest-ai-audio-controller
+      - ai-audio-controller
       operationId: audioToText
       requestBody:
         content:
@@ -2003,7 +2003,7 @@ paths:
   /api/assessment/{assessmentQuestionInstance}/answer:
     post:
       tags:
-      - rest-assessment-controller
+      - assessment-controller
       operationId: answerQuestion
       parameters:
       - name: assessmentQuestionInstance
@@ -2033,7 +2033,7 @@ paths:
   /api/assessment/{assessmentAttempt}:
     post:
       tags:
-      - rest-assessment-controller
+      - assessment-controller
       operationId: submitAssessmentResult
       parameters:
       - name: assessmentAttempt
@@ -2057,7 +2057,7 @@ paths:
   /api/assessment/questions/{notebook}:
     post:
       tags:
-      - rest-assessment-controller
+      - assessment-controller
       operationId: generateAssessmentQuestions
       parameters:
       - name: notebook
@@ -2081,7 +2081,7 @@ paths:
   /api/ai/suggest-title/{note}:
     post:
       tags:
-      - rest-ai-controller
+      - ai-controller
       operationId: suggestTitle
       parameters:
       - name: note
@@ -2105,7 +2105,7 @@ paths:
   /api/ai/generate-image:
     post:
       tags:
-      - rest-ai-controller
+      - ai-controller
       operationId: generateImage
       requestBody:
         content:
@@ -2129,7 +2129,7 @@ paths:
   /api/user/{user}:
     patch:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: updateUser
       parameters:
       - name: user
@@ -2159,7 +2159,7 @@ paths:
   /api/text_content/{note}/title:
     patch:
       tags:
-      - rest-text-content-controller
+      - text-content-controller
       operationId: updateNoteTitle
       parameters:
       - name: note
@@ -2189,7 +2189,7 @@ paths:
   /api/text_content/{note}/details:
     patch:
       tags:
-      - rest-text-content-controller
+      - text-content-controller
       operationId: updateNoteDetails
       parameters:
       - name: note
@@ -2219,7 +2219,7 @@ paths:
   /api/notes/{note}:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: show
       parameters:
       - name: note
@@ -2242,7 +2242,7 @@ paths:
                 $ref: "#/components/schemas/NoteRealm"
     patch:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: updateNoteAccessories
       parameters:
       - name: note
@@ -2271,7 +2271,7 @@ paths:
   /api/notes/{note}/undo-delete:
     patch:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: undoDeleteNote
       parameters:
       - name: note
@@ -2295,7 +2295,7 @@ paths:
   /api/notebooks/{notebook}/move-to-circle/{circle}:
     patch:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: moveToCircle
       parameters:
       - name: notebook
@@ -2324,7 +2324,7 @@ paths:
   /api/notebooks/{notebook}/ai-assistant:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: getAiAssistant
       parameters:
       - name: notebook
@@ -2347,7 +2347,7 @@ paths:
                 $ref: "#/components/schemas/NotebookAiAssistant"
     patch:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: updateAiAssistant
       parameters:
       - name: notebook
@@ -2377,7 +2377,7 @@ paths:
   /api/memory-trackers/{memoryTracker}/mark-as-repeated:
     patch:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: markAsRepeated
       parameters:
       - name: memoryTracker
@@ -2406,7 +2406,7 @@ paths:
   /api/fine-tuning/{suggestedQuestion}/update-suggested-question-for-fine-tuning:
     patch:
       tags:
-      - rest-fine-tuning-data-controller
+      - fine-tuning-data-controller
       operationId: updateSuggestedQuestionForFineTuning
       parameters:
       - name: suggestedQuestion
@@ -2436,7 +2436,7 @@ paths:
   /api/conversation/{conversationId}/read:
     patch:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: markConversationAsRead
       parameters:
       - name: conversationId
@@ -2462,7 +2462,7 @@ paths:
   /api/wikidata/search/{search}:
     get:
       tags:
-      - rest-wikidata-controller
+      - wikidata-controller
       operationId: searchWikidata
       parameters:
       - name: search
@@ -2488,7 +2488,7 @@ paths:
   /api/wikidata/entity-data/{wikidataId}:
     get:
       tags:
-      - rest-wikidata-controller
+      - wikidata-controller
       operationId: fetchWikidataEntityDataByID
       parameters:
       - name: wikidataId
@@ -2512,7 +2512,7 @@ paths:
   /api/user/get-tokens:
     get:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: getTokens
       responses:
         "500":
@@ -2532,7 +2532,7 @@ paths:
   /api/user/current-user-info:
     get:
       tags:
-      - rest-current-user-info-controller
+      - current-user-info-controller
       operationId: currentUserInfo
       responses:
         "500":
@@ -2572,7 +2572,7 @@ paths:
   /api/recalls/recalling:
     get:
       tags:
-      - rest-recalls-controller
+      - recalls-controller
       operationId: recalling
       parameters:
       - name: timezone
@@ -2602,7 +2602,7 @@ paths:
   /api/recalls/overview:
     get:
       tags:
-      - rest-recalls-controller
+      - recalls-controller
       operationId: overview
       parameters:
       - name: timezone
@@ -2626,7 +2626,7 @@ paths:
   /api/recall-prompts/{recallPrompt}:
     get:
       tags:
-      - rest-recall-prompt-controller
+      - recall-prompt-controller
       operationId: showQuestion
       parameters:
       - name: recallPrompt
@@ -2650,7 +2650,7 @@ paths:
   /api/recall-prompts/{memoryTracker}/question:
     get:
       tags:
-      - rest-recall-prompt-controller
+      - recall-prompt-controller
       operationId: askAQuestion
       parameters:
       - name: memoryTracker
@@ -2674,7 +2674,7 @@ paths:
   /api/notes/{note}/note-info:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: getNoteInfo
       parameters:
       - name: note
@@ -2698,7 +2698,7 @@ paths:
   /api/notes/{note}/graph:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: getGraph
       parameters:
       - name: note
@@ -2728,7 +2728,7 @@ paths:
   /api/notes/{note}/descendants:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: getDescendants
       parameters:
       - name: note
@@ -2752,7 +2752,7 @@ paths:
   /api/notes/{note}/accessory:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: showNoteAccessory
       parameters:
       - name: note
@@ -2776,7 +2776,7 @@ paths:
   /api/notes/recent:
     get:
       tags:
-      - rest-note-controller
+      - note-controller
       operationId: getRecentNotes
       responses:
         "500":
@@ -2796,7 +2796,7 @@ paths:
   /api/notebooks:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: myNotebooks
       responses:
         "500":
@@ -2814,7 +2814,7 @@ paths:
   /api/notebooks/{notebook}/obsidian:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: downloadNotebookForObsidian
       parameters:
       - name: notebook
@@ -2839,7 +2839,7 @@ paths:
   /api/notebooks/{notebook}/notes:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: getNotes
       parameters:
       - name: notebook
@@ -2865,7 +2865,7 @@ paths:
   /api/notebooks/{notebook}/dump:
     get:
       tags:
-      - rest-notebook-controller
+      - notebook-controller
       operationId: downloadNotebookDump
       parameters:
       - name: notebook
@@ -2891,7 +2891,7 @@ paths:
   /api/notebook_certificate_approvals/get-all-pending-request:
     get:
       tags:
-      - rest-notebook-certificate-approval-controller
+      - notebook-certificate-approval-controller
       operationId: getAllPendingRequest
       responses:
         "500":
@@ -2911,7 +2911,7 @@ paths:
   /api/notebook_certificate_approvals/for-notebook/{notebook}:
     get:
       tags:
-      - rest-notebook-certificate-approval-controller
+      - notebook-certificate-approval-controller
       operationId: getApprovalForNotebook
       parameters:
       - name: notebook
@@ -2935,7 +2935,7 @@ paths:
   /api/memory-trackers/{memoryTracker}:
     get:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: show_1
       parameters:
       - name: memoryTracker
@@ -2959,7 +2959,7 @@ paths:
   /api/memory-trackers/{memoryTracker}/spelling-question:
     get:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: getSpellingQuestion
       parameters:
       - name: memoryTracker
@@ -2983,7 +2983,7 @@ paths:
   /api/memory-trackers/recently-reviewed:
     get:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: getRecentlyReviewed
       responses:
         "500":
@@ -3003,7 +3003,7 @@ paths:
   /api/memory-trackers/recent:
     get:
       tags:
-      - rest-memory-tracker-controller
+      - memory-tracker-controller
       operationId: getRecentMemoryTrackers
       responses:
         "500":
@@ -3023,7 +3023,7 @@ paths:
   /api/healthcheck:
     get:
       tags:
-      - rest-health-check-controller
+      - health-check-controller
       operationId: ping
       responses:
         "500":
@@ -3041,7 +3041,7 @@ paths:
   /api/fine-tuning/all-suggested-questions-for-fine-tuning:
     get:
       tags:
-      - rest-fine-tuning-data-controller
+      - fine-tuning-data-controller
       operationId: getAllSuggestedQuestions
       responses:
         "500":
@@ -3061,7 +3061,7 @@ paths:
   /api/failure-reports:
     get:
       tags:
-      - rest-failure-report-controller
+      - failure-report-controller
       operationId: failureReports
       responses:
         "500":
@@ -3079,7 +3079,7 @@ paths:
   /api/failure-reports/{failureReport}:
     get:
       tags:
-      - rest-failure-report-controller
+      - failure-report-controller
       operationId: show_2
       parameters:
       - name: failureReport
@@ -3103,7 +3103,7 @@ paths:
   /api/data_upgrade:
     get:
       tags:
-      - rest-health-check-controller
+      - health-check-controller
       operationId: dataUpgrade
       responses:
         "500":
@@ -3123,7 +3123,7 @@ paths:
   /api/conversation/{conversationId}:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getConversation
       parameters:
       - name: conversationId
@@ -3147,7 +3147,7 @@ paths:
   /api/conversation/{conversationId}/messages:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getConversationMessages
       parameters:
       - name: conversationId
@@ -3173,7 +3173,7 @@ paths:
   /api/conversation/{conversationId}/export:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: exportConversation
       parameters:
       - name: conversationId
@@ -3197,7 +3197,7 @@ paths:
   /api/conversation/unread:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getUnreadConversations
       responses:
         "500":
@@ -3217,7 +3217,7 @@ paths:
   /api/conversation/all:
     get:
       tags:
-      - rest-conversation-message-controller
+      - conversation-message-controller
       operationId: getConversationsOfCurrentUser
       responses:
         "500":
@@ -3237,7 +3237,7 @@ paths:
   /api/circles/{circle}:
     get:
       tags:
-      - rest-circle-controller
+      - circle-controller
       operationId: showCircle
       parameters:
       - name: circle
@@ -3261,7 +3261,7 @@ paths:
   /api/bazaar:
     get:
       tags:
-      - rest-bazaar-controller
+      - bazaar-controller
       operationId: bazaar
       responses:
         "500":
@@ -3331,7 +3331,7 @@ paths:
   /api/assessment:
     get:
       tags:
-      - rest-assessment-controller
+      - assessment-controller
       operationId: getMyAssessments
       responses:
         "500":
@@ -3351,7 +3351,7 @@ paths:
   /api/ai/dummy:
     get:
       tags:
-      - rest-ai-controller
+      - ai-controller
       operationId: dummyEntryToGenerateDataTypesThatAreRequiredInEventStream
       responses:
         "500":
@@ -3369,7 +3369,7 @@ paths:
   /api/ai/available-gpt-models:
     get:
       tags:
-      - rest-ai-controller
+      - ai-controller
       operationId: getAvailableGptModels
       responses:
         "500":
@@ -3389,7 +3389,7 @@ paths:
   /api/user/token/{tokenId}:
     delete:
       tags:
-      - rest-user-controller
+      - user-controller
       operationId: deleteToken
       parameters:
       - name: tokenId
@@ -3409,7 +3409,7 @@ paths:
   /api/failure-reports/delete:
     delete:
       tags:
-      - rest-failure-report-controller
+      - failure-report-controller
       operationId: deleteFailureReports
       requestBody:
         content:


### PR DESCRIPTION
Remove the "Rest" prefix from all `@RestController` classes and their corresponding files to align with Spring Boot conventions.

This refactoring involved renaming 26 controller classes and files, updating all references in the codebase, and regenerating TypeScript types. Compilation has been verified, and files were renamed using `git mv` to preserve history. Exceptions like `ApplicationController` and `AttachmentController` (which use `@Controller`) were intentionally kept as-is.

---
<a href="https://cursor.com/background-agent?bcId=bc-956d6c45-4e30-41b9-8c05-d244f54b0fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-956d6c45-4e30-41b9-8c05-d244f54b0fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

