### PR TITLE
Refactor note model and update docs

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/NoteService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/NoteService.java
@@ -1,0 +1,53 @@
+package com.odde.doughnut.services;
+
+import com.odde.doughnut.entities.Note;
+import com.odde.doughnut.entities.repositories.NoteRepository;
+import jakarta.persistence.EntityManager;
+import java.sql.Timestamp;
+import java.util.List;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoteService {
+  private final NoteRepository noteRepository;
+  private final EntityManager entityManager;
+
+  public NoteService(NoteRepository noteRepository, EntityManager entityManager) {
+    this.noteRepository = noteRepository;
+    this.entityManager = entityManager;
+  }
+
+  public void destroy(Note note, Timestamp currentUTCTimestamp) {
+    if (note.getNotebook() != null) {
+      if (note.getNotebook().getHeadNote() == note) {
+        note.getNotebook().setDeletedAt(currentUTCTimestamp);
+        entityManager.merge(note.getNotebook());
+      }
+    }
+
+    note.setDeletedAt(currentUTCTimestamp);
+    entityManager.merge(note);
+  }
+
+  public void restore(Note note) {
+    if (note.getNotebook() != null) {
+      if (note.getNotebook().getHeadNote() == note) {
+        note.getNotebook().setDeletedAt(null);
+        entityManager.merge(note.getNotebook());
+      }
+    }
+    note.setDeletedAt(null);
+    entityManager.merge(note);
+  }
+
+  public boolean hasDuplicateWikidataId(Note note) {
+    if (Strings.isEmpty(note.getWikidataId())) {
+      return false;
+    }
+    List<Note> existingNotes =
+        noteRepository.noteWithWikidataIdWithinNotebook(
+            note.getNotebook().getId(), note.getWikidataId());
+    return (existingNotes.stream().anyMatch(n -> !n.equals(note)));
+  }
+}

--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataIdWithApi.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/WikidataIdWithApi.java
@@ -3,7 +3,7 @@ package com.odde.doughnut.services.wikidataApis;
 import com.odde.doughnut.controllers.dto.WikidataEntityData;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.exceptions.DuplicateWikidataIdException;
-import com.odde.doughnut.factoryServices.ModelFactoryService;
+import com.odde.doughnut.services.NoteService;
 import com.odde.doughnut.services.wikidataApis.thirdPartyEntities.WikidataEntityHash;
 import java.io.IOException;
 import java.util.Objects;
@@ -57,10 +57,10 @@ public final class WikidataIdWithApi {
     return model.map(i -> i.getAuthorList(wikidataApi)).orElse(Stream.empty());
   }
 
-  public void associateNoteToWikidata(Note note, ModelFactoryService modelFactoryService)
+  public void associateNoteToWikidata(Note note, NoteService noteService)
       throws IOException, InterruptedException, DuplicateWikidataIdException {
     note.setWikidataId(this.wikidataId);
-    if (modelFactoryService.toNoteModel(note).hasDuplicateWikidataId()) {
+    if (noteService.hasDuplicateWikidataId(note)) {
       throw new DuplicateWikidataIdException();
     }
     extractWikidataInfoToNote(note);

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerMotionTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerMotionTests.java
@@ -35,6 +35,7 @@ class NoteControllerMotionTests {
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   @Autowired NoteMotionService noteMotionService;
+  @Autowired com.odde.doughnut.services.NoteService noteService;
   private UserModel userModel;
   NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
@@ -49,7 +50,8 @@ class NoteControllerMotionTests {
             userModel,
             httpClientAdapter,
             testabilitySettings,
-            noteMotionService);
+            noteMotionService,
+            noteService);
     subject = makeMe.aNote("subject").creatorAndOwner(userModel).please();
   }
 

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerRecentNotesTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerRecentNotesTests.java
@@ -31,6 +31,7 @@ class NoteControllerRecentNotesTests {
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   @Autowired NoteMotionService noteMotionService;
+  @Autowired com.odde.doughnut.services.NoteService noteService;
   private UserModel userModel;
   NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
@@ -44,7 +45,8 @@ class NoteControllerRecentNotesTests {
             userModel,
             httpClientAdapter,
             testabilitySettings,
-            noteMotionService);
+            noteMotionService,
+            noteService);
   }
 
   @Test
@@ -82,7 +84,8 @@ class NoteControllerRecentNotesTests {
             userModel,
             httpClientAdapter,
             testabilitySettings,
-            noteMotionService);
+            noteMotionService,
+            noteService);
 
     assertThrows(ResponseStatusException.class, () -> controller.getRecentNotes());
   }

--- a/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RestNoteControllerTests.java
@@ -41,6 +41,7 @@ class NoteControllerTests {
   @Mock HttpClientAdapter httpClientAdapter;
   @Autowired NoteSearchService noteSearchService;
   @Autowired NoteMotionService noteMotionService;
+  @Autowired com.odde.doughnut.services.NoteService noteService;
   private UserModel userModel;
   NoteController controller;
   private final TestabilitySettings testabilitySettings = new TestabilitySettings();
@@ -55,7 +56,8 @@ class NoteControllerTests {
             userModel,
             httpClientAdapter,
             testabilitySettings,
-            noteMotionService);
+            noteMotionService,
+            noteService);
   }
 
   @Nested

--- a/ongoing/model_refactoring_to_stateless_services.md
+++ b/ongoing/model_refactoring_to_stateless_services.md
@@ -184,7 +184,7 @@ authorizationService.assertAuthorization(user, note);
 - Repository aggregation via public field injection
 
 **Target**: `ModelFactoryService` should be removed entirely. All operations should move to appropriate domain services:
-- Model factory methods → Remove (use services directly)
+- Model factory methods → Remove (use services directly) - `toNoteModel()` can be removed
 - User token operations → Move to `UserService`
 - Note embedding operations → Move to `NoteEmbeddingService`
 - Link creation operations → Move to `NoteService` or `LinkService`
@@ -410,7 +410,6 @@ This aligns tests with the stateless services architecture and makes them simple
 ### Models to Convert
 
 - `UserModel` → `UserService`
-- `NoteModel` → `NoteService`
 - `BazaarModel` → `BazaarService`
 
 ### Supporting Classes


### PR DESCRIPTION
Introduce `NoteService` and refactor `NoteModel`'s responsibilities into it to advance the stateless service refactoring.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2292d06-8dd6-4c80-a6fb-0e7f079bdbb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2292d06-8dd6-4c80-a6fb-0e7f079bdbb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

