### PR TITLE
Close notebook settings form after update

### DIFF
--- a/frontend/src/components/notebook/NotebookAssistantManagementDialog.vue
+++ b/frontend/src/components/notebook/NotebookAssistantManagementDialog.vue
@@ -34,6 +34,7 @@ import TextInput from "../form/TextInput.vue"
 
 const props = defineProps({
   notebook: { type: Object as PropType<Notebook>, required: true },
+  closer: { type: Function as PropType<() => void>, required: false },
 })
 
 const additionalInstruction = ref("")
@@ -49,6 +50,9 @@ const updateAiInstructions = async () => {
   })
   if (!error) {
     // Success - handled by global interceptor
+    if (props.closer) {
+      props.closer()
+    }
   }
 }
 

--- a/frontend/src/components/notebook/NotebookButtons.vue
+++ b/frontend/src/components/notebook/NotebookButtons.vue
@@ -5,7 +5,9 @@
       <template #button_face>
         <SvgEditNotebook />
       </template>
-      <NotebookEditDialog v-bind="{ notebook, user }" />
+      <template #default="{ closer }">
+        <NotebookEditDialog v-bind="{ notebook, user, closer }" />
+      </template>
     </PopButton>
     <PopButton
       title="Move to ..."

--- a/frontend/src/components/notebook/NotebookEditDialog.vue
+++ b/frontend/src/components/notebook/NotebookEditDialog.vue
@@ -50,7 +50,7 @@
   <!-- Admin Section -->
   <template v-if="user?.admin">
     <hr/>
-    <NotebookAssistantManagementDialog :notebook="notebook" />
+    <NotebookAssistantManagementDialog :notebook="notebook" :closer="closer" />
   </template>
 
   <!-- Notebook Indexing Section -->
@@ -112,6 +112,7 @@ const router = useRouter()
 const props = defineProps({
   notebook: { type: Object as PropType<Notebook>, required: true },
   user: { type: Object as PropType<User>, required: false },
+  closer: { type: Function as PropType<() => void>, required: false },
 })
 
 // Form data


### PR DESCRIPTION
Close the notebook AI assistant settings form after a successful update.

The form was not closing because the `closer` function from the `PopButton` component was not propagated to `NotebookAssistantManagementDialog` and called upon successful save. This PR passes the `closer` function through `NotebookEditDialog` to `NotebookAssistantManagementDialog` and invokes it after the `updateAiInstructions` function completes successfully.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764029186977709?thread_ts=1764029186.977709&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-4dfa6be7-eb3f-4df9-b392-580ec00e4bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dfa6be7-eb3f-4df9-b392-580ec00e4bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

