### PR TITLE
Align account dropdown and menu breakpoints

### DIFF
--- a/frontend/src/components/toolbars/MainMenu.vue
+++ b/frontend/src/components/toolbars/MainMenu.vue
@@ -216,14 +216,14 @@ const showUserSettingsDialog = () => {
   a[href="https://odd-e.com"] {
     display: none;
   }
+
+  .daisy-dropdown { @apply daisy-dropdown-end; }
 }
 
 @media (max-width: theme('screens.md')) {
   :deep(.label) {
     display: none;
   }
-
-  .daisy-dropdown { @apply daisy-dropdown-end; }
 }
 
 </style>


### PR DESCRIPTION
Align user Account dropdown positioning breakpoint with the main menu's layout change for consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-f250577c-83ca-45ae-a025-356356c6a1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f250577c-83ca-45ae-a025-356356c6a1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

