### PR TITLE
Investigate unexpected ai prompts on spelling trackers

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/RecallQuestionService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/RecallQuestionService.java
@@ -37,6 +37,11 @@ public class RecallQuestionService {
   }
 
   public RecallPrompt generateAQuestion(MemoryTracker memoryTracker) {
+    // Spelling memory trackers should not have AI-generated questions
+    if (Boolean.TRUE.equals(memoryTracker.getSpelling())) {
+      return null;
+    }
+
     // First check if there's an existing unanswered recall prompt for this note and memory tracker
     RecallPrompt existingPrompt = findExistingUnansweredRecallPrompt(memoryTracker);
     if (existingPrompt != null) {

--- a/frontend/src/components/review/Quiz.vue
+++ b/frontend/src/components/review/Quiz.vue
@@ -91,6 +91,11 @@ const useQuestionFetching = (props: QuizProps) => {
       const memoryTrackerId = memoryTracker?.memoryTrackerId
       if (memoryTrackerId === undefined) break
 
+      // Skip spelling memory trackers - they don't need AI-generated questions
+      if (memoryTracker?.spelling) {
+        continue
+      }
+
       const cachedValue = recallPromptCache.value[memoryTrackerId]
       if (cachedValue !== undefined) continue
 
@@ -149,6 +154,11 @@ const isCurrentMemoryTrackerFetching = computed(() => {
 })
 const currentQuestionFetched = computed(() => {
   const memoryTrackerId = currentMemoryTrackerId.value
+  const memoryTracker = currentMemoryTracker.value
+  // Spelling trackers don't need recall prompts, so they're always "fetched"
+  if (memoryTracker?.spelling) {
+    return true
+  }
   return (
     memoryTrackerId !== undefined && memoryTrackerId in recallPromptCache.value
   )


### PR DESCRIPTION
Prevent AI-generated questions and recall prompts from being created for spelling memory trackers.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764591432802139?thread_ts=1764591432.802139&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-9dc7e25e-4911-42ea-bc5e-bb8424925ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9dc7e25e-4911-42ea-bc5e-bb8424925ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

