### PR TITLE
Remove updated at from note graph serialization

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/graphRAG/BareNote.java
+++ b/backend/src/main/java/com/odde/doughnut/services/graphRAG/BareNote.java
@@ -21,8 +21,7 @@ import lombok.Getter;
   "parentUriAndTitle",
   "relationToFocusNote",
   "details",
-  "createdAt",
-  "updatedAt"
+  "createdAt"
 })
 public class BareNote {
   private final Note note;
@@ -77,11 +76,6 @@ public class BareNote {
   @JsonProperty("createdAt")
   public java.sql.Timestamp getCreatedAt() {
     return note.getCreatedAt();
-  }
-
-  @JsonProperty("updatedAt")
-  public java.sql.Timestamp getUpdatedAt() {
-    return note.getUpdatedAt();
   }
 
   public static BareNote fromNote(Note note, RelationshipToFocusNote relation) {

--- a/backend/src/test/java/com/odde/doughnut/services/graphRAG/GraphRAGResultTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/graphRAG/GraphRAGResultTest.java
@@ -106,12 +106,11 @@ class GraphRAGResultTest {
     // Assert
     assertThat(
         jsonNode::fieldNames,
-        containsInAnyOrder(
-            "uri", "title", "details", "relationToFocusNote", "createdAt", "updatedAt"));
+        containsInAnyOrder("uri", "title", "details", "relationToFocusNote", "createdAt"));
   }
 
   @Test
-  void shouldIncludeCreatedAtAndUpdatedAtWhenSerializedToJson() throws Exception {
+  void shouldIncludeCreatedAtWhenSerializedToJson() throws Exception {
     // Arrange
     Timestamp createdAt = new Timestamp(System.currentTimeMillis() - 86400000); // 1 day ago
     Timestamp updatedAt = new Timestamp(System.currentTimeMillis());
@@ -132,10 +131,9 @@ class GraphRAGResultTest {
 
     // Assert
     assertThat(jsonNode.has("createdAt"), is(true));
-    assertThat(jsonNode.has("updatedAt"), is(true));
+    assertThat(jsonNode.has("updatedAt"), is(false));
     // Timestamps are serialized as ISO strings when WRITE_DATES_AS_TIMESTAMPS is disabled
     assertThat(jsonNode.get("createdAt").asText(), is(not(emptyString())));
-    assertThat(jsonNode.get("updatedAt").asText(), is(not(emptyString())));
   }
 
   @Nested
@@ -165,7 +163,7 @@ class GraphRAGResultTest {
     }
 
     @Test
-    void shouldIncludeCreatedAtAndUpdatedAtWhenSerializedToJson() throws Exception {
+    void shouldIncludeCreatedAtWhenSerializedToJson() throws Exception {
       // Arrange
       Timestamp createdAt = new Timestamp(System.currentTimeMillis() - 86400000); // 1 day ago
       Timestamp updatedAt = new Timestamp(System.currentTimeMillis());
@@ -186,10 +184,9 @@ class GraphRAGResultTest {
 
       // Assert
       assertThat(jsonNode.has("createdAt"), is(true));
-      assertThat(jsonNode.has("updatedAt"), is(true));
+      assertThat(jsonNode.has("updatedAt"), is(false));
       // Timestamps are serialized as ISO strings when WRITE_DATES_AS_TIMESTAMPS is disabled
       assertThat(jsonNode.get("createdAt").asText(), is(not(emptyString())));
-      assertThat(jsonNode.get("updatedAt").asText(), is(not(emptyString())));
     }
   }
 }


### PR DESCRIPTION
Remove the `updatedAt` field from the `BareNote` class to exclude it from note graph JSON serialization.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764116120770379?thread_ts=1764116120.770379&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-a598d933-314f-483f-9a17-0d7e2f1f075d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a598d933-314f-483f-9a17-0d7e2f1f075d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

