### PR TITLE
Add spelling question type and update endpoints

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/dto/AnswerSpellingDTO.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/dto/AnswerSpellingDTO.java
@@ -6,4 +6,5 @@ import lombok.Setter;
 public class AnswerSpellingDTO {
   @Getter @Setter private String spellingAnswer;
   @Getter @Setter private Integer thinkingTimeMs;
+  @Getter @Setter private Integer recallPromptId;
 }

--- a/backend/src/main/java/com/odde/doughnut/entities/QuestionType.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/QuestionType.java
@@ -1,5 +1,6 @@
 package com.odde.doughnut.entities;
 
 public enum QuestionType {
-  MCQ
+  MCQ,
+  SPELLING
 }

--- a/backend/src/main/java/com/odde/doughnut/entities/RecallPrompt.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/RecallPrompt.java
@@ -20,6 +20,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = false)
 @JsonPropertyOrder({
   "id",
+  "questionType",
   "multipleChoicesQuestion",
   "notebook",
   "note",
@@ -44,7 +45,7 @@ public class RecallPrompt extends EntityIdentifiedByIdOnly {
   @Enumerated(EnumType.STRING)
   @Column(name = "question_type")
   @NotNull
-  @JsonIgnore
+  @JsonProperty
   private QuestionType questionType;
 
   public Notebook getNotebook() {

--- a/frontend/src/pages/MemoryTrackerPageView.vue
+++ b/frontend/src/pages/MemoryTrackerPageView.vue
@@ -107,8 +107,11 @@
               Thinking time: {{ formatThinkingTime(prompt.answer.thinkingTimeMs) }}
             </span>
           </div>
+          <div v-if="prompt.questionType === 'SPELLING'" class="daisy-alert daisy-alert-info">
+            This is a spelling question. Details are not needed.
+          </div>
           <QuestionDisplay
-            v-if="prompt.predefinedQuestion && prompt.answer"
+            v-else-if="prompt.predefinedQuestion && prompt.answer"
             v-bind="{
               multipleChoicesQuestion: prompt.predefinedQuestion.multipleChoicesQuestion,
               correctChoiceIndex: prompt.predefinedQuestion.correctAnswerIndex,

--- a/frontend/tests/fixtures/AssessmentAttemptBuilder.ts
+++ b/frontend/tests/fixtures/AssessmentAttemptBuilder.ts
@@ -20,7 +20,10 @@ class AssessmentAttemptBuilder extends Builder<AssessmentAttempt> {
     this.data.assessmentQuestionInstances = questions.map((question) => ({
       id: question.id,
       multipleChoicesQuestion: question.multipleChoicesQuestion,
-      recallPrompt: question,
+      recallPrompt: {
+        ...question,
+        questionType: question.questionType ?? "MCQ",
+      },
     }))
     return this
   }

--- a/frontend/tests/fixtures/RecallPromptBuilder.ts
+++ b/frontend/tests/fixtures/RecallPromptBuilder.ts
@@ -17,6 +17,7 @@ class RecallPromptBuilder extends Builder<RecallPrompt> {
   private answerTimeToUse?: string
   private questionGeneratedTimeToUse?: string
   private isContestedToUse?: boolean
+  private questionTypeToUse?: string
 
   withQuestionStem(stem: string) {
     this.predefinedQuestionBuilder.withQuestionStem(stem)
@@ -58,11 +59,17 @@ class RecallPromptBuilder extends Builder<RecallPrompt> {
     return this
   }
 
+  withQuestionType(questionType: string) {
+    this.questionTypeToUse = questionType
+    return this
+  }
+
   do(): RecallPrompt {
     const predefinedQuestion =
       this.predefinedQuestionToUse ?? this.predefinedQuestionBuilder.do()
     return {
       id: generateId(),
+      questionType: (this.questionTypeToUse ?? "MCQ") as "MCQ" | "SPELLING",
       multipleChoicesQuestion: predefinedQuestion.multipleChoicesQuestion,
       notebook: new NotebookBuilder().do(),
       note: this.noteToUse,

--- a/frontend/tests/pages/AssessmentPage.spec.ts
+++ b/frontend/tests/pages/AssessmentPage.spec.ts
@@ -4,7 +4,10 @@ import AssessmentPage from "@/pages/AssessmentPage.vue"
 import helper, { mockSdkService, wrapSdkResponse } from "@tests/helpers"
 import makeMe from "@tests/fixtures/makeMe"
 import { flushPromises } from "@vue/test-utils"
-import type { AssessmentQuestionInstance } from "@generated/backend"
+import type {
+  AssessmentQuestionInstance,
+  RecallPrompt,
+} from "@generated/backend"
 
 vitest.mock("vue-router", () => ({
   useRouter: () => ({
@@ -19,9 +22,13 @@ describe("assessment page", () => {
     const notebook = makeMe.aNotebook.please()
     const assessmentQuestionInstance =
       makeMe.anAssessmentQuestionInstance.please()
+    const recallPrompt: RecallPrompt = {
+      ...assessmentQuestionInstance,
+      questionType: "MCQ",
+    }
     const assessmentAttempt = makeMe.anAssessmentAttempt
       .forNotebook(notebook)
-      .withQuestions([assessmentQuestionInstance])
+      .withQuestions([recallPrompt])
       .please()
     let generateAssessmentQuestionsSpy: ReturnType<
       typeof mockSdkService<"generateAssessmentQuestions">
@@ -72,16 +79,26 @@ describe("assessment page", () => {
       .withChoices(["answer3", "answer4"])
       .please()
     const answerResult1: AssessmentQuestionInstance = {
-      ...quizQuestion_1,
+      id: quizQuestion_1.id,
+      multipleChoicesQuestion: quizQuestion_1.multipleChoicesQuestion,
       answer: { id: 1, correct: true, choiceIndex: 0 },
     }
     const answerResult2: AssessmentQuestionInstance = {
-      ...quizQuestion_2,
+      id: quizQuestion_2.id,
+      multipleChoicesQuestion: quizQuestion_2.multipleChoicesQuestion,
       answer: { id: 1, correct: true, choiceIndex: 0 },
+    }
+    const recallPrompt1: RecallPrompt = {
+      ...quizQuestion_1,
+      questionType: "MCQ",
+    }
+    const recallPrompt2: RecallPrompt = {
+      ...quizQuestion_2,
+      questionType: "MCQ",
     }
     const assessmentAttempt = makeMe.anAssessmentAttempt
       .forNotebook(notebook)
-      .withQuestions([quizQuestion_1, quizQuestion_2])
+      .withQuestions([recallPrompt1, recallPrompt2])
       .please()
     let answerQuestionSpy: ReturnType<typeof mockSdkService<"answerQuestion">>
     let submitAssessmentResultSpy: ReturnType<

--- a/frontend/tests/pages/MemoryTrackerPageView.spec.ts
+++ b/frontend/tests/pages/MemoryTrackerPageView.spec.ts
@@ -516,4 +516,51 @@ describe("MemoryTrackerPageView", () => {
       expect(reEnableButton.exists()).toBe(false)
     })
   })
+
+  describe("spelling question type", () => {
+    it("displays spelling question message when question type is SPELLING", async () => {
+      const memoryTracker = makeMe.aMemoryTracker.please()
+      const spellingPrompt = makeMe.aRecallPrompt
+        .withQuestionType("SPELLING")
+        .please()
+
+      const wrapper = helper
+        .component(MemoryTrackerPageView)
+        .withProps({
+          recallPrompts: [spellingPrompt],
+          memoryTracker,
+          memoryTrackerId: 1,
+        })
+        .mount()
+
+      await flushPromises()
+
+      expect(wrapper.text()).toContain(
+        "This is a spelling question. Details are not needed."
+      )
+    })
+
+    it("does not display question details for spelling questions", async () => {
+      const memoryTracker = makeMe.aMemoryTracker.please()
+      const spellingPrompt = makeMe.aRecallPrompt
+        .withQuestionType("SPELLING")
+        .please()
+
+      const wrapper = helper
+        .component(MemoryTrackerPageView)
+        .withProps({
+          recallPrompts: [spellingPrompt],
+          memoryTracker,
+          memoryTrackerId: 1,
+        })
+        .mount()
+
+      await flushPromises()
+
+      // Should not display multiple choice question
+      expect(wrapper.findComponent({ name: "QuestionDisplay" }).exists()).toBe(
+        false
+      )
+    })
+  })
 })

--- a/generated/backend/types.gen.ts
+++ b/generated/backend/types.gen.ts
@@ -178,6 +178,7 @@ export type Answer = {
 
 export type RecallPrompt = {
     id: number;
+    questionType: 'MCQ' | 'SPELLING';
     multipleChoicesQuestion?: MultipleChoicesQuestion;
     notebook?: Notebook;
     note?: Note;
@@ -283,6 +284,7 @@ export type MemoryTracker = {
 export type AnswerSpellingDto = {
     spellingAnswer?: string;
     thinkingTimeMs?: number;
+    recallPromptId?: number;
 };
 
 export type SpellingResultDto = {
@@ -551,11 +553,6 @@ export type NotebookCertificateApprovalDto = {
     approval?: NotebookCertificateApproval;
 };
 
-export type SpellingQuestion = {
-    stem?: string;
-    notebook?: Notebook;
-};
-
 export type FailureReport = {
     id?: number;
     errorName: string;
@@ -629,6 +626,7 @@ export type SubscriptionWritable = {
 
 export type RecallPromptWritable = {
     id: number;
+    questionType: 'MCQ' | 'SPELLING';
     multipleChoicesQuestion?: MultipleChoicesQuestion;
     notebook?: Notebook;
     note?: NoteWritable;
@@ -3753,7 +3751,7 @@ export type GetSpellingQuestionResponses = {
     /**
      * OK
      */
-    200: SpellingQuestion;
+    200: RecallPrompt;
 };
 
 export type GetSpellingQuestionResponse = GetSpellingQuestionResponses[keyof GetSpellingQuestionResponses];

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -2933,7 +2933,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/SpellingQuestion"
+                $ref: "#/components/schemas/RecallPrompt"
   /api/memory-trackers/{memoryTracker}/recall-prompts:
     get:
       tags:
@@ -3782,6 +3782,11 @@ components:
         id:
           type: integer
           format: int32
+        questionType:
+          type: string
+          enum:
+          - MCQ
+          - SPELLING
         multipleChoicesQuestion:
           $ref: "#/components/schemas/MultipleChoicesQuestion"
         notebook:
@@ -3802,6 +3807,7 @@ components:
           $ref: "#/components/schemas/Answer"
       required:
       - id
+      - questionType
     AnswerDTO:
       type: object
       properties:
@@ -4005,6 +4011,9 @@ components:
         spellingAnswer:
           type: string
         thinkingTimeMs:
+          type: integer
+          format: int32
+        recallPromptId:
           type: integer
           format: int32
     SpellingResultDTO:
@@ -4591,13 +4600,6 @@ components:
       properties:
         approval:
           $ref: "#/components/schemas/NotebookCertificateApproval"
-    SpellingQuestion:
-      type: object
-      properties:
-        stem:
-          type: string
-        notebook:
-          $ref: "#/components/schemas/Notebook"
     FailureReport:
       type: object
       properties:


### PR DESCRIPTION
Add a new 'spelling' question type to `RecallPrompt` and integrate it into the memory tracker system to enable spelling practice.

---
<a href="https://cursor.com/background-agent?bcId=bc-7055253e-e21c-4954-b01f-9279febb0df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7055253e-e21c-4954-b01f-9279febb0df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

