### PR TITLE
Limit breadcrumb width and enable scrolling

### DIFF
--- a/frontend/src/components/review/NoteUnderQuestion.vue
+++ b/frontend/src/components/review/NoteUnderQuestion.vue
@@ -1,7 +1,9 @@
 <template>
   <fieldset class="note-under-question">
     <legend>Note under question</legend>
-    <Breadcrumb v-bind="{ noteTopology, includingSelf: true }" />
+    <div class="breadcrumb-container">
+      <Breadcrumb v-bind="{ noteTopology, includingSelf: true }" />
+    </div>
   </fieldset>
 </template>
 
@@ -40,4 +42,17 @@ defineProps({
     top: -12px
     left: 10px
     width: auto
+
+  .breadcrumb-container
+    max-width: 100%
+    overflow-x: auto
+    overflow-y: hidden
+    -webkit-overflow-scrolling: touch
+
+    :deep(.daisy-breadcrumbs)
+      white-space: nowrap
+
+      ul
+        white-space: nowrap
+        display: inline-flex
 </style>


### PR DESCRIPTION
Limit the width of breadcrumbs in "Note under question" and enable horizontal scrolling to prevent them from stretching the full page width.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764203369298589?thread_ts=1764203369.298589&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-15573d6a-cd0f-47f1-a535-5974d88b5656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15573d6a-cd0f-47f1-a535-5974d88b5656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

