### PR TITLE
Run and fix backend unit tests

### DIFF
--- a/backend/src/test/java/com/odde/doughnut/controllers/AssimilationControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/AssimilationControllerTests.java
@@ -9,6 +9,7 @@ import com.odde.doughnut.controllers.dto.InitialInfo;
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.SubscriptionService;
 import com.odde.doughnut.testability.MakeMe;
 import com.odde.doughnut.testability.TestabilitySettings;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
 class AssimilationControllerTests {
   @Autowired private ModelFactoryService modelFactoryService;
   @Autowired private MakeMe makeMe;
+  @Autowired private SubscriptionService subscriptionService;
   private UserModel currentUser;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
 
@@ -35,12 +37,17 @@ class AssimilationControllerTests {
   @BeforeEach
   void setup() {
     currentUser = makeMe.aUser().toModelPlease();
-    controller = new AssimilationController(modelFactoryService, currentUser, testabilitySettings);
+    controller =
+        new AssimilationController(
+            modelFactoryService, currentUser, subscriptionService, testabilitySettings);
   }
 
   AssimilationController nullUserController() {
     return new AssimilationController(
-        modelFactoryService, makeMe.aNullUserModelPlease(), testabilitySettings);
+        modelFactoryService,
+        makeMe.aNullUserModelPlease(),
+        subscriptionService,
+        testabilitySettings);
   }
 
   @Nested

--- a/scripts/cloud_agent_setup.sh
+++ b/scripts/cloud_agent_setup.sh
@@ -41,7 +41,7 @@ fi
 # Install required MySQL dependencies
 echo "==> Installing MySQL dependencies..."
 sudo apt-get update -qq
-sudo apt-get install -y -qq libaio-dev libaio1t64 2>&1 | grep -v "^Get:" | grep -v "^Reading" | tail -5 || true
+sudo apt-get install -y -qq libaio-dev libaio1t64 libnuma1 2>&1 | grep -v "^Get:" | grep -v "^Reading" | tail -5 || true
 
 # Create libaio symlink if needed (Ubuntu 24.04 compatibility)
 if [ ! -e "/usr/lib/x86_64-linux-gnu/libaio.so.1" ]; then


### PR DESCRIPTION
Fix backend unit tests by adding a missing MySQL dependency to the setup script and updating `AssimilationControllerTests` for a changed controller constructor.

The `cloud_agent_setup.sh` script was failing to install MySQL due to a missing `libnuma1` dependency. Additionally, `AssimilationControllerTests.java` failed to compile because the `AssimilationController` constructor now requires a `SubscriptionService` parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7f8f6eb-bb6d-4b87-a9d3-a286cf693402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7f8f6eb-bb6d-4b87-a9d3-a286cf693402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

