### PR TITLE
Refactor suggested question for fine tuning model

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/FineTuningDataController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/FineTuningDataController.java
@@ -6,6 +6,7 @@ import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.FineTuningService;
+import com.odde.doughnut.services.SuggestedQuestionForFineTuningService;
 import com.odde.doughnut.services.ai.OpenAIChatGPTFineTuningExample;
 import com.odde.doughnut.services.ai.OtherAiServices;
 import com.theokanning.openai.client.OpenAiApi;
@@ -24,13 +25,16 @@ class FineTuningDataController {
   private final UserModel currentUser;
   private final FineTuningService fineTuningService;
   private final OtherAiServices otherAiServices;
+  private final SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService;
 
   public FineTuningDataController(
       ModelFactoryService modelFactoryService,
+      SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService,
       UserModel currentUser,
       OpenAiApi openAiApi,
       OtherAiServices otherAiServices) {
     this.modelFactoryService = modelFactoryService;
+    this.suggestedQuestionForFineTuningService = suggestedQuestionForFineTuningService;
     this.currentUser = currentUser;
     this.fineTuningService = new FineTuningService(this.modelFactoryService, openAiApi);
     this.otherAiServices = otherAiServices;
@@ -44,9 +48,7 @@ class FineTuningDataController {
       @RequestBody QuestionSuggestionParams suggestion)
       throws UnexpectedNoAccessRightException {
     currentUser.assertAdminAuthorization();
-    return modelFactoryService
-        .toSuggestedQuestionForFineTuningService(suggestedQuestion)
-        .update(suggestion);
+    return suggestedQuestionForFineTuningService.update(suggestedQuestion, suggestion);
   }
 
   @PostMapping("/{suggestedQuestion}/duplicate")
@@ -56,9 +58,7 @@ class FineTuningDataController {
           SuggestedQuestionForFineTuning suggestedQuestion)
       throws UnexpectedNoAccessRightException {
     currentUser.assertAdminAuthorization();
-    return modelFactoryService
-        .toSuggestedQuestionForFineTuningService(suggestedQuestion)
-        .duplicate();
+    return suggestedQuestionForFineTuningService.duplicate(suggestedQuestion);
   }
 
   @PostMapping("/{suggestedQuestion}/delete")
@@ -68,7 +68,7 @@ class FineTuningDataController {
           SuggestedQuestionForFineTuning suggestedQuestion)
       throws UnexpectedNoAccessRightException {
     currentUser.assertAdminAuthorization();
-    return modelFactoryService.toSuggestedQuestionForFineTuningService(suggestedQuestion).delete();
+    return suggestedQuestionForFineTuningService.delete(suggestedQuestion);
   }
 
   @PostMapping("/upload-and-trigger-fine-tuning")

--- a/backend/src/main/java/com/odde/doughnut/controllers/PredefinedQuestionController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/PredefinedQuestionController.java
@@ -8,6 +8,7 @@ import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.GlobalSettingsService;
 import com.odde.doughnut.services.PredefinedQuestionService;
+import com.odde.doughnut.services.SuggestedQuestionForFineTuningService;
 import com.odde.doughnut.services.ai.AiQuestionGenerator;
 import com.odde.doughnut.services.ai.MCQWithAnswer;
 import com.odde.doughnut.testability.TestabilitySettings;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 class PredefinedQuestionController {
   private final ModelFactoryService modelFactoryService;
   private final PredefinedQuestionService predefinedQuestionService;
+  private final SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService;
 
   private final UserModel currentUser;
 
@@ -36,10 +38,12 @@ class PredefinedQuestionController {
   public PredefinedQuestionController(
       @Qualifier("testableOpenAiApi") OpenAiApi openAiApi,
       ModelFactoryService modelFactoryService,
+      SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService,
       UserModel currentUser,
       TestabilitySettings testabilitySettings,
       ObjectMapper objectMapper) {
     this.modelFactoryService = modelFactoryService;
+    this.suggestedQuestionForFineTuningService = suggestedQuestionForFineTuningService;
     this.currentUser = currentUser;
     this.testabilitySettings = testabilitySettings;
     aiQuestionGenerator =
@@ -70,9 +74,8 @@ class PredefinedQuestionController {
           PredefinedQuestion predefinedQuestion,
       @Valid @RequestBody QuestionSuggestionCreationParams suggestion) {
     SuggestedQuestionForFineTuning sqft = new SuggestedQuestionForFineTuning();
-    var suggestedQuestionForFineTuningService =
-        modelFactoryService.toSuggestedQuestionForFineTuningService(sqft);
     return suggestedQuestionForFineTuningService.suggestQuestionForFineTuning(
+        sqft,
         predefinedQuestion,
         suggestion,
         currentUser.getEntity(),

--- a/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
+++ b/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
@@ -124,11 +124,6 @@ public class ModelFactoryService {
     return new Authorization(entity, this);
   }
 
-  public SuggestedQuestionForFineTuningModel toSuggestedQuestionForFineTuningService(
-      SuggestedQuestionForFineTuning suggestion) {
-    return new SuggestedQuestionForFineTuningModel(suggestion, this);
-  }
-
   public <T extends EntityIdentifiedByIdOnly> T save(T entity) {
     if (entity.getId() == null) {
       entityManager.persist(entity);

--- a/backend/src/main/java/com/odde/doughnut/testability/TestabilityRestController.java
+++ b/backend/src/main/java/com/odde/doughnut/testability/TestabilityRestController.java
@@ -11,6 +11,7 @@ import com.odde.doughnut.models.UserModel;
 import com.odde.doughnut.services.CircleService;
 import com.odde.doughnut.services.GithubService;
 import com.odde.doughnut.services.NoteConstructionService;
+import com.odde.doughnut.services.SuggestedQuestionForFineTuningService;
 import com.odde.doughnut.testability.model.PredefinedQuestionsTestData;
 import com.odde.doughnut.utils.TimestampOperations;
 import jakarta.persistence.EntityManagerFactory;
@@ -40,6 +41,7 @@ class TestabilityRestController {
   @Autowired ModelFactoryService modelFactoryService;
   @Autowired CircleService circleService;
   @Autowired TestabilitySettings testabilitySettings;
+  @Autowired SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService;
 
   @PostMapping("/clean_db_and_reset_testability_settings")
   @Transactional
@@ -290,7 +292,7 @@ class TestabilityRestController {
         example -> {
           SuggestedQuestionForFineTuning suggestion = new SuggestedQuestionForFineTuning();
           suggestion.setUser(currentUser.getEntity());
-          modelFactoryService.toSuggestedQuestionForFineTuningService(suggestion).update(example);
+          suggestedQuestionForFineTuningService.update(suggestion, example);
         });
     return "OK";
   }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestPredefinedQuestionControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestPredefinedQuestionControllerTests.java
@@ -14,6 +14,7 @@ import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.factoryServices.quizFacotries.PredefinedQuestionNotPossibleException;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.SuggestedQuestionForFineTuningService;
 import com.odde.doughnut.services.ai.MCQWithAnswer;
 import com.odde.doughnut.testability.MakeMe;
 import com.odde.doughnut.testability.OpenAIChatCompletionMock;
@@ -36,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 class PredefinedQuestionControllerTests {
   @Mock OpenAiApi openAiApi;
   @Autowired ModelFactoryService modelFactoryService;
+  @Autowired SuggestedQuestionForFineTuningService suggestedQuestionForFineTuningService;
   @Autowired MakeMe makeMe;
   private UserModel currentUser;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
@@ -51,6 +53,7 @@ class PredefinedQuestionControllerTests {
         new PredefinedQuestionController(
             openAiApi,
             modelFactoryService,
+            suggestedQuestionForFineTuningService,
             currentUser,
             testabilitySettings,
             getTestObjectMapper());
@@ -60,6 +63,7 @@ class PredefinedQuestionControllerTests {
     return new PredefinedQuestionController(
         openAiApi,
         modelFactoryService,
+        suggestedQuestionForFineTuningService,
         makeMe.aNullUserModelPlease(),
         testabilitySettings,
         getTestObjectMapper());

--- a/ongoing/model_refactoring_to_stateless_services.md
+++ b/ongoing/model_refactoring_to_stateless_services.md
@@ -414,7 +414,6 @@ This aligns tests with the stateless services architecture and makes them simple
 - `SubscriptionModel` → `SubscriptionService`
 - `NoteMotionModel` → `NoteMotionService` or integrate into `NoteService`
 - `BazaarModel` → `BazaarService`
-- `SuggestedQuestionForFineTuningModel` → `SuggestedQuestionForFineTuningService`
 
 ### Supporting Classes
 


### PR DESCRIPTION
Replaced `SuggestedQuestionForFineTuningModel` with `SuggestedQuestionForFineTuningService` to progress towards the stateless services architecture.

This change converts `SuggestedQuestionForFineTuningModel` into a stateless `@Service` bean that directly uses `EntityManager`, aligning with the refactoring goal outlined in `model_refactoring_to_stateless_services.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c9ca23-6bcf-4bc3-97f8-f643b7a20adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45c9ca23-6bcf-4bc3-97f8-f643b7a20adf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

