### PR TITLE
Change question choice tap highlight to yellow

### DIFF
--- a/frontend/src/components/review/QuestionChoices.vue
+++ b/frontend/src/components/review/QuestionChoices.vue
@@ -101,7 +101,7 @@ export default defineComponent({
 
 button, a, input
   border: 0
-  -webkit-tap-highlight-color: rgba(0,0,0,0)
+  -webkit-tap-highlight-color: yellow
   -webkit-touch-callout: none
   -webkit-user-select: none
 


### PR DESCRIPTION
Change `-webkit-tap-highlight-color` to yellow for question choices to provide visual feedback on mobile taps.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764285849997429?thread_ts=1764285849.997429&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-87d364b1-755d-4287-ae2c-e27a2fa501e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87d364b1-755d-4287-ae2c-e27a2fa501e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

