### PR TITLE
Ensure unique question choice keys

### DIFF
--- a/frontend/src/components/assessment/AssessmentQuestion.vue
+++ b/frontend/src/components/assessment/AssessmentQuestion.vue
@@ -3,6 +3,7 @@
     v-bind="{
       multipleChoicesQuestion: localAssessmentQuestionInstance.multipleChoicesQuestion,
       answer: localAssessmentQuestionInstance.answer,
+      questionId: localAssessmentQuestionInstance.id,
     }"
     @answer="submitAnswer($event)"
     :key="localAssessmentQuestionInstance.id"

--- a/frontend/src/components/notes/Questions.vue
+++ b/frontend/src/components/notes/Questions.vue
@@ -59,7 +59,7 @@
               :class="{
                 'correct-choice': index === question.correctAnswerIndex,
               }"
-              :key="index"
+              :key="`${question.id}-${choice}`"
             >
               {{ choice }}
             </td>

--- a/frontend/src/components/review/AnsweredQuestionComponent.vue
+++ b/frontend/src/components/review/AnsweredQuestionComponent.vue
@@ -8,6 +8,7 @@
       multipleChoicesQuestion: answeredQuestion.predefinedQuestion.multipleChoicesQuestion,
       correctChoiceIndex: answeredQuestion.predefinedQuestion.correctAnswerIndex,
       answer: answeredQuestion.answer,
+      questionId: answeredQuestion.predefinedQuestion.id,
     }"
   />
   <AnswerResult v-bind="{ answeredQuestion }" />

--- a/frontend/src/components/review/ContestableQuestion.vue
+++ b/frontend/src/components/review/ContestableQuestion.vue
@@ -6,7 +6,7 @@
     <div class="daisy-card-body">
       <h3 class="daisy-card-title">Previous Question Contested ...</h3>
       <p>{{ q.badQuestionReason }}</p>
-      <QuestionDisplay :multiple-choices-question="q.quizeQuestion.multipleChoicesQuestion" :disabled="true" :key="q.quizeQuestion.id"/>
+      <QuestionDisplay :multiple-choices-question="q.quizeQuestion.multipleChoicesQuestion" :disabled="true" :question-id="q.quizeQuestion.id" :key="q.quizeQuestion.id"/>
     </div>
   </div>
   <p v-if="currentQuestionLegitMessage" class="daisy-text-warning daisy-mb-4">

--- a/frontend/src/components/review/QuestionChoices.vue
+++ b/frontend/src/components/review/QuestionChoices.vue
@@ -3,7 +3,7 @@
     <li
       class="choice daisy-w-[46%] daisy-min-h-[80px] daisy-m-[2%] sm:daisy-w-full"
       v-for="(choice, index) in choices"
-      :key="index"
+      :key="getChoiceKey(choice, index)"
     >
       <button
         :class="[
@@ -46,9 +46,19 @@ export default defineComponent({
     correctChoiceIndex: Number,
     answerChoiceIndex: Number,
     disabled: Boolean,
+    questionId: {
+      type: [Number, String],
+      default: undefined,
+    },
   },
   emits: ["answer"],
   methods: {
+    getChoiceKey(choice: string, index: number) {
+      if (this.questionId !== undefined) {
+        return `${this.questionId}-${choice}`
+      }
+      return `choice-${index}-${choice}`
+    },
     handleInnerClick(event: Event) {
       // Prevent any link clicks from navigating, but allow text selection
       if (event.target instanceof HTMLAnchorElement) {

--- a/frontend/src/components/review/QuestionDisplay.vue
+++ b/frontend/src/components/review/QuestionDisplay.vue
@@ -7,6 +7,7 @@
       :correct-choice-index="correctChoiceIndex"
       :answer-choice-index="answer?.choiceIndex"
       :disabled="disabled"
+      :question-id="questionId"
       @answer="submitAnswer($event)"
     />
   </div>
@@ -30,6 +31,10 @@ defineProps({
   correctChoiceIndex: Number,
   answer: Object as PropType<Answer>,
   disabled: Boolean,
+  questionId: {
+    type: [Number, String],
+    default: undefined,
+  },
 })
 
 const emits = defineEmits(["answer"])

--- a/frontend/src/components/review/RecallPromptComponent.vue
+++ b/frontend/src/components/review/RecallPromptComponent.vue
@@ -6,6 +6,7 @@
       }"
       @answer="submitQuizAnswer($event)"
       :key="recallPrompt.id"
+      :question-id="recallPrompt.id"
       :disabled="isLoading || isAnswered"
     />
 


### PR DESCRIPTION
Ensures unique keys for question choices in the frontend display to improve Vue reactivity and prevent key conflicts.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764199262078369?thread_ts=1764199262.078369&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-bb3ccd04-e8a2-4092-9314-41307804805a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb3ccd04-e8a2-4092-9314-41307804805a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

