### PR TITLE
Implement spelling answer functionality for memory tracker

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/Answer.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/Answer.java
@@ -31,6 +31,10 @@ public class Answer extends EntityIdentifiedByIdOnly {
   @Setter
   private Integer thinkingTimeMs;
 
+  @Column(name = "spelling_answer")
+  @Setter
+  private String spellingAnswer;
+
   @JsonIgnore
   String getAnswerDisplay(@NotNull MultipleChoicesQuestion bareQuestion) {
     if (getChoiceIndex() != null) {

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -3,6 +3,7 @@ package com.odde.doughnut.services;
 import com.odde.doughnut.controllers.dto.AnswerSpellingDTO;
 import com.odde.doughnut.controllers.dto.InitialInfo;
 import com.odde.doughnut.controllers.dto.SpellingResultDTO;
+import com.odde.doughnut.entities.Answer;
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.QuestionType;
@@ -149,10 +150,21 @@ public class MemoryTrackerService {
     if (recallPrompt.getQuestionType() != QuestionType.SPELLING) {
       throw new IllegalArgumentException("Recall prompt must be of type SPELLING");
     }
+    if (recallPrompt.getAnswer() != null) {
+      throw new IllegalArgumentException("Recall prompt is already answered");
+    }
     MemoryTracker memoryTracker = recallPrompt.getMemoryTracker();
     String spellingAnswer = answerSpellingDTO.getSpellingAnswer();
     Note note = memoryTracker.getNote();
     Boolean correct = note.matchAnswer(spellingAnswer);
+
+    Answer answer = new Answer();
+    answer.setSpellingAnswer(spellingAnswer);
+    answer.setCorrect(correct);
+    answer.setThinkingTimeMs(answerSpellingDTO.getThinkingTimeMs());
+    recallPrompt.setAnswer(answer);
+    entityPersister.save(recallPrompt);
+
     markAsRepeated(currentUTCTimestamp, correct, memoryTracker);
     return new SpellingResultDTO(note, spellingAnswer, correct, memoryTracker.getId());
   }

--- a/backend/src/main/resources/db/migration/V300000107__add_spelling_answer_to_quiz_answer.sql
+++ b/backend/src/main/resources/db/migration/V300000107__add_spelling_answer_to_quiz_answer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `quiz_answer` ADD COLUMN `spelling_answer` VARCHAR(255) NULL;

--- a/frontend/src/pages/MemoryTrackerPageView.vue
+++ b/frontend/src/pages/MemoryTrackerPageView.vue
@@ -107,8 +107,28 @@
               Thinking time: {{ formatThinkingTime(prompt.answer.thinkingTimeMs) }}
             </span>
           </div>
-          <div v-if="prompt.questionType === 'SPELLING'" class="daisy-alert daisy-alert-info">
-            This is a spelling question. Details are not needed.
+          <div v-if="prompt.questionType === 'SPELLING'">
+            <div v-if="prompt.answer" class="daisy-space-y-2">
+              <div class="daisy-flex daisy-items-center daisy-gap-2">
+                <span class="daisy-font-semibold">Your answer:</span>
+                <span>{{ prompt.answer.spellingAnswer }}</span>
+              </div>
+              <div class="daisy-flex daisy-items-center daisy-gap-2">
+                <span class="daisy-font-semibold">Result:</span>
+                <span
+                  :class="{
+                    'daisy-badge-success': prompt.answer.correct,
+                    'daisy-badge-error': !prompt.answer.correct,
+                  }"
+                  class="daisy-badge"
+                >
+                  {{ prompt.answer.correct ? 'Correct' : 'Incorrect' }}
+                </span>
+              </div>
+            </div>
+            <div v-else class="daisy-alert daisy-alert-info">
+              This is a spelling question. Details are not needed.
+            </div>
           </div>
           <QuestionDisplay
             v-else-if="prompt.predefinedQuestion && prompt.answer"

--- a/frontend/tests/pages/MemoryTrackerPageView.spec.ts
+++ b/frontend/tests/pages/MemoryTrackerPageView.spec.ts
@@ -518,7 +518,7 @@ describe("MemoryTrackerPageView", () => {
   })
 
   describe("spelling question type", () => {
-    it("displays spelling question message when question type is SPELLING", async () => {
+    it("displays spelling question message when question type is SPELLING and unanswered", async () => {
       const memoryTracker = makeMe.aMemoryTracker.please()
       const spellingPrompt = makeMe.aRecallPrompt
         .withQuestionType("SPELLING")
@@ -538,6 +538,71 @@ describe("MemoryTrackerPageView", () => {
       expect(wrapper.text()).toContain(
         "This is a spelling question. Details are not needed."
       )
+    })
+
+    it("displays spelling answer information when answered correctly", async () => {
+      const memoryTracker = makeMe.aMemoryTracker.please()
+      const spellingPrompt = makeMe.aRecallPrompt
+        .withQuestionType("SPELLING")
+        .withAnswer({
+          id: 1,
+          spellingAnswer: "Sedition",
+          correct: true,
+          thinkingTimeMs: 3000,
+        })
+        .withAnswerTime(new Date().toISOString())
+        .please()
+
+      const wrapper = helper
+        .component(MemoryTrackerPageView)
+        .withProps({
+          recallPrompts: [spellingPrompt],
+          memoryTracker,
+          memoryTrackerId: 1,
+        })
+        .mount()
+
+      await flushPromises()
+
+      expect(wrapper.text()).toContain("Your answer:")
+      expect(wrapper.text()).toContain("Sedition")
+      expect(wrapper.text()).toContain("Result:")
+      expect(wrapper.text()).toContain("Correct")
+      expect(wrapper.text()).toContain("Thinking time: 3.0s")
+      expect(wrapper.text()).not.toContain(
+        "This is a spelling question. Details are not needed."
+      )
+    })
+
+    it("displays spelling answer information when answered incorrectly", async () => {
+      const memoryTracker = makeMe.aMemoryTracker.please()
+      const spellingPrompt = makeMe.aRecallPrompt
+        .withQuestionType("SPELLING")
+        .withAnswer({
+          id: 1,
+          spellingAnswer: "asdf",
+          correct: false,
+          thinkingTimeMs: 1500,
+        })
+        .withAnswerTime(new Date().toISOString())
+        .please()
+
+      const wrapper = helper
+        .component(MemoryTrackerPageView)
+        .withProps({
+          recallPrompts: [spellingPrompt],
+          memoryTracker,
+          memoryTrackerId: 1,
+        })
+        .mount()
+
+      await flushPromises()
+
+      expect(wrapper.text()).toContain("Your answer:")
+      expect(wrapper.text()).toContain("asdf")
+      expect(wrapper.text()).toContain("Result:")
+      expect(wrapper.text()).toContain("Incorrect")
+      expect(wrapper.text()).toContain("Thinking time: 1.5s")
     })
 
     it("does not display question details for spelling questions", async () => {

--- a/generated/backend/types.gen.ts
+++ b/generated/backend/types.gen.ts
@@ -174,6 +174,7 @@ export type Answer = {
     choiceIndex?: number;
     correct: boolean;
     thinkingTimeMs?: number;
+    spellingAnswer?: string;
 };
 
 export type RecallPrompt = {

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -3773,6 +3773,8 @@ components:
         thinkingTimeMs:
           type: integer
           format: int32
+        spellingAnswer:
+          type: string
       required:
       - correct
       - id


### PR DESCRIPTION
Add `spelling_answer` to the `Answer` entity and update the frontend to display the user's spelling answer, correctness, and thinking time for answered spelling questions.

This change allows the system to store the user's input for spelling questions and provides immediate feedback on the `MemoryTrackerPageView` by showing what the user answered and if it was correct, along with other relevant details.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e672b4d-1273-4268-8ab7-ae56fcd9bd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e672b4d-1273-4268-8ab7-ae56fcd9bd16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

