### PR TITLE
Update recall prompt generation and testing

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/RecallPrompt.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/RecallPrompt.java
@@ -59,6 +59,10 @@ public class RecallPrompt extends EntityIdentifiedByIdOnly {
   @JsonProperty
   private QuestionType questionType;
 
+  @Column(name = "created_at")
+  @JsonIgnore
+  private Timestamp createdAt = new Timestamp(System.currentTimeMillis());
+
   public Notebook getNotebook() {
     if (getPredefinedQuestion() == null) {
       return null;
@@ -129,10 +133,7 @@ public class RecallPrompt extends EntityIdentifiedByIdOnly {
 
   @JsonProperty
   public Timestamp getQuestionGeneratedTime() {
-    if (getPredefinedQuestion() == null) {
-      return null;
-    }
-    return getPredefinedQuestion().getCreatedAt();
+    return getCreatedAt();
   }
 
   @JsonProperty

--- a/backend/src/main/resources/db/migration/V300000108__add_created_at_to_recall_prompt.sql
+++ b/backend/src/main/resources/db/migration/V300000108__add_created_at_to_recall_prompt.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `recall_prompt` ADD COLUMN `created_at` timestamp(3) NULL DEFAULT NULL;
+
+-- Set created_at for existing records based on predefined_question's created_at if available
+UPDATE `recall_prompt` rp
+INNER JOIN `predefined_question` pq ON rp.`predefined_question_id` = pq.`id`
+SET rp.`created_at` = pq.`created_at`
+WHERE rp.`created_at` IS NULL;
+
+-- For records without predefined_question, set to current timestamp
+UPDATE `recall_prompt`
+SET `created_at` = CURRENT_TIMESTAMP(3)
+WHERE `created_at` IS NULL;

--- a/backend/src/test/java/com/odde/doughnut/entities/RecallPromptTest.java
+++ b/backend/src/test/java/com/odde/doughnut/entities/RecallPromptTest.java
@@ -56,4 +56,35 @@ class RecallPromptTest {
       assertThat(spellingQuestion, nullValue());
     }
   }
+
+  @Nested
+  class GetQuestionGeneratedTime {
+    @Test
+    void shouldReturnRecallPromptCreatedAtForMCQ() {
+      java.sql.Timestamp createdAt = new java.sql.Timestamp(System.currentTimeMillis());
+      RecallPrompt recallPrompt = new RecallPrompt();
+      recallPrompt.setQuestionType(QuestionType.MCQ);
+      recallPrompt.setMemoryTracker(memoryTracker);
+      recallPrompt.setCreatedAt(createdAt);
+      recallPrompt.setPredefinedQuestion(
+          makeMe.aPredefinedQuestion().ofAIGeneratedQuestionForNote(note).please());
+
+      java.sql.Timestamp questionGeneratedTime = recallPrompt.getQuestionGeneratedTime();
+
+      assertThat(questionGeneratedTime, equalTo(createdAt));
+    }
+
+    @Test
+    void shouldReturnRecallPromptCreatedAtForSpelling() {
+      java.sql.Timestamp createdAt = new java.sql.Timestamp(System.currentTimeMillis());
+      RecallPrompt recallPrompt = new RecallPrompt();
+      recallPrompt.setQuestionType(QuestionType.SPELLING);
+      recallPrompt.setMemoryTracker(memoryTracker);
+      recallPrompt.setCreatedAt(createdAt);
+
+      java.sql.Timestamp questionGeneratedTime = recallPrompt.getQuestionGeneratedTime();
+
+      assertThat(questionGeneratedTime, equalTo(createdAt));
+    }
+  }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Use `RecallPrompt.createdAt` for `questionGeneratedTime` to ensure both MCQ and spelling recall prompts consistently have a generated time.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, spelling recall prompts without an associated `PredefinedQuestion` would not have a `questionGeneratedTime`. This change adds a `createdAt` field directly to `RecallPrompt` and uses it, providing a generated time for all recall prompt types.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764760518554699?thread_ts=1764760518.554699&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-8cb51021-5e49-4cb4-a46a-6ac3a089d521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cb51021-5e49-4cb4-a46a-6ac3a089d521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

