### PR TITLE
Use 100dvh and 100vh for height

### DIFF
--- a/frontend/src/DoughnutApp.vue
+++ b/frontend/src/DoughnutApp.vue
@@ -89,6 +89,7 @@ onMounted(async () => {
 
 .app-container {
   height: 100vh; // Default to viewport height for desktop (vertical menu)
+  height: 100dvh; // Dynamic viewport height for mobile devices
   display: flex;
   overflow: hidden; // Prevent scrolling on desktop
 }
@@ -111,6 +112,7 @@ onMounted(async () => {
 @media (max-width: theme('screens.lg')) {
   .app-container {
     height: 100vh; // Keep fixed height for proper page height calculations
+    height: 100dvh; // Dynamic viewport height for mobile devices
     flex-direction: column;
     overflow: hidden; // Prevent container scrolling
   }

--- a/frontend/src/components/common/FullScreen.vue
+++ b/frontend/src/components/common/FullScreen.vue
@@ -116,6 +116,7 @@ onUnmounted(async () => {
   left: 0;
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
   background-color: black;
   z-index: 9999;
   display: flex;

--- a/frontend/src/components/commons/Modal.vue
+++ b/frontend/src/components/commons/Modal.vue
@@ -96,6 +96,7 @@ onUnmounted(() => {
   position: relative;
   max-width: 700px;
   max-height: 100vh;
+  max-height: 100dvh;
   overflow: auto;
   margin: 0px auto;
   padding: 20px 30px;
@@ -107,6 +108,7 @@ onUnmounted(() => {
 .modal-sidebar {
   position: relative;
   height: 100vh;
+  height: 100dvh;
   overflow: auto;
   padding: 0px 0px;
   background-color: #fff;

--- a/frontend/src/components/toolbars/MainMenu.stories.ts
+++ b/frontend/src/components/toolbars/MainMenu.stories.ts
@@ -54,7 +54,7 @@ const meta = {
       return {
         components: { story },
         template:
-          '<div style="width: 200px; height: 100vh; background: #f5f5f5;"><story /></div>',
+          '<div style="width: 200px; height: 100vh; height: 100dvh; background: #f5f5f5;"><story /></div>',
         beforeUnmount() {
           // Restore original method when story unmounts
           UserController.getMenuData = originalGetMenuData
@@ -116,7 +116,7 @@ export const WithDueCount: Story = {
       return {
         components: { story },
         template:
-          '<div style="width: 200px; height: 100vh; background: #f5f5f5;"><story /></div>',
+          '<div style="width: 200px; height: 100vh; height: 100dvh; background: #f5f5f5;"><story /></div>',
         beforeUnmount() {
           UserController.getMenuData = originalGetMenuData
         },
@@ -162,7 +162,7 @@ export const WithRecallCount: Story = {
       return {
         components: { story },
         template:
-          '<div style="width: 200px; height: 100vh; background: #f5f5f5;"><story /></div>',
+          '<div style="width: 200px; height: 100vh; height: 100dvh; background: #f5f5f5;"><story /></div>',
         beforeUnmount() {
           UserController.getMenuData = originalGetMenuData
         },
@@ -213,7 +213,7 @@ export const WithUnreadMessages: Story = {
       return {
         components: { story },
         template:
-          '<div style="width: 200px; height: 100vh; background: #f5f5f5;"><story /></div>',
+          '<div style="width: 200px; height: 100vh; height: 100dvh; background: #f5f5f5;"><story /></div>',
         beforeUnmount() {
           UserController.getMenuData = originalGetMenuData
         },

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -197,6 +197,7 @@ onUnmounted(() => {
 
 .upper-half {
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 2rem;
   background: linear-gradient(to bottom, #ffffff, #f5f5f5);
 }
@@ -267,6 +268,7 @@ onUnmounted(() => {
 
 .lower-half {
   min-height: 100vh;
+  min-height: 100dvh;
   padding: 2rem;
   background: linear-gradient(to bottom, #f5f5f5, #ffffff);
 }


### PR DESCRIPTION
Update height declarations to use `100vh` and `100dvh` to correctly handle dynamic viewport heights on mobile devices.

On mobile devices, browser UI elements (like the address bar) can appear or disappear, changing the available viewport height. Standard `100vh` does not always adapt to these changes, leading to layout issues. `100dvh` (dynamic viewport height) ensures the layout adjusts properly, with `100vh` serving as a fallback for unsupported browsers.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764633957649259?thread_ts=1764633957.649259&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-c001ee96-cfd1-497e-88a2-36594038ed33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c001ee96-cfd1-497e-88a2-36594038ed33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

