### PR TITLE
Create reusable mock service helper

### DIFF
--- a/frontend/tests/helpers/index.ts
+++ b/frontend/tests/helpers/index.ts
@@ -11,16 +11,83 @@ class StoredComponentTestHelper {
 }
 
 /**
+ * Creates a mock SDK response object with the standard structure.
+ * This helper ensures type safety and consistency across all test mocks.
+ */
+export function createMockResponse<T>(data: T) {
+  return {
+    data,
+    error: undefined,
+    request: {} as Request,
+    response: {} as Response,
+  } as const
+}
+
+/**
+ * Mocks an SDK service method with a resolved value.
+ * This is a type-safe helper that simplifies mocking SDK calls in tests.
+ *
+ * @param methodName - The name of the SDK method to mock (e.g., "showNote", "recalling")
+ * @param data - The data to return in the mock response
+ * @returns A vitest spy on the mocked method
+ *
+ * @example
+ * ```ts
+ * mockSdkMethod("showNote", makeMe.aNoteRealm.please())
+ * mockSdkMethod("getRecentNotes", [])
+ * ```
+ */
+export function mockSdkMethod<K extends keyof typeof sdk>(
+  methodName: K,
+  data: Awaited<ReturnType<(typeof sdk)[K]>>["data"]
+) {
+  // biome-ignore lint/suspicious/noExplicitAny: vi.spyOn has complex types that require type assertions
+  return (vi.spyOn(sdk, methodName as any) as any).mockResolvedValue(
+    createMockResponse(data) as Awaited<ReturnType<(typeof sdk)[K]>>
+  )
+}
+
+/**
+ * Mocks an SDK service method with a custom implementation.
+ * Use this when you need to control the behavior based on input parameters.
+ *
+ * @param methodName - The name of the SDK method to mock
+ * @param implementation - A function that receives the options and returns the mock response data
+ * @returns A vitest spy on the mocked method
+ *
+ * @example
+ * ```ts
+ * const mockedCall = vi.fn()
+ * mockSdkMethodWithImplementation("recalling", async (options) => {
+ *   const result = await mockedCall(options)
+ *   return result
+ * })
+ * ```
+ */
+export function mockSdkMethodWithImplementation<
+  K extends keyof typeof sdk,
+  TData = Awaited<ReturnType<(typeof sdk)[K]>>["data"],
+>(
+  methodName: K,
+  implementation: (
+    options: Parameters<(typeof sdk)[K]>[0]
+  ) => Promise<TData> | TData
+) {
+  // biome-ignore lint/suspicious/noExplicitAny: vi.spyOn has complex types that require type assertions
+  return (vi.spyOn(sdk, methodName as any) as any).mockImplementation(
+    async (options: Parameters<(typeof sdk)[K]>[0]) => {
+      const result = await implementation(options)
+      return createMockResponse(result) as Awaited<ReturnType<(typeof sdk)[K]>>
+    }
+  )
+}
+
+/**
  * Mocks showNoteAccessory service to prevent unhandled promise rejections
  * in tests that use NoteAccessoryAsync component.
  */
 export function mockShowNoteAccessory() {
-  return vi.spyOn(sdk, "showNoteAccessory").mockResolvedValue({
-    data: undefined as never,
-    error: undefined as never,
-    request: {} as Request,
-    response: {} as Response,
-  })
+  return mockSdkMethod("showNoteAccessory", undefined as never)
 }
 
 /**
@@ -35,12 +102,7 @@ export function mockShowNote(noteRealm?: NoteRealm) {
       note: { id: 1 },
       children: [],
     } as unknown as NoteRealm)
-  return vi.spyOn(sdk, "showNote").mockResolvedValue({
-    data: defaultNote,
-    error: undefined,
-    request: {} as Request,
-    response: {} as Response,
-  })
+  return mockSdkMethod("showNote", defaultNote)
 }
 
 export default new StoredComponentTestHelper()

--- a/frontend/tests/notes/NoteInfo.spec.ts
+++ b/frontend/tests/notes/NoteInfo.spec.ts
@@ -1,7 +1,7 @@
 import NoteInfoBar from "@/components/notes/NoteInfoBar.vue"
 import { flushPromises } from "@vue/test-utils"
 import makeMe from "@tests/fixtures/makeMe"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod } from "@tests/helpers"
 import type { NoteInfo } from "@generated/backend"
 import * as sdk from "@generated/backend/sdk.gen"
 
@@ -13,12 +13,7 @@ const stubResponse: NoteInfo = {
 
 describe("note info", () => {
   it("should render values", async () => {
-    vi.spyOn(sdk, "getNoteInfo").mockResolvedValue({
-      data: stubResponse,
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("getNoteInfo", stubResponse)
     const wrapper = helper
       .component(NoteInfoBar)
       .withProps({

--- a/frontend/tests/notes/NoteShow.spec.ts
+++ b/frontend/tests/notes/NoteShow.spec.ts
@@ -3,7 +3,7 @@ import type { NoteRealm } from "@generated/backend"
 import { screen } from "@testing-library/vue"
 import { flushPromises } from "@vue/test-utils"
 import makeMe from "@tests/fixtures/makeMe"
-import helper, { mockShowNoteAccessory } from "@tests/helpers"
+import helper, { mockShowNoteAccessory, mockSdkMethod } from "@tests/helpers"
 import * as sdk from "@generated/backend/sdk.gen"
 
 describe("new/updated pink banner", () => {
@@ -22,12 +22,7 @@ describe("new/updated pink banner", () => {
     [new Date(Date.UTC(2016, 1, 12)), "rgb(150,150,150)"],
   ])("should show fresher color if recently updated", async (updatedAt, expectedColor) => {
     const note = makeMe.aNoteRealm.updatedAtDate(updatedAt).please()
-    vi.spyOn(sdk, "showNote").mockResolvedValue({
-      data: note,
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("showNote", note)
 
     const wrapper = helper
       .component(NoteShow)
@@ -52,12 +47,7 @@ describe("note wth children", () => {
   })
 
   const render = (n: NoteRealm) => {
-    vi.spyOn(sdk, "showNote").mockResolvedValue({
-      data: n,
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("showNote", n)
     helper
       .component(NoteShow)
       .withRouter()

--- a/frontend/tests/pages/AssessmentHistoryPage.spec.ts
+++ b/frontend/tests/pages/AssessmentHistoryPage.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, beforeEach, vi } from "vitest"
+import { describe, it, beforeEach } from "vitest"
 import AssessmentAndCertificateHistoryPage from "@/pages/AssessmentAndCertificateHistoryPage.vue"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod } from "@tests/helpers"
 import makeMe from "@tests/fixtures/makeMe"
 import { nextTick } from "vue"
 import type { AssessmentAttempt } from "@generated/backend"
@@ -16,12 +16,7 @@ describe("assessment and certificate history page", () => {
   let wrapper
 
   beforeEach(() => {
-    vi.spyOn(sdk, "getMyAssessments").mockResolvedValue({
-      data: [assessmentForArt, assessmentForTech],
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("getMyAssessments", [assessmentForArt, assessmentForTech])
     wrapper = helper
       .component(AssessmentAndCertificateHistoryPage)
       .withCurrentUser(user)

--- a/frontend/tests/pages/AssessmentPage.spec.ts
+++ b/frontend/tests/pages/AssessmentPage.spec.ts
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/vue"
-import { describe, it } from "vitest"
+import { describe, it, vi } from "vitest"
 import AssessmentPage from "@/pages/AssessmentPage.vue"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod, createMockResponse } from "@tests/helpers"
 import makeMe from "@tests/fixtures/makeMe"
 import { flushPromises } from "@vue/test-utils"
 import type { AssessmentQuestionInstance } from "@generated/backend"
@@ -25,12 +25,7 @@ describe("assessment page", () => {
       .withQuestions([assessmentQuestionInstance])
       .please()
     beforeEach(() => {
-      vi.spyOn(sdk, "generateAssessmentQuestions").mockResolvedValue({
-        data: assessmentAttempt,
-        error: undefined,
-        request: {} as Request,
-        response: {} as Response,
-      })
+      mockSdkMethod("generateAssessmentQuestions", assessmentAttempt)
     })
 
     it("calls API ONCE on mount", async () => {
@@ -82,31 +77,19 @@ describe("assessment page", () => {
       .withQuestions([quizQuestion_1, quizQuestion_2])
       .please()
     beforeEach(() => {
-      vi.spyOn(sdk, "generateAssessmentQuestions").mockResolvedValue({
-        data: assessmentAttempt,
-        error: undefined,
-        request: {} as Request,
-        response: {} as Response,
-      })
+      mockSdkMethod("generateAssessmentQuestions", assessmentAttempt)
       vi.spyOn(sdk, "answerQuestion")
-        .mockResolvedValueOnce({
-          data: answerResult1,
-          error: undefined,
-          request: {} as Request,
-          response: {} as Response,
-        })
-        .mockResolvedValueOnce({
-          data: answerResult2,
-          error: undefined,
-          request: {} as Request,
-          response: {} as Response,
-        })
-      vi.spyOn(sdk, "submitAssessmentResult").mockResolvedValue({
-        data: assessmentAttempt,
-        error: undefined,
-        request: {} as Request,
-        response: {} as Response,
-      })
+        .mockResolvedValueOnce(
+          createMockResponse(answerResult1) as Awaited<
+            ReturnType<typeof sdk.answerQuestion>
+          >
+        )
+        .mockResolvedValueOnce(
+          createMockResponse(answerResult2) as Awaited<
+            ReturnType<typeof sdk.answerQuestion>
+          >
+        )
+      mockSdkMethod("submitAssessmentResult", assessmentAttempt)
     })
 
     it("should submit assessment result when answer all questions", async () => {

--- a/frontend/tests/pages/BazaarPage.spec.ts
+++ b/frontend/tests/pages/BazaarPage.spec.ts
@@ -1,19 +1,14 @@
 import BazaarPage from "@/pages/BazaarPage.vue"
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect } from "vitest"
 import makeMe from "@tests/fixtures/makeMe"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod } from "@tests/helpers"
 import * as sdk from "@generated/backend/sdk.gen"
 
 describe("bazaar page", () => {
   it("fetch API to be called ONCE on mount", async () => {
     const notebook = makeMe.aNotebook.please()
     const bazaarNotebooks = makeMe.bazaarNotebooks.notebooks(notebook).please()
-    vi.spyOn(sdk, "bazaar").mockResolvedValue({
-      data: bazaarNotebooks,
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("bazaar", bazaarNotebooks)
     helper.component(BazaarPage).withRouter().render()
     expect(sdk.bazaar).toBeCalledTimes(1)
   })

--- a/frontend/tests/pages/ManageMCPTokensPage.spec.ts
+++ b/frontend/tests/pages/ManageMCPTokensPage.spec.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { screen } from "@testing-library/vue"
 import ManageMCPTokensPage from "@/pages/ManageMCPTokensPage.vue"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod } from "@tests/helpers"
 import { createRouter, createWebHistory } from "vue-router"
 import routes from "@/routes/routes"
-import * as sdk from "@generated/backend/sdk.gen"
 
 describe("ManageMCPTokensPage", () => {
   let router: ReturnType<typeof createRouter>
@@ -18,21 +17,13 @@ describe("ManageMCPTokensPage", () => {
   })
 
   it('displays "No Label" when token label is empty', async () => {
-    vi.spyOn(sdk, "generateToken").mockResolvedValue({
-      data: {
-        token: "mocked-token",
-        label: "",
-        id: 1,
-      },
-      request: new Request("http://localhost"),
-      response: new Response(),
+    mockSdkMethod("generateToken", {
+      token: "mocked-token",
+      label: "",
+      id: 1,
     } as never)
 
-    vi.spyOn(sdk, "getTokens").mockResolvedValue({
-      data: [],
-      request: new Request("http://localhost"),
-      response: new Response(),
-    } as never)
+    mockSdkMethod("getTokens", [] as never)
 
     const { findByText } = helper
       .component(ManageMCPTokensPage)

--- a/frontend/tests/pages/NotebooksPage.spec.ts
+++ b/frontend/tests/pages/NotebooksPage.spec.ts
@@ -1,21 +1,16 @@
 import NotebooksPage from "@/pages/NotebooksPage.vue"
 import { describe, it } from "vitest"
 import makeMe from "@tests/fixtures/makeMe"
-import helper from "@tests/helpers"
+import helper, { mockSdkMethod } from "@tests/helpers"
 import * as sdk from "@generated/backend/sdk.gen"
 
 describe("Notebooks Page", () => {
   it("fetch API to be called ONCE", async () => {
     const notebook = makeMe.aNotebook.please()
 
-    vi.spyOn(sdk, "myNotebooks").mockResolvedValue({
-      data: {
-        notebooks: [notebook],
-        subscriptions: [],
-      },
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
+    mockSdkMethod("myNotebooks", {
+      notebooks: [notebook],
+      subscriptions: [],
     })
     helper.component(NotebooksPage).withRouter().render()
     expect(sdk.myNotebooks).toBeCalledTimes(1)

--- a/frontend/tests/pages/RecentPage.spec.ts
+++ b/frontend/tests/pages/RecentPage.spec.ts
@@ -1,28 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach } from "vitest"
 import RecentPage from "@/pages/RecentPage.vue"
-import helper from "@tests/helpers"
-import * as sdk from "@generated/backend/sdk.gen"
+import helper, { mockSdkMethod } from "@tests/helpers"
 
 describe("RecentPage.vue", () => {
   beforeEach(() => {
-    vi.spyOn(sdk, "getRecentNotes").mockResolvedValue({
-      data: [],
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
-    vi.spyOn(sdk, "getRecentMemoryTrackers").mockResolvedValue({
-      data: [],
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
-    vi.spyOn(sdk, "getRecentlyReviewed").mockResolvedValue({
-      data: [],
-      error: undefined,
-      request: {} as Request,
-      response: {} as Response,
-    })
+    mockSdkMethod("getRecentNotes", [])
+    mockSdkMethod("getRecentMemoryTrackers", [])
+    mockSdkMethod("getRecentlyReviewed", [])
   })
   describe("Tab Navigation", () => {
     it("shows Recently Added/Updated tab by default", async () => {

--- a/frontend/tests/store/storedApi.spec.ts
+++ b/frontend/tests/store/storedApi.spec.ts
@@ -1,7 +1,7 @@
 import type { Router } from "vue-router"
 import createNoteStorage from "@/store/createNoteStorage"
 import makeMe from "@tests/fixtures/makeMe"
-import * as sdk from "@generated/backend/sdk.gen"
+import { mockSdkMethodWithImplementation } from "@tests/helpers"
 
 describe("storedApiCollection", () => {
   const note = makeMe.aNoteRealm.please()
@@ -15,14 +15,8 @@ describe("storedApiCollection", () => {
 
     beforeEach(() => {
       deleteNote = vi.fn().mockResolvedValue([note])
-      vi.spyOn(sdk, "deleteNote").mockImplementation(async (options) => {
-        const result = await deleteNote(options)
-        return {
-          data: result,
-          error: undefined,
-          request: {} as Request,
-          response: {} as Response,
-        }
+      mockSdkMethodWithImplementation("deleteNote", async (options) => {
+        return await deleteNote(options)
       })
     })
 
@@ -42,23 +36,11 @@ describe("storedApiCollection", () => {
     beforeEach(() => {
       updateNoteDetails = vi.fn().mockResolvedValue(note)
       showNote = vi.fn().mockResolvedValue(note)
-      vi.spyOn(sdk, "updateNoteDetails").mockImplementation(async (options) => {
-        const result = await updateNoteDetails(options)
-        return {
-          data: result,
-          error: undefined,
-          request: {} as Request,
-          response: {} as Response,
-        }
+      mockSdkMethodWithImplementation("updateNoteDetails", async (options) => {
+        return await updateNoteDetails(options)
       })
-      vi.spyOn(sdk, "showNote").mockImplementation(async (options) => {
-        const result = await showNote(options)
-        return {
-          data: result,
-          error: undefined,
-          request: {} as Request,
-          response: {} as Response,
-        }
+      mockSdkMethodWithImplementation("showNote", async (options) => {
+        return await showNote(options)
       })
       noteRef = storageAccessor.refOfNoteRealm(note.id)
     })


### PR DESCRIPTION
Introduce helper functions to simplify and type-check SDK service call mocking in frontend unit tests.

This refactoring addresses significant boilerplate in frontend unit tests by centralizing SDK service call mocking. The new helpers enhance type safety, reduce redundancy, and improve consistency and maintainability across tests.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764024858117139?thread_ts=1764024858.117139&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-8ea731bc-3995-470d-9dfe-421a2437d59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ea731bc-3995-470d-9dfe-421a2437d59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

