### PR TITLE
Fix search indicator bug and add animation

### DIFF
--- a/frontend/src/models/searchState.ts
+++ b/frontend/src/models/searchState.ts
@@ -1,0 +1,22 @@
+import { reactive } from "vue"
+
+/**
+ * Domain model for search state management
+ */
+export class SearchState {
+  private state = reactive({
+    isSearchInProgress: false,
+  })
+
+  get isSearchInProgress(): boolean {
+    return this.state.isSearchInProgress
+  }
+
+  startSearch(): void {
+    this.state.isSearchInProgress = true
+  }
+
+  completeSearch(): void {
+    this.state.isSearchInProgress = false
+  }
+}


### PR DESCRIPTION
Fixes a bug where the "Searching..." indicator didn't show on subsequent searches and adds a dynamic effect to it.

The indicator's visibility was previously tied only to the initial `searchResult === undefined` state, preventing it from showing when a new search was initiated after previous results were already displayed. This PR introduces a dedicated `SearchState` domain model to track the search in-progress status independently, ensuring the indicator appears correctly while previous results remain visible.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764112605342369?thread_ts=1764112605.342369&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-56cdd1ac-d1c9-428b-8eae-d99cf1f5b0cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56cdd1ac-d1c9-428b-8eae-d99cf1f5b0cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

