### PR TITLE
Fix frontend unit test warnings

### DIFF
--- a/frontend/src/components/commons/Modal.vue
+++ b/frontend/src/components/commons/Modal.vue
@@ -45,10 +45,18 @@ const sidebarStyle = computed(() => {
 })
 
 // Route watcher
-const route = useRoute()
-watch(route, () => {
-  emit("close_request")
-})
+let route
+try {
+  route = useRoute()
+  if (route) {
+    watch(route, () => {
+      emit("close_request")
+    })
+  }
+} catch {
+  // Router not available (e.g., in tests without router)
+  // Skip route watching
+}
 
 // ESC key handler - only for non-popup modals
 const handleEscape = (event: KeyboardEvent) => {

--- a/frontend/tests/notes/QuestionExportDialog.spec.ts
+++ b/frontend/tests/notes/QuestionExportDialog.spec.ts
@@ -26,6 +26,7 @@ describe("QuestionExportDialog", () => {
     const { getByTestId } = helper
       .component(QuestionExportDialog)
       .withProps({ noteId: note.id })
+      .withRouter()
       .render()
 
     await waitFor(() => {
@@ -52,6 +53,7 @@ describe("QuestionExportDialog", () => {
     const { getByTestId } = helper
       .component(QuestionExportDialog)
       .withProps({ noteId: note.id })
+      .withRouter()
       .render()
 
     await waitFor(() => {

--- a/frontend/tests/notes/Questions.spec.ts
+++ b/frontend/tests/notes/Questions.spec.ts
@@ -50,6 +50,7 @@ describe("Questions", () => {
     const { getByLabelText, getByTestId } = helper
       .component(Questions)
       .withProps({ note })
+      .withRouter()
       .render()
 
     await flushPromises()


### PR DESCRIPTION
Remove frontend unit test warnings related to missing router injection and invalid watch source.

The `Modal` component was attempting to use `useRoute()` and watch the route even when no router was provided in the test environment, leading to "injection not found" and "invalid watch source" warnings. This PR makes the route watching conditional in `Modal.vue` and adds `.withRouter()` to tests that render the `Modal` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-82cba558-e51c-449f-a6d5-c76894ce98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82cba558-e51c-449f-a6d5-c76894ce98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

