### PR TITLE
Update and test spelling memory tracker

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/RecallPromptRepository.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/RecallPromptRepository.java
@@ -12,10 +12,10 @@ public interface RecallPromptRepository extends CrudRepository<RecallPrompt, Int
   @Query(
       value =
           "SELECT rp.* FROM recall_prompt rp "
-              + "JOIN predefined_question pq ON rp.predefined_question_id = pq.id "
+              + "LEFT JOIN predefined_question pq ON rp.predefined_question_id = pq.id "
               + "WHERE rp.memory_tracker_id = :memoryTrackerId "
               + "AND rp.quiz_answer_id IS NULL "
-              + "AND pq.is_contested = false "
+              + "AND (pq.id IS NULL OR pq.is_contested = false) "
               + "ORDER BY rp.id DESC LIMIT 1",
       nativeQuery = true)
   Optional<RecallPrompt> findUnansweredByMemoryTracker(

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -136,6 +136,13 @@ public class MemoryTrackerService {
   }
 
   public RecallPrompt getSpellingQuestion(MemoryTracker memoryTracker) {
+    // First check if there's an existing unanswered recall prompt for this memory tracker
+    RecallPrompt existingPrompt =
+        recallPromptRepository.findUnansweredByMemoryTracker(memoryTracker.getId()).orElse(null);
+    if (existingPrompt != null && existingPrompt.getQuestionType() == QuestionType.SPELLING) {
+      return existingPrompt;
+    }
+
     RecallPrompt recallPrompt = new RecallPrompt();
     recallPrompt.setMemoryTracker(memoryTracker);
     recallPrompt.setQuestionType(QuestionType.SPELLING);

--- a/backend/src/test/java/com/odde/doughnut/controllers/MemoryTrackerControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/MemoryTrackerControllerTest.java
@@ -54,6 +54,28 @@ class MemoryTrackerControllerTest extends ControllerTestBase {
     }
 
     @Test
+    void shouldRecycleUnansweredSpellingRecallPromptForSpellingMemoryTracker()
+        throws UnexpectedNoAccessRightException {
+      Note note =
+          makeMe
+              .aNote("moon")
+              .details("partner of earth")
+              .creatorAndOwner(currentUser.getUser())
+              .please();
+      MemoryTracker memoryTracker = makeMe.aMemoryTrackerFor(note).spelling().please();
+
+      // Create an unanswered spelling recall prompt
+      RecallPrompt existingPrompt =
+          makeMe.aRecallPrompt().forMemoryTracker(memoryTracker).spelling().please();
+
+      // Ask question again - should return the existing unanswered prompt
+      RecallPrompt recallPrompt = controller.askAQuestion(memoryTracker);
+      assertThat(recallPrompt.getId(), equalTo(existingPrompt.getId()));
+      assertThat(recallPrompt.getQuestionType(), equalTo(QuestionType.SPELLING));
+      assertThat(recallPrompt.getMemoryTracker(), equalTo(memoryTracker));
+    }
+
+    @Test
     void shouldReturnMCQRecallPromptForNonSpellingMemoryTracker()
         throws UnexpectedNoAccessRightException {
       Note note =


### PR DESCRIPTION
Recycle unanswered recall prompts for spelling memory trackers to ensure consistent question generation behavior.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764760363784689?thread_ts=1764760363.784689&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-0b284566-7d6a-4ec4-b189-0ab66b3c9b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b284566-7d6a-4ec4-b189-0ab66b3c9b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

