### PR TITLE
Fix memory tracker soft delete bug

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/MemoryTrackerRepository.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/MemoryTrackerRepository.java
@@ -27,6 +27,9 @@ public interface MemoryTrackerRepository extends CrudRepository<MemoryTracker, I
   @Query(value = "SELECT * " + byUserId + "AND rp.note_id =:noteId", nativeQuery = true)
   List<MemoryTracker> findByUserAndNote(Integer userId, @Param("noteId") Integer noteId);
 
+  @Query(value = "SELECT * FROM memory_tracker rp WHERE rp.note_id IN :noteIds", nativeQuery = true)
+  List<MemoryTracker> findByNoteIds(@Param("noteIds") List<Integer> noteIds);
+
   @Query(
       value =
           "SELECT * "

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -118,4 +118,24 @@ public class MemoryTrackerService {
     markAsRepeated(currentUTCTimestamp, correct, memoryTracker);
     return new SpellingResultDTO(note, spellingAnswer, correct);
   }
+
+  public void softDeleteMemoryTrackersForNotes(List<Note> notes) {
+    if (notes.isEmpty()) {
+      return;
+    }
+    List<Integer> noteIds = notes.stream().map(Note::getId).toList();
+    List<MemoryTracker> memoryTrackers = memoryTrackerRepository.findByNoteIds(noteIds);
+    memoryTrackers.forEach(mt -> mt.setRemovedFromTracking(true));
+    memoryTrackers.forEach(entityPersister::save);
+  }
+
+  public void restoreMemoryTrackersForNotes(List<Note> notes) {
+    if (notes.isEmpty()) {
+      return;
+    }
+    List<Integer> noteIds = notes.stream().map(Note::getId).toList();
+    List<MemoryTracker> memoryTrackers = memoryTrackerRepository.findByNoteIds(noteIds);
+    memoryTrackers.forEach(mt -> mt.setRemovedFromTracking(false));
+    memoryTrackers.forEach(entityPersister::save);
+  }
 }


### PR DESCRIPTION
Soft delete memory trackers for a note and its descendants when the note is deleted, and restore them upon undo, to fix a data inconsistency bug.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1763681006556179?thread_ts=1763681006.556179&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-a04a1cb7-77f8-4f81-aa9a-948ed70e1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a04a1cb7-77f8-4f81-aa9a-948ed70e1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

