### PR TITLE
Adjust content loader layout

### DIFF
--- a/frontend/src/components/commons/LoadingThinBar.vue
+++ b/frontend/src/components/commons/LoadingThinBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="toolbar-overlap loading-bar">
-    <ContentLoader :height="15" :speed="2" primary-color="#888"></ContentLoader>
+    <ContentLoader :height="2" :speed="2" primary-color="#888"></ContentLoader>
   </div>
 </template>
 
@@ -13,8 +13,9 @@ import { ContentLoader } from "vue-content-loader"
   position: fixed;
   left: 0;
   top: 0;
-  width: 100%;
-  height: 5px;
+  right: 0;
+  width: 100vw;
+  height: 2px;
   z-index: 2147483647;
 
   svg {


### PR DESCRIPTION
Make the `LoadingThinBar` component full width and thinner to improve its visual presentation in the `DoughnutApp` layout.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764721481662659?thread_ts=1764721481.662659&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-a665f8f9-995b-47dc-9780-1ffc61105008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a665f8f9-995b-47dc-9780-1ffc61105008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

