### PR TITLE
Debug CI e2e test failure

### DIFF
--- a/e2e_test/start/mock_services/createOpenAiChatCompletionMock.ts
+++ b/e2e_test/start/mock_services/createOpenAiChatCompletionMock.ts
@@ -67,19 +67,13 @@ const openAiChatCompletionStubber = (
 
   return {
     stubQuestionGeneration(argumentsString: string) {
-      return serviceMocker.stubPoster(`/chat/completions`, {
-        object: 'chat.completion',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: argumentsString,
-            },
-            index: 0,
-            finish_reason: 'stop',
-          },
-        ],
-      })
+      return stubChatCompletion(
+        {
+          role: 'assistant',
+          content: argumentsString,
+        },
+        'stop'
+      )
     },
     requestDoesNotMessageMatch(message: MessageToMatch) {
       return openAiChatCompletionStubber(serviceMocker, bodyToMatch, {
@@ -95,19 +89,13 @@ const openAiChatCompletionStubber = (
       )
     },
     stubQuestionEvaluation(argumentsString: string) {
-      return serviceMocker.stubPoster(`/chat/completions`, {
-        object: 'chat.completion',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: argumentsString,
-            },
-            index: 0,
-            finish_reason: 'stop',
-          },
-        ],
-      })
+      return stubChatCompletion(
+        {
+          role: 'assistant',
+          content: argumentsString,
+        },
+        'stop'
+      )
     },
   }
 }


### PR DESCRIPTION
Update `stubQuestionGeneration` and `stubQuestionEvaluation` to correctly use message predicates, fixing e2e test failures on CI.

The previous implementation of `stubQuestionGeneration` and `stubQuestionEvaluation` used `serviceMocker.stubPoster`, which matched all POST requests to `/chat/completions`, ignoring the specific message content predicate set by `requestMessageMatches`. This caused the mock to respond to incorrect requests, leading to "failed to get the first question" errors in e2e tests on CI due to timing or request order differences. The change ensures the stubs only respond to requests matching the intended "Memory Assistant" content.

---
<a href="https://cursor.com/background-agent?bcId=bc-149b6e99-5ccb-4177-b941-4f81135e5cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-149b6e99-5ccb-4177-b941-4f81135e5cf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

