### PR TITLE
Refactor authorization logic for stateless services

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/UserController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/UserController.java
@@ -6,8 +6,8 @@ import com.odde.doughnut.entities.User;
 import com.odde.doughnut.entities.UserToken;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
-import com.odde.doughnut.models.Authorization;
 import com.odde.doughnut.models.UserModel;
+import com.odde.doughnut.services.AuthorizationService;
 import com.odde.doughnut.testability.TestabilitySettings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -37,7 +37,7 @@ class UserController {
   @PostMapping("")
   @Transactional
   public User createUser(Principal principal, @RequestBody User user) {
-    if (principal == null) Authorization.throwUserNotFound();
+    if (principal == null) AuthorizationService.throwUserNotFound();
     user.setExternalIdentifier(principal.getName());
     modelFactoryService.save(user);
     return user;

--- a/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
+++ b/backend/src/main/java/com/odde/doughnut/factoryServices/ModelFactoryService.java
@@ -4,6 +4,7 @@ import com.odde.doughnut.controllers.dto.AnswerDTO;
 import com.odde.doughnut.entities.*;
 import com.odde.doughnut.entities.repositories.*;
 import com.odde.doughnut.models.*;
+import com.odde.doughnut.services.AuthorizationService;
 import com.odde.doughnut.services.NotebookService;
 import jakarta.persistence.EntityManager;
 import java.sql.Timestamp;
@@ -40,6 +41,8 @@ public class ModelFactoryService {
   @Autowired public NoteEmbeddingRepository noteEmbeddingRepository;
   @Autowired public NoteEmbeddingJdbcRepository noteEmbeddingJdbcRepository;
 
+  @Autowired public AuthorizationService authorizationService;
+
   public void storeNoteEmbedding(Note note, java.util.List<Float> embedding) {
     noteEmbeddingJdbcRepository.insert(note.getId(), embedding);
   }
@@ -75,7 +78,7 @@ public class ModelFactoryService {
     UserToken usertoken = userTokenRepository.findByToken(token);
 
     if (usertoken == null) {
-      Authorization.throwUserNotFound();
+      AuthorizationService.throwUserNotFound();
     }
 
     return this.findUserById(usertoken.getUserId());
@@ -95,7 +98,7 @@ public class ModelFactoryService {
   }
 
   public UserModel toUserModel(User user) {
-    return new UserModel(user, this);
+    return new UserModel(user, this, authorizationService);
   }
 
   public Authorization toAuthorization(User entity) {

--- a/backend/src/main/java/com/odde/doughnut/models/UserModel.java
+++ b/backend/src/main/java/com/odde/doughnut/models/UserModel.java
@@ -5,6 +5,7 @@ import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.User;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.factoryServices.ModelFactoryService;
+import com.odde.doughnut.services.AuthorizationService;
 import com.odde.doughnut.utils.TimestampOperations;
 import java.sql.Timestamp;
 import java.time.*;
@@ -16,14 +17,15 @@ public class UserModel implements ReviewScope {
 
   @Getter protected final User entity;
   protected final ModelFactoryService modelFactoryService;
+  protected final AuthorizationService authorizationService;
 
-  public UserModel(User user, ModelFactoryService modelFactoryService) {
+  public UserModel(
+      User user,
+      ModelFactoryService modelFactoryService,
+      AuthorizationService authorizationService) {
     this.entity = user;
     this.modelFactoryService = modelFactoryService;
-  }
-
-  private Authorization getAuthorization() {
-    return modelFactoryService.toAuthorization(entity);
+    this.authorizationService = authorizationService;
   }
 
   public String getName() {
@@ -71,18 +73,18 @@ public class UserModel implements ReviewScope {
   }
 
   public <T> void assertAuthorization(T object) throws UnexpectedNoAccessRightException {
-    getAuthorization().assertAuthorization(object);
+    authorizationService.assertAuthorization(entity, object);
   }
 
   public <T> void assertReadAuthorization(T object) throws UnexpectedNoAccessRightException {
-    getAuthorization().assertReadAuthorization(object);
+    authorizationService.assertReadAuthorization(entity, object);
   }
 
   public void assertAdminAuthorization() throws UnexpectedNoAccessRightException {
-    getAuthorization().assertAdminAuthorization();
+    authorizationService.assertAdminAuthorization(entity);
   }
 
   public void assertLoggedIn() {
-    getAuthorization().assertLoggedIn();
+    authorizationService.assertLoggedIn(entity);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/AuthorizationService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/AuthorizationService.java
@@ -1,0 +1,162 @@
+package com.odde.doughnut.services;
+
+import com.odde.doughnut.entities.*;
+import com.odde.doughnut.entities.repositories.BazaarNotebookRepository;
+import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AuthorizationService {
+  private final BazaarNotebookRepository bazaarNotebookRepository;
+
+  public AuthorizationService(BazaarNotebookRepository bazaarNotebookRepository) {
+    this.bazaarNotebookRepository = bazaarNotebookRepository;
+  }
+
+  public <T> void assertAuthorization(User user, T object) throws UnexpectedNoAccessRightException {
+    switch (object) {
+      case Note obj -> assertAuthorizationNote(user, obj);
+      case Notebook obj -> assertAuthorizationNotebook(user, obj);
+      case BazaarNotebook obj -> assertAuthorizationBazaarNotebook(user, obj);
+      case Circle obj -> assertAuthorizationCircle(user, obj);
+      case Subscription obj -> assertAuthorizationSubscription(user, obj);
+      case User obj -> assertAuthorizationUser(user, obj);
+      case AssessmentAttempt obj -> assertAuthorizationUser(user, obj.getUser());
+      case AssessmentQuestionInstance obj -> assertAuthorization(user, obj.getAssessmentAttempt());
+      case Conversation obj -> assertAuthorizationConversation(user, obj);
+      default ->
+          throw new ResponseStatusException(
+              HttpStatus.INTERNAL_SERVER_ERROR, "Unknown object type");
+    }
+  }
+
+  private void assertAuthorizationConversation(User user, Conversation obj)
+      throws UnexpectedNoAccessRightException {
+    if (!obj.getSubjectOwnership().ownsBy(user) && !obj.getConversationInitiator().equals(user)) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  private void assertAuthorizationBazaarNotebook(User user, BazaarNotebook object)
+      throws UnexpectedNoAccessRightException {
+    if (!isAdmin(user)) {
+      assertAuthorizationNotebook(user, object.getNotebook());
+    }
+  }
+
+  public <T> void assertReadAuthorization(User user, T object)
+      throws UnexpectedNoAccessRightException {
+    switch (object) {
+      case Note obj -> assertReadAuthorizationNote(user, obj);
+      case Notebook obj -> assertReadAuthorizationNotebook(user, obj);
+      case Subscription obj -> assertReadAuthorization(user, obj);
+      case RecallPrompt obj -> assertReadAuthorizationRecallPrompt(user, obj);
+      case PredefinedQuestion obj -> assertReadAuthorizationPredefinedQuestion(user, obj);
+      case MemoryTracker obj -> assertReadAuthorizationMemoryTracker(user, obj);
+      case User obj -> assertAuthorizationUser(user, obj);
+      default ->
+          throw new ResponseStatusException(
+              HttpStatus.INTERNAL_SERVER_ERROR, "Unknown object type");
+    }
+  }
+
+  private void assertReadAuthorizationMemoryTracker(User user, MemoryTracker object)
+      throws UnexpectedNoAccessRightException {
+    assertAuthorizationUser(user, object.getUser());
+  }
+
+  private void assertReadAuthorizationPredefinedQuestion(User user, PredefinedQuestion question)
+      throws UnexpectedNoAccessRightException {
+    assertReadAuthorization(user, question.getNote());
+  }
+
+  private void assertReadAuthorizationRecallPrompt(User user, RecallPrompt object)
+      throws UnexpectedNoAccessRightException {
+    assertReadAuthorizationPredefinedQuestion(user, object.getPredefinedQuestion());
+  }
+
+  private void assertAuthorizationNote(User user, Note note)
+      throws UnexpectedNoAccessRightException {
+    assertLoggedIn(user);
+    if (!hasFullAuthority(user, note.getNotebook())) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  private void assertReadAuthorizationNote(User user, Note note)
+      throws UnexpectedNoAccessRightException {
+    assertReadAuthorizationNotebook(user, note.getNotebook());
+  }
+
+  private boolean hasFullAuthority(User user, Notebook notebook) {
+    if (user == null) return false;
+    return user.owns(notebook);
+  }
+
+  private void assertReadAuthorizationNotebook(User user, Notebook notebook)
+      throws UnexpectedNoAccessRightException {
+    if (notebook != null) {
+      if (user != null && user.canReferTo(notebook)) {
+        return;
+      }
+      if (bazaarNotebookRepository.findByNotebook(notebook) != null) {
+        return;
+      }
+    }
+    assertLoggedIn(user);
+    throw new UnexpectedNoAccessRightException();
+  }
+
+  private void assertAuthorizationNotebook(User user, Notebook notebook)
+      throws UnexpectedNoAccessRightException {
+    if (!hasFullAuthority(user, notebook)) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  private void assertAuthorizationCircle(User user, Circle circle)
+      throws UnexpectedNoAccessRightException {
+    assertLoggedIn(user);
+    if (user == null || !user.inCircle(circle)) {
+      System.out.printf("user: %s, circle: %s%n", user, circle);
+      System.out.printf("user: %s, circle: %s%n", user, circle);
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  private void assertAuthorizationSubscription(User user, Subscription subscription)
+      throws UnexpectedNoAccessRightException {
+    if (subscription.getUser() != user) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  private void assertAuthorizationUser(User user, User targetUser)
+      throws UnexpectedNoAccessRightException {
+    if (!user.getId().equals(targetUser.getId())) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  public void assertAdminAuthorization(User user) throws UnexpectedNoAccessRightException {
+    if (!isAdmin(user)) {
+      throw new UnexpectedNoAccessRightException();
+    }
+  }
+
+  public boolean isAdmin(User user) {
+    return user != null && user.isAdmin();
+  }
+
+  public void assertLoggedIn(User user) {
+    if (user == null) {
+      throwUserNotFound();
+    }
+  }
+
+  public static void throwUserNotFound() {
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User Not Found");
+  }
+}


### PR DESCRIPTION
Refactor `Authorization` record into `AuthorizationService` to align with stateless service architecture.

---
<a href="https://cursor.com/background-agent?bcId=bc-967158fc-a756-40b9-8e68-7b4bad1c183e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-967158fc-a756-40b9-8e68-7b4bad1c183e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

