### PR TITLE
Fix frontend tests and update e2e tests

### DIFF
--- a/frontend/src/components/review/Quiz.vue
+++ b/frontend/src/components/review/Quiz.vue
@@ -186,6 +186,7 @@ const onSpellingAnswer = async (answerData: AnswerSpellingDto) => {
       body: {
         spellingAnswer: answerData.spellingAnswer!,
         thinkingTimeMs: answerData.thinkingTimeMs,
+        recallPromptId: answerData.recallPromptId,
       },
     })
   )


### PR DESCRIPTION
Update spelling question handling to use `RecallPrompt` and include `recallPromptId` in API calls, fixing frontend tests broken by a recent refactor.

Commit 22d51349fd80ff278d1b038c0e8f67b576bf78b3 refactored spelling questions to be based on the more generic `RecallPrompt` type, which introduced the `recallPromptId`. This PR updates the frontend components and their tests to correctly handle this new data structure and pass the `recallPromptId` in API requests, ensuring proper functionality and test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-7efd940e-71f8-4987-bf12-606afb53b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7efd940e-71f8-4987-bf12-606afb53b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

