### PR TITLE
Refactor timestamp operations and update docs

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/AssimilationController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/AssimilationController.java
@@ -7,6 +7,7 @@ import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.AssimilationService;
 import com.odde.doughnut.services.MemoryTrackerService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.TestabilitySettings;
 import jakarta.annotation.Resource;
 import java.sql.Timestamp;
@@ -23,6 +24,7 @@ class AssimilationController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
   private final MemoryTrackerService memoryTrackerService;
+  private final TimestampService timestampService;
 
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
@@ -30,11 +32,13 @@ class AssimilationController {
   public AssimilationController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
-      TestabilitySettings testabilitySettings) {
+      TestabilitySettings testabilitySettings,
+      TimestampService timestampService) {
     this.modelFactoryService = modelFactoryService;
     this.currentUser = currentUser;
     this.testabilitySettings = testabilitySettings;
-    this.memoryTrackerService = new MemoryTrackerService(modelFactoryService);
+    this.timestampService = timestampService;
+    this.memoryTrackerService = new MemoryTrackerService(modelFactoryService, timestampService);
   }
 
   @GetMapping("/assimilating")
@@ -44,7 +48,8 @@ class AssimilationController {
     ZoneId timeZone = ZoneId.of(timezone);
     Timestamp currentUTCTimestamp = testabilitySettings.getCurrentUTCTimestamp();
 
-    return new AssimilationService(currentUser, modelFactoryService, currentUTCTimestamp, timeZone)
+    return new AssimilationService(
+            currentUser, modelFactoryService, currentUTCTimestamp, timeZone, timestampService)
         .getNotesToAssimilate()
         .toList();
   }
@@ -65,7 +70,8 @@ class AssimilationController {
     ZoneId timeZone = ZoneId.of(timezone);
     Timestamp currentUTCTimestamp = testabilitySettings.getCurrentUTCTimestamp();
 
-    return new AssimilationService(currentUser, modelFactoryService, currentUTCTimestamp, timeZone)
+    return new AssimilationService(
+            currentUser, modelFactoryService, currentUTCTimestamp, timeZone, timestampService)
         .getCounts();
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/controllers/McpNoteCreationController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/McpNoteCreationController.java
@@ -11,6 +11,7 @@ import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.NoteConstructionService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.WikidataService;
 import com.odde.doughnut.services.httpQuery.HttpClientAdapter;
 import com.odde.doughnut.services.search.NoteSearchService;
@@ -44,10 +45,12 @@ public class McpNoteCreationController {
       HttpClientAdapter httpClientAdapter,
       TestabilitySettings testabilitySettings,
       NoteSearchService noteSearchService,
-      NoteRepository noteRepository) {
+      NoteRepository noteRepository,
+      TimestampService timestampService) {
     this.currentUser = currentUser;
     this.wikidataService =
-        new WikidataService(httpClientAdapter, testabilitySettings.getWikidataServiceUrl());
+        new WikidataService(
+            httpClientAdapter, testabilitySettings.getWikidataServiceUrl(), timestampService);
     this.noteConstructionService =
         new NoteConstructionService(
             currentUser.getEntity(),

--- a/backend/src/main/java/com/odde/doughnut/controllers/NoteController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NoteController.java
@@ -11,6 +11,7 @@ import com.odde.doughnut.models.NoteMotionModel;
 import com.odde.doughnut.models.NoteViewer;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.GraphRAGService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.WikidataService;
 import com.odde.doughnut.services.graphRAG.BareNote;
 import com.odde.doughnut.services.graphRAG.CharacterBasedTokenCountingStrategy;
@@ -45,12 +46,14 @@ class NoteController {
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       HttpClientAdapter httpClientAdapter,
-      TestabilitySettings testabilitySettings) {
+      TestabilitySettings testabilitySettings,
+      TimestampService timestampService) {
     this.modelFactoryService = modelFactoryService;
     this.currentUser = currentUser;
     this.testabilitySettings = testabilitySettings;
     this.wikidataService =
-        new WikidataService(httpClientAdapter, testabilitySettings.getWikidataServiceUrl());
+        new WikidataService(
+            httpClientAdapter, testabilitySettings.getWikidataServiceUrl(), timestampService);
   }
 
   @PostMapping(value = "/{note}/updateWikidataId")

--- a/backend/src/main/java/com/odde/doughnut/controllers/NoteCreationController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NoteCreationController.java
@@ -28,10 +28,12 @@ class NoteCreationController {
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
       HttpClientAdapter httpClientAdapter,
-      TestabilitySettings testabilitySettings) {
+      TestabilitySettings testabilitySettings,
+      TimestampService timestampService) {
     this.currentUser = currentUser;
     this.wikidataService =
-        new WikidataService(httpClientAdapter, testabilitySettings.getWikidataServiceUrl());
+        new WikidataService(
+            httpClientAdapter, testabilitySettings.getWikidataServiceUrl(), timestampService);
     this.noteConstructionService =
         new NoteConstructionService(
             currentUser.getEntity(),

--- a/backend/src/main/java/com/odde/doughnut/controllers/RecallsController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/RecallsController.java
@@ -5,6 +5,7 @@ import com.odde.doughnut.controllers.dto.RecallStatus;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.RecallService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.TestabilitySettings;
 import jakarta.annotation.Resource;
 import java.sql.Timestamp;
@@ -22,6 +23,7 @@ import org.springframework.web.context.annotation.SessionScope;
 class RecallsController {
   private final ModelFactoryService modelFactoryService;
   private final UserModel currentUser;
+  private final TimestampService timestampService;
 
   @Resource(name = "testabilitySettings")
   private final TestabilitySettings testabilitySettings;
@@ -29,10 +31,12 @@ class RecallsController {
   public RecallsController(
       ModelFactoryService modelFactoryService,
       UserModel currentUser,
-      TestabilitySettings testabilitySettings) {
+      TestabilitySettings testabilitySettings,
+      TimestampService timestampService) {
     this.modelFactoryService = modelFactoryService;
     this.currentUser = currentUser;
     this.testabilitySettings = testabilitySettings;
+    this.timestampService = timestampService;
   }
 
   @GetMapping("/overview")
@@ -41,7 +45,8 @@ class RecallsController {
     currentUser.assertLoggedIn();
     ZoneId timeZone = ZoneId.of(timezone);
     Timestamp currentUTCTimestamp = testabilitySettings.getCurrentUTCTimestamp();
-    return new RecallService(currentUser, currentUTCTimestamp, timeZone, modelFactoryService)
+    return new RecallService(
+            currentUser, currentUTCTimestamp, timeZone, modelFactoryService, timestampService)
         .getRecallStatus();
   }
 
@@ -53,7 +58,8 @@ class RecallsController {
     currentUser.assertLoggedIn();
     ZoneId timeZone = ZoneId.of(timezone);
     Timestamp currentUTCTimestamp = testabilitySettings.getCurrentUTCTimestamp();
-    return new RecallService(currentUser, currentUTCTimestamp, timeZone, modelFactoryService)
+    return new RecallService(
+            currentUser, currentUTCTimestamp, timeZone, modelFactoryService, timestampService)
         .getDueMemoryTrackers(dueInDays == null ? 0 : dueInDays);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/controllers/WikidataController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/WikidataController.java
@@ -3,6 +3,7 @@ package com.odde.doughnut.controllers;
 import com.odde.doughnut.controllers.dto.WikidataEntityData;
 import com.odde.doughnut.controllers.dto.WikidataSearchEntity;
 import com.odde.doughnut.exceptions.WikidataServiceErrorException;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.WikidataService;
 import com.odde.doughnut.services.httpQuery.HttpClientAdapter;
 import com.odde.doughnut.testability.TestabilitySettings;
@@ -24,9 +25,12 @@ public class WikidataController {
   WikidataService wikidataService;
 
   public WikidataController(
-      TestabilitySettings testabilitySettings, HttpClientAdapter httpClientAdapter) {
+      TestabilitySettings testabilitySettings,
+      HttpClientAdapter httpClientAdapter,
+      TimestampService timestampService) {
     wikidataService =
-        new WikidataService(httpClientAdapter, testabilitySettings.getWikidataServiceUrl());
+        new WikidataService(
+            httpClientAdapter, testabilitySettings.getWikidataServiceUrl(), timestampService);
   }
 
   @GetMapping("/entity-data/{wikidataId}")

--- a/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
+++ b/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
@@ -5,6 +5,7 @@ import com.odde.doughnut.entities.*;
 import com.odde.doughnut.entities.repositories.*;
 import com.odde.doughnut.models.*;
 import com.odde.doughnut.services.NotebookService;
+import com.odde.doughnut.services.TimestampService;
 import jakarta.persistence.EntityManager;
 import java.sql.Timestamp;
 import java.util.List;
@@ -39,6 +40,7 @@ public class ModelFactoryService {
 
   @Autowired public NoteEmbeddingRepository noteEmbeddingRepository;
   @Autowired public NoteEmbeddingJdbcRepository noteEmbeddingJdbcRepository;
+  @Autowired public TimestampService timestampService;
 
   public void storeNoteEmbedding(Note note, java.util.List<Float> embedding) {
     noteEmbeddingJdbcRepository.insert(note.getId(), embedding);
@@ -113,7 +115,7 @@ public class ModelFactoryService {
   }
 
   public UserModel toUserModel(User user) {
-    return new UserModel(user, this);
+    return new UserModel(user, this, timestampService);
   }
 
   public SubscriptionModel toSubscriptionModel(Subscription sub) {

--- a/backend/src/main/java/com/odde/doughnut/models/UserModel.java
+++ b/backend/src/main/java/com/odde/doughnut/models/UserModel.java
@@ -5,6 +5,7 @@ import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.User;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
+import com.odde.doughnut.services.TimestampService;
 import java.sql.Timestamp;
 import java.time.*;
 import java.util.List;
@@ -15,10 +16,13 @@ public class UserModel implements ReviewScope {
 
   @Getter protected final User entity;
   protected final ModelFactoryService modelFactoryService;
+  private final TimestampService timestampService;
 
-  public UserModel(User user, ModelFactoryService modelFactoryService) {
+  public UserModel(
+      User user, ModelFactoryService modelFactoryService, TimestampService timestampService) {
     this.entity = user;
     this.modelFactoryService = modelFactoryService;
+    this.timestampService = timestampService;
   }
 
   private Authorization getAuthorization() {
@@ -57,7 +61,7 @@ public class UserModel implements ReviewScope {
 
   public Stream<MemoryTracker> getMemoryTrackerNeedToRepeat(
       Timestamp currentUTCTimestamp, ZoneId timeZone) {
-    final Timestamp timestamp = TimestampOperations.alignByHalfADay(currentUTCTimestamp, timeZone);
+    final Timestamp timestamp = timestampService.alignByHalfADay(currentUTCTimestamp, timeZone);
     return modelFactoryService.memoryTrackerRepository
         .findAllByUserAndNextRecallAtLessThanEqualOrderByNextRecallAt(entity.getId(), timestamp);
   }

--- a/backend/src/main/java/com/odde/doughnut/services/AssimilationService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/AssimilationService.java
@@ -6,7 +6,6 @@ import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.ReviewScope;
 import com.odde.doughnut.models.SubscriptionModel;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -18,16 +17,19 @@ public class AssimilationService {
   private final ModelFactoryService modelFactoryService;
   private final Timestamp currentUTCTimestamp;
   private final ZoneId timeZone;
+  private final TimestampService timestampService;
 
   public AssimilationService(
       UserModel user,
       ModelFactoryService modelFactoryService,
       Timestamp currentUTCTimestamp,
-      ZoneId timeZone) {
+      ZoneId timeZone,
+      TimestampService timestampService) {
     userModel = user;
     this.modelFactoryService = modelFactoryService;
     this.currentUTCTimestamp = currentUTCTimestamp;
     this.timeZone = timeZone;
+    this.timestampService = timestampService;
   }
 
   private Stream<Note> getDueNoteToAssimilate(ReviewScope reviewScope, int count) {
@@ -85,12 +87,12 @@ public class AssimilationService {
   }
 
   private List<MemoryTracker> getNotesAssimilatedToday() {
-    Timestamp oneDayAgo = TimestampOperations.addHoursToTimestamp(currentUTCTimestamp, -24);
+    Timestamp oneDayAgo = timestampService.addHoursToTimestamp(currentUTCTimestamp, -24);
     return userModel.getRecentMemoryTrackers(oneDayAgo).stream()
         .filter(
             p ->
-                TimestampOperations.getDayId(p.getAssimilatedAt(), timeZone)
-                    == TimestampOperations.getDayId(currentUTCTimestamp, timeZone))
+                timestampService.getDayId(p.getAssimilatedAt(), timeZone)
+                    == timestampService.getDayId(currentUTCTimestamp, timeZone))
         .filter(p -> !p.getRemovedFromTracking())
         .toList();
   }

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -15,9 +15,12 @@ import java.util.List;
 
 public class MemoryTrackerService {
   private final ModelFactoryService modelFactoryService;
+  private final TimestampService timestampService;
 
-  public MemoryTrackerService(ModelFactoryService modelFactoryService) {
+  public MemoryTrackerService(
+      ModelFactoryService modelFactoryService, TimestampService timestampService) {
     this.modelFactoryService = modelFactoryService;
+    this.timestampService = timestampService;
   }
 
   public List<MemoryTracker> assimilate(
@@ -66,7 +69,7 @@ public class MemoryTrackerService {
 
   public void updateForgettingCurve(MemoryTracker memoryTracker, int adjustment) {
     memoryTracker.setForgettingCurveIndex(memoryTracker.getForgettingCurveIndex() + adjustment);
-    memoryTracker.setNextRecallAt(memoryTracker.calculateNextRecallAt());
+    memoryTracker.setNextRecallAt(memoryTracker.calculateNextRecallAt(timestampService));
     modelFactoryService.save(memoryTracker);
   }
 
@@ -87,7 +90,7 @@ public class MemoryTrackerService {
 
   public void markAsRepeated(
       Timestamp currentUTCTimestamp, Boolean correct, MemoryTracker memoryTracker) {
-    memoryTracker.markAsRepeated(currentUTCTimestamp, correct);
+    memoryTracker.markAsRepeated(currentUTCTimestamp, correct, timestampService);
     modelFactoryService.save(memoryTracker);
   }
 

--- a/backend/src/main/java/com/odde/doughnut/services/RecallService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/RecallService.java
@@ -5,7 +5,6 @@ import com.odde.doughnut.controllers.dto.MemoryTrackerLite;
 import com.odde.doughnut.controllers.dto.RecallStatus;
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -18,16 +17,19 @@ public class RecallService {
   private final Timestamp currentUTCTimestamp;
   private final ZoneId timeZone;
   private final ModelFactoryService modelFactoryService;
+  private final TimestampService timestampService;
 
   public RecallService(
       UserModel userModel,
       Timestamp currentUTCTimestamp,
       ZoneId timeZone,
-      ModelFactoryService modelFactoryService) {
+      ModelFactoryService modelFactoryService,
+      TimestampService timestampService) {
     this.userModel = userModel;
     this.currentUTCTimestamp = currentUTCTimestamp;
     this.timeZone = timeZone;
     this.modelFactoryService = modelFactoryService;
+    this.timestampService = timestampService;
   }
 
   private int totalAssimilatedCount() {
@@ -37,7 +39,7 @@ public class RecallService {
 
   private Stream<MemoryTracker> getMemoryTrackersNeedToRepeat(int dueInDays) {
     return userModel.getMemoryTrackerNeedToRepeat(
-        TimestampOperations.addHoursToTimestamp(currentUTCTimestamp, dueInDays * 24), timeZone);
+        timestampService.addHoursToTimestamp(currentUTCTimestamp, dueInDays * 24), timeZone);
   }
 
   public RecallStatus getRecallStatus() {
@@ -45,7 +47,7 @@ public class RecallService {
     recallStatus.toRepeatCount = getToRecallCount();
     recallStatus.totalAssimilatedCount = totalAssimilatedCount();
     recallStatus.setRecallWindowEndAt(
-        TimestampOperations.addHoursToTimestamp(currentUTCTimestamp, 24));
+        timestampService.addHoursToTimestamp(currentUTCTimestamp, 24));
     return recallStatus;
   }
 

--- a/backend/src/main/java/com/odde/doughnut/services/TimestampService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/TimestampService.java
@@ -1,4 +1,4 @@
-package com.odde.doughnut.models;
+package com.odde.doughnut.services;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -9,39 +9,39 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Service;
 
-public abstract class TimestampOperations {
-  public static Timestamp addHoursToTimestamp(Timestamp timestamp, int hoursToAdd) {
+@Service
+public class TimestampService {
+  public Timestamp addHoursToTimestamp(Timestamp timestamp, int hoursToAdd) {
     ZonedDateTime zonedDateTime = timestamp.toInstant().atZone(ZoneId.of("UTC"));
     return Timestamp.from(zonedDateTime.plusHours(hoursToAdd).toInstant());
   }
 
-  public static int getDayId(Timestamp timestamp, ZoneId timeZone) {
-    ZonedDateTime userLocalDateTime = TimestampOperations.getZonedDateTime(timestamp, timeZone);
+  public int getDayId(Timestamp timestamp, ZoneId timeZone) {
+    ZonedDateTime userLocalDateTime = getZonedDateTime(timestamp, timeZone);
     return userLocalDateTime.getYear() * 366 + userLocalDateTime.getDayOfYear();
   }
 
-  public static Timestamp alignByHalfADay(Timestamp currentUTCTimestamp, ZoneId timeZone) {
+  public Timestamp alignByHalfADay(Timestamp currentUTCTimestamp, ZoneId timeZone) {
     final ZonedDateTime alignedZonedDt = alignDayAndHourByHalfADay(currentUTCTimestamp, timeZone);
     return Timestamp.from(alignedZonedDt.withMinute(0).withSecond(0).toInstant());
   }
 
-  private static ZonedDateTime alignDayAndHourByHalfADay(
-      Timestamp currentUTCTimestamp, ZoneId timeZone) {
-    final ZonedDateTime zonedDateTime =
-        TimestampOperations.getZonedDateTime(currentUTCTimestamp, timeZone);
+  private ZonedDateTime alignDayAndHourByHalfADay(Timestamp currentUTCTimestamp, ZoneId timeZone) {
+    final ZonedDateTime zonedDateTime = getZonedDateTime(currentUTCTimestamp, timeZone);
     if (zonedDateTime.getHour() < 12) {
       return zonedDateTime.withHour(12);
     }
     return zonedDateTime.plusDays(1).withHour(0);
   }
 
-  public static ZonedDateTime getZonedDateTime(Timestamp timestamp, ZoneId timeZone) {
+  public ZonedDateTime getZonedDateTime(Timestamp timestamp, ZoneId timeZone) {
     ZonedDateTime systemLocalDateTime = timestamp.toLocalDateTime().atZone(ZoneId.systemDefault());
     return systemLocalDateTime.withZoneSameInstant(timeZone);
   }
 
-  public static long getDiffInHours(Timestamp currentUTCTimestamp, Timestamp nextRecallAt) {
+  public long getDiffInHours(Timestamp currentUTCTimestamp, Timestamp nextRecallAt) {
     long diff = currentUTCTimestamp.getTime() - nextRecallAt.getTime();
     return TimeUnit.HOURS.convert(diff, TimeUnit.MILLISECONDS);
   }
@@ -53,7 +53,7 @@ public abstract class TimestampOperations {
    * @param inputTime ISO time string (e.g., "2020-01-01T00:00:00Z", "-0044-03-15T00:00:00Z")
    * @return Formatted date string (e.g., "01 January 2020", "January 1170", "1170", "1171 B.C.")
    */
-  public static String formatISOTimeToYearSupportingBC(String inputTime) {
+  public String formatISOTimeToYearSupportingBC(String inputTime) {
     DateTimeFormatter formatter =
         DateTimeFormatter.ofPattern("dd MMMM yyyy")
             .withZone(ZoneId.systemDefault())
@@ -124,7 +124,7 @@ public abstract class TimestampOperations {
     }
   }
 
-  public static Timestamp getStartOfDay(Timestamp timestamp, ZoneId zoneId) {
+  public Timestamp getStartOfDay(Timestamp timestamp, ZoneId zoneId) {
     LocalDateTime localDateTime =
         timestamp
             .toInstant()

--- a/backend/src/main/java/com/odde/doughnut/services/WikidataService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/WikidataService.java
@@ -8,11 +8,13 @@ import java.io.IOException;
 import java.util.List;
 import org.springframework.web.util.UriComponentsBuilder;
 
-public record WikidataService(WikidataApi wikidataApi) {
-  public WikidataService(HttpClientAdapter httpClientAdapter, String wikidataUrl) {
+public record WikidataService(WikidataApi wikidataApi, TimestampService timestampService) {
+  public WikidataService(
+      HttpClientAdapter httpClientAdapter, String wikidataUrl, TimestampService timestampService) {
     this(
         new WikidataApi(
-            new QueryBuilder(httpClientAdapter, UriComponentsBuilder.fromHttpUrl(wikidataUrl))));
+            new QueryBuilder(httpClientAdapter, UriComponentsBuilder.fromHttpUrl(wikidataUrl))),
+        timestampService);
   }
 
   public List<WikidataSearchEntity> searchWikidata(String search)
@@ -21,6 +23,6 @@ public record WikidataService(WikidataApi wikidataApi) {
   }
 
   public WikidataIdWithApi wrapWikidataIdWithApi(String wikidataId) {
-    return new WikidataId(wikidataId).withApi(wikidataApi);
+    return new WikidataId(wikidataId).withApi(wikidataApi, timestampService);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataEntityModel.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataEntityModel.java
@@ -1,14 +1,18 @@
 package com.odde.doughnut.services.wikidataApis;
 
 import com.odde.doughnut.entities.Coordinate;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.wikidataApis.thirdPartyEntities.WikidataEntity;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class WikidataEntityModel extends WikidataEntityModelOfProperties {
-  public WikidataEntityModel(WikidataEntity entity) {
+  private final TimestampService timestampService;
+
+  public WikidataEntityModel(WikidataEntity entity, TimestampService timestampService) {
     super(entity);
+    this.timestampService = timestampService;
   }
 
   private Boolean isHuman() {
@@ -24,7 +28,7 @@ public class WikidataEntityModel extends WikidataEntityModelOfProperties {
             getCountryOfOriginValue()
                 .flatMap(
                     wikidataId1 -> wikidataId1.withApi(wikidataApi).fetchEnglishTitleFromApi()),
-            getBirthdayValue().map(WikidataValue::formattedTime))
+            getBirthdayValue().map(value -> value.formattedTime(timestampService)))
         .filter(Optional::isPresent)
         .map(Optional::get)
         .filter(value -> !value.isBlank())

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataId.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataId.java
@@ -1,11 +1,13 @@
 package com.odde.doughnut.services.wikidataApis;
 
+import com.odde.doughnut.services.TimestampService;
+
 public record WikidataId(String wikidataId) {
   public boolean isHuman() {
     return "Q5".equals(wikidataId);
   }
 
-  public WikidataIdWithApi withApi(WikidataApi wikidataApi) {
-    return WikidataIdWithApi.create(wikidataId, wikidataApi);
+  public WikidataIdWithApi withApi(WikidataApi wikidataApi, TimestampService timestampService) {
+    return WikidataIdWithApi.create(wikidataId, wikidataApi, timestampService);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataIdWithApi.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataIdWithApi.java
@@ -4,6 +4,7 @@ import com.odde.doughnut.controllers.dto.WikidataEntityData;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.exceptions.DuplicateWikidataIdException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.wikidataApis.thirdPartyEntities.WikidataEntityHash;
 import java.io.IOException;
 import java.util.Objects;
@@ -14,15 +15,19 @@ import org.apache.logging.log4j.util.Strings;
 public final class WikidataIdWithApi {
   private final String wikidataId;
   private final WikidataApi wikidataApi;
+  private final TimestampService timestampService;
 
-  public static WikidataIdWithApi create(String wikidataId, WikidataApi wikidataApi) {
+  public static WikidataIdWithApi create(
+      String wikidataId, WikidataApi wikidataApi, TimestampService timestampService) {
     if (Strings.isBlank(wikidataId)) return null;
-    return new WikidataIdWithApi(wikidataId, wikidataApi);
+    return new WikidataIdWithApi(wikidataId, wikidataApi, timestampService);
   }
 
-  private WikidataIdWithApi(String wikidataId, WikidataApi wikidataApi) {
+  private WikidataIdWithApi(
+      String wikidataId, WikidataApi wikidataApi, TimestampService timestampService) {
     this.wikidataId = wikidataId;
     this.wikidataApi = wikidataApi;
+    this.timestampService = timestampService;
   }
 
   public Optional<String> fetchEnglishTitleFromApi() {
@@ -37,7 +42,7 @@ public final class WikidataIdWithApi {
       throws IOException, InterruptedException {
     WikidataEntityHash entityHash = wikidataApi.getEntityHashById(wikidataId);
     if (entityHash == null) return Optional.empty();
-    return entityHash.getEntityModel(wikidataId);
+    return entityHash.getEntityModel(wikidataId, timestampService);
   }
 
   public void extractWikidataInfoToNote(Note note) throws IOException, InterruptedException {

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataValue.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataValue.java
@@ -2,7 +2,7 @@ package com.odde.doughnut.services.wikidataApis;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.odde.doughnut.entities.Coordinate;
-import com.odde.doughnut.models.TimestampOperations;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.wikidataApis.thirdPartyEntities.WikidataDatavalue;
 
 public record WikidataValue(WikidataDatavalue datavalue) {
@@ -21,7 +21,7 @@ public record WikidataValue(WikidataDatavalue datavalue) {
     return new Coordinate(datavalue.mustGetStringValue());
   }
 
-  public String formattedTime() {
-    return TimestampOperations.formatISOTimeToYearSupportingBC(datavalue.mustGetISOTime());
+  public String formattedTime(TimestampService timestampService) {
+    return timestampService.formatISOTimeToYearSupportingBC(datavalue.mustGetISOTime());
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/thirdPartyEntities/WikidataEntityHash.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/thirdPartyEntities/WikidataEntityHash.java
@@ -1,5 +1,6 @@
 package com.odde.doughnut.services.wikidataApis.thirdPartyEntities;
 
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.wikidataApis.WikidataEntityModel;
 import java.util.Map;
 import java.util.Optional;
@@ -8,10 +9,11 @@ import lombok.Setter;
 public class WikidataEntityHash {
   @Setter private Map<String, WikidataEntity> entities;
 
-  public Optional<WikidataEntityModel> getEntityModel(String wikidataId) {
+  public Optional<WikidataEntityModel> getEntityModel(
+      String wikidataId, TimestampService timestampService) {
     if (entities == null || !entities.containsKey(wikidataId)) {
       return Optional.empty();
     }
-    return Optional.of(new WikidataEntityModel(entities.get(wikidataId)));
+    return Optional.of(new WikidataEntityModel(entities.get(wikidataId), timestampService));
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/testability/TestabilityRestController.java
+++ b/backend/src/main/java/com/odde/doughnut/testability/TestabilityRestController.java
@@ -7,11 +7,11 @@ import com.odde.doughnut.entities.*;
 import com.odde.doughnut.entities.repositories.NoteRepository;
 import com.odde.doughnut.entities.repositories.UserRepository;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.CircleService;
 import com.odde.doughnut.services.GithubService;
 import com.odde.doughnut.services.NoteConstructionService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.model.PredefinedQuestionsTestData;
 import jakarta.persistence.EntityManagerFactory;
 import java.io.IOException;
@@ -40,6 +40,7 @@ class TestabilityRestController {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired CircleService circleService;
   @Autowired TestabilitySettings testabilitySettings;
+  @Autowired TimestampService timestampService;
 
   @PostMapping("/clean_db_and_reset_testability_settings")
   @Transactional
@@ -350,7 +351,7 @@ class TestabilityRestController {
   public List<Object> timeTravelRelativeToNow(
       @RequestBody TimeTravelRelativeToNow timeTravelRelativeToNow) {
     Timestamp timestamp =
-        TimestampOperations.addHoursToTimestamp(
+        timestampService.addHoursToTimestamp(
             new Timestamp(System.currentTimeMillis()), timeTravelRelativeToNow.hours);
     testabilitySettings.timeTravelTo(timestamp);
     return Collections.emptyList();

--- a/backend/src/test/java/com/odde/doughnut/algorithms/SpacedRepetitionEarlyRewardsAndLatePenaltyTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/SpacedRepetitionEarlyRewardsAndLatePenaltyTest.java
@@ -12,11 +12,18 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.User;
-import com.odde.doughnut.models.TimestampOperations;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.MakeMe;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@SpringBootTest
+@ActiveProfiles("test")
 public class SpacedRepetitionEarlyRewardsAndLatePenaltyTest {
+  @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
   final int currentForgettingCurveIndex =
       DEFAULT_FORGETTING_CURVE_INDEX + DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT * 2;
   final int baselineForgettingCurveIndex =
@@ -76,13 +83,13 @@ public class SpacedRepetitionEarlyRewardsAndLatePenaltyTest {
   }
 
   private int getNextForgettingCurveIndexWithDelay(int delayInHours) {
-    MakeMe makeMe = MakeMe.makeMeWithoutFactoryService();
     User user = makeMe.aUser().withSpaceIntervals("3, 6, 9, 12, 15").inMemoryPlease();
     Note note = makeMe.aNote().inMemoryPlease();
     MemoryTracker memoryTracker =
         makeMe.aMemoryTrackerFor(note).by(user).afterNthStrictRepetition(3).inMemoryPlease();
     memoryTracker.reviewedSuccessfully(
-        TimestampOperations.addHoursToTimestamp(memoryTracker.getNextRecallAt(), delayInHours));
+        timestampService.addHoursToTimestamp(memoryTracker.getNextRecallAt(), delayInHours),
+        timestampService);
     return memoryTracker.getForgettingCurveIndex();
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/controllers/CertificateControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/CertificateControllerTests.java
@@ -4,8 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.odde.doughnut.entities.Certificate;
 import com.odde.doughnut.entities.Notebook;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.MakeMe;
 import com.odde.doughnut.testability.TestabilitySettings;
 import java.sql.Timestamp;
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CertificateControllerTests {
   public static final int oneYearInHours = 8760;
   @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
   private UserModel currentUser;
   private CertificateController controller;
   Timestamp currentTime;
@@ -60,7 +61,7 @@ public class CertificateControllerTests {
       assertEquals(notebook, cert.getNotebook());
       assertEquals(currentTime, cert.getStartDate());
       Timestamp expiryDate =
-          TimestampOperations.addHoursToTimestamp(
+          timestampService.addHoursToTimestamp(
               new Timestamp(currentTime.getTime()), oneYearInHours);
       assertEquals(expiryDate, cert.getExpiryDate());
     }
@@ -70,7 +71,7 @@ public class CertificateControllerTests {
       makeMe.anAssessmentAttempt(currentUser.getEntity()).notebook(notebook).score(20, 20).please();
       Timestamp currentTimeAtStart = currentTime;
       Timestamp newStartDate =
-          TimestampOperations.addHoursToTimestamp(
+          timestampService.addHoursToTimestamp(
               new Timestamp(currentTime.getTime()), oneYearInHours);
       testabilitySettings.timeTravelTo(newStartDate);
       Certificate certLater = controller.claimCertificate(notebook);

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestMemoryTrackerControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestMemoryTrackerControllerTest.java
@@ -15,8 +15,8 @@ import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.MakeMe;
 import com.odde.doughnut.testability.TestabilitySettings;
 import java.sql.Timestamp;
@@ -36,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
 class MemoryTrackerControllerTest {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
 
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   private UserModel userModel;
@@ -348,7 +349,7 @@ class MemoryTrackerControllerTest {
         assertThat(
             memoryTracker.getNextRecallAt(),
             lessThan(
-                TimestampOperations.addHoursToTimestamp(
+                timestampService.addHoursToTimestamp(
                     testabilitySettings.getCurrentUTCTimestamp(), 25)));
       }
     }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
@@ -9,8 +9,8 @@ import com.odde.doughnut.controllers.dto.*;
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.graphRAG.GraphRAGResult;
 import com.odde.doughnut.services.httpQuery.HttpClientAdapter;
 import com.odde.doughnut.services.search.NoteSearchService;
@@ -37,6 +37,7 @@ class NoteControllerTests {
   @Autowired ModelFactoryService modelFactoryService;
 
   @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   private UserModel userModel;
@@ -194,7 +195,7 @@ class NoteControllerTests {
         testabilitySettings.timeTravelTo(timestamp);
         controller.deleteNote(child);
 
-        timestamp = TimestampOperations.addHoursToTimestamp(timestamp, 1);
+        timestamp = timestampService.addHoursToTimestamp(timestamp, 1);
         testabilitySettings.timeTravelTo(timestamp);
         controller.deleteNote(subject);
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestRecallPromptControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestRecallPromptControllerTests.java
@@ -12,9 +12,9 @@ import com.odde.doughnut.controllers.dto.*;
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.TimestampOperations;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.GlobalSettingsService;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.services.ai.MCQWithAnswer;
 import com.odde.doughnut.services.ai.QuestionEvaluation;
 import com.odde.doughnut.testability.MakeMe;
@@ -43,6 +43,7 @@ class RecallPromptControllerTests {
   @Mock OpenAiApi openAiApi;
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
   private UserModel currentUser;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
   OpenAIChatCompletionMock openAIChatCompletionMock;
@@ -168,7 +169,7 @@ class RecallPromptControllerTests {
         assertThat(
             memoryTracker.getNextRecallAt(),
             lessThan(
-                TimestampOperations.addHoursToTimestamp(
+                timestampService.addHoursToTimestamp(
                     testabilitySettings.getCurrentUTCTimestamp(), 25)));
       }
     }

--- a/backend/src/test/java/com/odde/doughnut/models/AssimilationServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/models/AssimilationServiceTest.java
@@ -36,7 +36,11 @@ public class AssimilationServiceTest {
     day1 = makeMe.aTimestamp().of(1, 8).fromShanghai().please();
     assimilationService =
         new AssimilationService(
-            userModel, makeMe.modelFactoryService, day1, ZoneId.of("Asia/Shanghai"));
+            userModel,
+            makeMe.modelFactoryService,
+            day1,
+            ZoneId.of("Asia/Shanghai"),
+            makeMe.getTimestampService());
   }
 
   @Test
@@ -187,7 +191,11 @@ public class AssimilationServiceTest {
         Timestamp day1_23 = makeMe.aTimestamp().of(1, 23).fromShanghai().please();
         AssimilationService recallService =
             new AssimilationService(
-                userModel, makeMe.modelFactoryService, day1_23, ZoneId.of("Asia/Shanghai"));
+                userModel,
+                makeMe.modelFactoryService,
+                day1_23,
+                ZoneId.of("Asia/Shanghai"),
+                makeMe.getTimestampService());
         assertThat(getFirstInitialMemoryTracker(recallService), is(nullValue()));
       }
 
@@ -197,7 +205,11 @@ public class AssimilationServiceTest {
         Timestamp day2 = makeMe.aTimestamp().of(2, 1).fromShanghai().please();
         AssimilationService recallService =
             new AssimilationService(
-                userModel, makeMe.modelFactoryService, day2, ZoneId.of("Asia/Shanghai"));
+                userModel,
+                makeMe.modelFactoryService,
+                day2,
+                ZoneId.of("Asia/Shanghai"),
+                makeMe.getTimestampService());
         assertThat(getFirstInitialMemoryTracker(recallService), equalTo(note2));
       }
     }
@@ -306,7 +318,11 @@ public class AssimilationServiceTest {
       // Create service for early morning check
       earlyMorningService =
           new AssimilationService(
-              userModel, makeMe.modelFactoryService, lateMorning, ZoneId.of("Asia/Shanghai"));
+              userModel,
+              makeMe.modelFactoryService,
+              lateMorning,
+              ZoneId.of("Asia/Shanghai"),
+              makeMe.getTimestampService());
     }
 
     @Test

--- a/backend/src/test/java/com/odde/doughnut/models/RecallServiceWithSpacedRepetitionAlgorithmTest.java
+++ b/backend/src/test/java/com/odde/doughnut/models/RecallServiceWithSpacedRepetitionAlgorithmTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Note;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.MakeMe;
 import java.sql.Timestamp;
 import java.time.ZoneId;
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class RecallServiceWithSpacedRepetitionAlgorithmTest {
   @Autowired MakeMe makeMe;
+  @Autowired TimestampService timestampService;
   UserModel userModel;
   UserModel anotherUser;
 
@@ -113,9 +115,8 @@ public class RecallServiceWithSpacedRepetitionAlgorithmTest {
         MemoryTracker memoryTracker =
             makeMe.aMemoryTrackerFor(note).by(userModel).afterNthStrictRepetition(ntimes).please();
         Timestamp currentUTCTimestamp =
-            TimestampOperations.addHoursToTimestamp(
-                memoryTracker.getNextRecallAt(), daysDelay * 24);
-        memoryTracker.markAsRepeated(currentUTCTimestamp, true);
+            timestampService.addHoursToTimestamp(memoryTracker.getNextRecallAt(), daysDelay * 24);
+        memoryTracker.markAsRepeated(currentUTCTimestamp, true, timestampService);
         assertThat(memoryTracker.getForgettingCurveIndex(), equalTo(expectedForgettingCurveIndex));
       }
     }
@@ -129,7 +130,6 @@ public class RecallServiceWithSpacedRepetitionAlgorithmTest {
   }
 
   private Timestamp daysAfterBase(MemoryTracker memoryTracker, Integer reviewDay) {
-    return TimestampOperations.addHoursToTimestamp(
-        memoryTracker.getLastRecalledAt(), reviewDay * 24);
+    return timestampService.addHoursToTimestamp(memoryTracker.getLastRecalledAt(), reviewDay * 24);
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/models/TimestampOperationsTest.java
+++ b/backend/src/test/java/com/odde/doughnut/models/TimestampOperationsTest.java
@@ -3,11 +3,19 @@ package com.odde.doughnut.models;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.odde.doughnut.services.TimestampService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class TimestampOperationsTest {
+  private TimestampService timestampService;
+
+  @BeforeEach
+  void setUp() {
+    timestampService = new TimestampService();
+  }
 
   @ParameterizedTest
   @CsvSource({
@@ -17,55 +25,55 @@ class TimestampOperationsTest {
     "1170-01-01T00:00:00Z, 01 January 1170"
   })
   void formatISOTimeToYearSupportingBC_validDates(String input, String expected) {
-    assertThat(TimestampOperations.formatISOTimeToYearSupportingBC(input), equalTo(expected));
+    assertThat(timestampService.formatISOTimeToYearSupportingBC(input), equalTo(expected));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesInvalidMonth() {
     // Invalid month "00" should be replaced with "01"
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("1170-00-01T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("1170-00-01T00:00:00Z");
     assertThat(result, equalTo("01 January 1170"));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesInvalidDay() {
     // Invalid day "00" should return just the month and year
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("1170-01-00T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("1170-01-00T00:00:00Z");
     assertThat(result, equalTo("January 1170"));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesBothInvalidMonthAndDay() {
     // Both invalid month and day "00-00" should return just the year
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("1170-00-00T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("1170-00-00T00:00:00Z");
     assertThat(result, equalTo("1170"));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesInvalidBCDates() {
     // Both invalid month and day in BC dates should return just the year + B.C.
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("-1170-00-00T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("-1170-00-00T00:00:00Z");
     assertThat(result, equalTo("1171 B.C."));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesInvalidBCDayOnly() {
     // Invalid day in BC dates should return just the month and year + B.C.
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("-1170-10-00T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("-1170-10-00T00:00:00Z");
     assertThat(result, equalTo("October 1171 B.C."));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesPlussignPrefix() {
     // Handles dates with '+' prefix
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("+1980-03-31T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("+1980-03-31T00:00:00Z");
     assertThat(result, equalTo("31 March 1980"));
   }
 
   @Test
   void formatISOTimeToYearSupportingBC_handlesSpecificHistoricalCase() {
     // Test for Confucius birth date
-    String result = TimestampOperations.formatISOTimeToYearSupportingBC("-0552-10-09T00:00:00Z");
+    String result = timestampService.formatISOTimeToYearSupportingBC("-0552-10-09T00:00:00Z");
     assertThat(result, equalTo("09 October 0553 B.C."));
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/services/MemoryTrackerServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/MemoryTrackerServiceTest.java
@@ -31,7 +31,8 @@ public class MemoryTrackerServiceTest {
   void setup() {
     userModel = makeMe.aUser().toModelPlease();
     day1 = makeMe.aTimestamp().of(1, 8).fromShanghai().please();
-    memoryTrackerService = new MemoryTrackerService(modelFactoryService);
+    memoryTrackerService =
+        new MemoryTrackerService(modelFactoryService, makeMe.getTimestampService());
   }
 
   @Nested

--- a/backend/src/test/java/com/odde/doughnut/testability/MakeMe.java
+++ b/backend/src/test/java/com/odde/doughnut/testability/MakeMe.java
@@ -3,6 +3,7 @@ package com.odde.doughnut.testability;
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.builders.*;
 import java.sql.Timestamp;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MakeMe extends MakeMeWithoutDB {
   @Autowired public ModelFactoryService modelFactoryService;
+  @Autowired public TimestampService timestampService;
 
   private MakeMe() {}
 
@@ -150,5 +152,9 @@ public class MakeMe extends MakeMeWithoutDB {
 
   public NoteEmbeddingBuilder aNoteEmbedding(Note note) {
     return new NoteEmbeddingBuilder(note, this);
+  }
+
+  public TimestampService getTimestampService() {
+    return timestampService;
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/testability/builders/MemoryTrackerBuilder.java
+++ b/backend/src/test/java/com/odde/doughnut/testability/builders/MemoryTrackerBuilder.java
@@ -2,14 +2,17 @@ package com.odde.doughnut.testability.builders;
 
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.TimestampService;
 import com.odde.doughnut.testability.EntityBuilder;
 import com.odde.doughnut.testability.MakeMe;
 import java.sql.Timestamp;
 
 public class MemoryTrackerBuilder extends EntityBuilder<MemoryTracker> {
+  private final TimestampService timestampService;
 
   public MemoryTrackerBuilder(MemoryTracker memoryTracker, MakeMe makeMe) {
     super(makeMe, memoryTracker);
+    this.timestampService = makeMe.getTimestampService();
     assimilatedAt(makeMe.aTimestamp().of(0, 0).please());
   }
 
@@ -31,7 +34,7 @@ public class MemoryTrackerBuilder extends EntityBuilder<MemoryTracker> {
 
   public MemoryTrackerBuilder afterNthStrictRepetition(Integer repetitionDone) {
     for (int i = 0; i < repetitionDone; i++) {
-      entity.reviewedSuccessfully(entity.getNextRecallAt());
+      entity.reviewedSuccessfully(entity.getNextRecallAt(), timestampService);
     }
     return this;
   }
@@ -41,7 +44,7 @@ public class MemoryTrackerBuilder extends EntityBuilder<MemoryTracker> {
 
   public MemoryTrackerBuilder forgettingCurveAndNextRecallAt(int value) {
     entity.setForgettingCurveIndex(value);
-    entity.setNextRecallAt(entity.calculateNextRecallAt());
+    entity.setNextRecallAt(entity.calculateNextRecallAt(timestampService));
     return this;
   }
 

--- a/ongoing/model_refactoring_to_stateless_services.md
+++ b/ongoing/model_refactoring_to_stateless_services.md
@@ -411,7 +411,6 @@ This aligns tests with the stateless services architecture and makes them simple
 
 - `UserModel` → `UserService`
 - `NoteModel` → `NoteService`
-- `CircleModel` → `CircleService`
 - `SubscriptionModel` → `SubscriptionService`
 - `NoteMotionModel` → `NoteMotionService` or integrate into `NoteService`
 - `BazaarModel` → `BazaarService`


### PR DESCRIPTION
Convert `TimestampOperations` static utility to `TimestampService` bean to align with the stateless services refactoring goal.

The original `TimestampOperations` was a static utility class in the `models` package. This PR refactors it into a `@Service` bean in the `services` package, allowing for dependency injection and better adherence to Spring Boot's architectural patterns for stateless operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6a37c69-8094-41b5-a0fa-7ae75ba1194d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6a37c69-8094-41b5-a0fa-7ae75ba1194d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

