### PR TITLE
Disable ios tap highlight on choices

### DIFF
--- a/frontend/src/components/review/QuestionChoices.vue
+++ b/frontend/src/components/review/QuestionChoices.vue
@@ -111,7 +111,7 @@ export default defineComponent({
 
 button, a, input
   border: 0
-  -webkit-tap-highlight-color: rgba(0,0,0,0)
+  -webkit-tap-highlight-color: transparent
   -webkit-touch-callout: none
   -webkit-user-select: none
 


### PR DESCRIPTION
Update `-webkit-tap-highlight-color` to `transparent` to suppress native iOS tap highlights on choice buttons.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764201733377599?thread_ts=1764201733.377599&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-e8b335fd-2bf1-40be-8c57-e0529ae45fa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8b335fd-2bf1-40be-8c57-e0529ae45fa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

