### PR TITLE
Update memory tracker display and tests

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/MemoryTrackerRepository.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/MemoryTrackerRepository.java
@@ -34,7 +34,15 @@ public interface MemoryTrackerRepository extends CrudRepository<MemoryTracker, I
   Stream<MemoryTracker> findAllByUserAndNextRecallAtLessThanEqualOrderByNextRecallAt(
       Integer userId, @Param("nextRecallAt") Timestamp nextRecallAt);
 
-  @Query(value = "SELECT rp.* " + byUserId + "AND rp.note_id =:noteId", nativeQuery = true)
+  @Query(
+      value =
+          "SELECT rp.* "
+              + " FROM memory_tracker rp "
+              + " JOIN note n ON rp.note_id = n.id "
+              + " WHERE rp.user_id = :userId "
+              + "   AND n.deleted_at IS NULL "
+              + "   AND rp.note_id = :noteId",
+      nativeQuery = true)
   List<MemoryTracker> findByUserAndNote(Integer userId, @Param("noteId") Integer noteId);
 
   @Query(

--- a/frontend/src/components/notes/NoteInfoMemoryTracker.vue
+++ b/frontend/src/components/notes/NoteInfoMemoryTracker.vue
@@ -1,22 +1,21 @@
 <template>
-  <td>{{ localMemoryTracker.spelling ? 'spelling' : 'normal' }}</td>
-  <td>
-    <span class="statistics-value">{{ localMemoryTracker.repetitionCount }}</span>
-    <div class="alert alert-danger" v-if="localMemoryTracker.removedFromTracking">
-      This memory tracker has been removed from tracking.
-    </div>
+  <td :class="{ 'strikethrough': isSkipped }">
+    {{ localMemoryTracker.spelling ? 'spelling' : 'normal' }}
   </td>
-  <td>
+  <td :class="{ 'strikethrough': isSkipped }">
+    <span class="statistics-value">{{ localMemoryTracker.repetitionCount }}</span>
+  </td>
+  <td :class="{ 'strikethrough': isSkipped }">
     <span class="statistics-value">{{ localMemoryTracker.forgettingCurveIndex }}</span>
   </td>
-  <td>
+  <td :class="{ 'strikethrough': isSkipped }">
     <span class="statistics-value">{{ new Date(localMemoryTracker.nextRecallAt).toLocaleString() }}</span>
   </td>
 </template>
 
 <script setup lang="ts">
 import type { PropType } from "vue"
-import { ref, watch } from "vue"
+import { ref, watch, computed } from "vue"
 import type { MemoryTracker } from "@generated/backend"
 
 const props = defineProps({
@@ -30,6 +29,10 @@ const emit = defineEmits(["update:modelValue"])
 
 const localMemoryTracker = ref<MemoryTracker>(props.modelValue)
 
+const isSkipped = computed(
+  () => localMemoryTracker.value.removedFromTracking === true
+)
+
 watch(
   () => props.modelValue,
   (newVal) => {
@@ -38,3 +41,10 @@ watch(
   { immediate: true }
 )
 </script>
+
+<style lang="scss" scoped>
+.strikethrough {
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+</style>

--- a/frontend/tests/components/notes/NoteInfoComponent.spec.ts
+++ b/frontend/tests/components/notes/NoteInfoComponent.spec.ts
@@ -1,0 +1,109 @@
+import NoteInfoComponent from "@/components/notes/NoteInfoComponent.vue"
+import { flushPromises } from "@vue/test-utils"
+import helper from "@tests/helpers"
+import makeMe from "@tests/fixtures/makeMe"
+import type { NoteInfo } from "@generated/backend"
+
+describe("NoteInfoComponent", () => {
+  it("should display all memory trackers including skipped ones", () => {
+    const noteInfo: NoteInfo = {
+      memoryTrackers: [
+        makeMe.aMemoryTracker
+          .removedFromTracking(false)
+          .repetitionCount(5)
+          .please(),
+        makeMe.aMemoryTracker
+          .removedFromTracking(true)
+          .repetitionCount(3)
+          .please(),
+      ],
+      note: makeMe.aNoteRealm.please(),
+      createdAt: "",
+    }
+
+    const wrapper = helper
+      .component(NoteInfoComponent)
+      .withProps({
+        noteInfo,
+      })
+      .withRouter()
+      .mount()
+
+    const rows = wrapper.findAll("tbody tr")
+    expect(rows).toHaveLength(2)
+  })
+
+  it("should make skipped memory trackers clickable", async () => {
+    const skippedMemoryTracker = makeMe.aMemoryTracker
+      .removedFromTracking(true)
+      .please()
+    skippedMemoryTracker.id = 123
+
+    const noteInfo: NoteInfo = {
+      memoryTrackers: [skippedMemoryTracker],
+      note: makeMe.aNoteRealm.please(),
+      createdAt: "",
+    }
+
+    const wrapper = helper
+      .component(NoteInfoComponent)
+      .withProps({
+        noteInfo,
+      })
+      .withRouter()
+      .mount()
+
+    await flushPromises()
+
+    const row = wrapper.find("tbody tr")
+    expect(row?.classes()).toContain("clickable-row")
+
+    await row?.trigger("click")
+    await flushPromises()
+
+    expect(wrapper.vm.$router.currentRoute.value.name).toBe("memoryTrackerShow")
+    expect(wrapper.vm.$router.currentRoute.value.params.memoryTrackerId).toBe(
+      "123"
+    )
+  })
+
+  it("should display memory trackers table when there are memory trackers", () => {
+    const noteInfo: NoteInfo = {
+      memoryTrackers: [makeMe.aMemoryTracker.please()],
+      note: makeMe.aNoteRealm.please(),
+      createdAt: "",
+    }
+
+    const wrapper = helper
+      .component(NoteInfoComponent)
+      .withProps({
+        noteInfo,
+      })
+      .withRouter()
+      .mount()
+
+    expect(wrapper.find("table").exists()).toBe(true)
+    const h6Elements = wrapper.findAll("h6")
+    expect(h6Elements.some((h6) => h6.text().includes("Memory Trackers"))).toBe(
+      true
+    )
+  })
+
+  it("should not display memory trackers table when there are no memory trackers", () => {
+    const noteInfo: NoteInfo = {
+      memoryTrackers: [],
+      note: makeMe.aNoteRealm.please(),
+      createdAt: "",
+    }
+
+    const wrapper = helper
+      .component(NoteInfoComponent)
+      .withProps({
+        noteInfo,
+      })
+      .withRouter()
+      .mount()
+
+    expect(wrapper.find("table").exists()).toBe(false)
+  })
+})

--- a/frontend/tests/components/notes/NoteInfoMemoryTracker.spec.ts
+++ b/frontend/tests/components/notes/NoteInfoMemoryTracker.spec.ts
@@ -1,0 +1,77 @@
+import NoteInfoMemoryTracker from "@/components/notes/NoteInfoMemoryTracker.vue"
+import helper from "@tests/helpers"
+import makeMe from "@tests/fixtures/makeMe"
+
+describe("NoteInfoMemoryTracker", () => {
+  it("should display memory tracker information", () => {
+    const memoryTracker = makeMe.aMemoryTracker
+      .repetitionCount(5)
+      .forgettingCurveIndex(3)
+      .nextRecallAt("2024-01-01T12:00:00Z")
+      .removedFromTracking(false)
+      .please()
+
+    const wrapper = helper
+      .component(NoteInfoMemoryTracker)
+      .withProps({
+        modelValue: memoryTracker,
+      })
+      .mount()
+
+    expect(wrapper.text()).toContain("normal")
+    expect(wrapper.text()).toContain("5")
+    expect(wrapper.text()).toContain("3")
+  })
+
+  it("should display spelling memory tracker", () => {
+    const memoryTracker = makeMe.aMemoryTracker
+      .removedFromTracking(false)
+      .please()
+    memoryTracker.spelling = true
+
+    const wrapper = helper
+      .component(NoteInfoMemoryTracker)
+      .withProps({
+        modelValue: memoryTracker,
+      })
+      .mount()
+
+    expect(wrapper.text()).toContain("spelling")
+  })
+
+  it("should apply strikethrough styling to skipped memory trackers", () => {
+    const memoryTracker = makeMe.aMemoryTracker
+      .removedFromTracking(true)
+      .please()
+
+    const wrapper = helper
+      .component(NoteInfoMemoryTracker)
+      .withProps({
+        modelValue: memoryTracker,
+      })
+      .mount()
+
+    const cells = wrapper.findAll("td")
+    cells.forEach((cell) => {
+      expect(cell.classes()).toContain("strikethrough")
+    })
+  })
+
+  it("should not apply strikethrough styling to active memory trackers", () => {
+    const memoryTracker = makeMe.aMemoryTracker
+      .removedFromTracking(false)
+      .please()
+
+    const wrapper = helper
+      .component(NoteInfoMemoryTracker)
+      .withProps({
+        modelValue: memoryTracker,
+      })
+      .mount()
+
+    const cells = wrapper.findAll("td")
+    cells.forEach((cell) => {
+      expect(cell.classes()).not.toContain("strikethrough")
+    })
+  })
+})


### PR DESCRIPTION
Display skipped memory trackers in NoteInfoMemoryTracker with strikeout styling and maintain clickability to provide a complete view of all associated trackers.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764715572274329?thread_ts=1764715572.274329&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-7a301f6c-b2c6-41fc-b994-135838a34642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a301f6c-b2c6-41fc-b994-135838a34642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

