### PR TITLE
Debug ios mcq highlight with yellow

### DIFF
--- a/frontend/src/components/review/QuestionChoices.vue
+++ b/frontend/src/components/review/QuestionChoices.vue
@@ -105,6 +105,14 @@ button, a, input
   -webkit-touch-callout: none
   -webkit-user-select: none
 
+button:active
+  background-color: yellow !important
+  color: black !important
+
+button:focus
+  background-color: yellow !important
+  color: black !important
+
 .choice-text
   user-select: text
   -webkit-user-select: text


### PR DESCRIPTION
Add yellow background to MCQ option buttons on `:active` and `:focus` to diagnose persistent highlight on iOS.

This change is a diagnostic step to identify the root cause of a persistent "tapped" highlight on MCQ options on iOS. The issue manifests as an option on a new question appearing highlighted at the same index as the previously tapped option, despite the component being re-rendered. Previous attempts ruled out `-webkit-tap-highlight-color` and general iOS touch-state resets. By applying a conspicuous yellow background to `:active` and `:focus` states, we aim to confirm if the persistent highlight is due to one of these CSS pseudo-states being retained by WebKit.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764290398027749?thread_ts=1764290398.027749&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-4eb1c598-cae6-47a8-92d2-13074427825d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4eb1c598-cae6-47a8-92d2-13074427825d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

