### PR TITLE
Fix flaky note graph service test in parallel

### DIFF
--- a/backend/src/test/java/com/odde/doughnut/services/NoteGraphServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/NoteGraphServiceTest.java
@@ -719,6 +719,11 @@ public class NoteGraphServiceTest {
           makeMe.aNote().under(grandParent).titleConstructor("Parent Sibling 1").please();
       parentSibling2 =
           makeMe.aNote().under(grandParent).titleConstructor("Parent Sibling 2").please();
+      // Refresh entities to ensure all relationships and children are loaded in the persistence
+      // context
+      // This prevents race conditions when tests run in parallel
+      makeMe.refresh(grandParent);
+      makeMe.refresh(parent);
       focusNote = makeMe.aNote().under(parent).titleConstructor("Focus Note").please();
     }
 


### PR DESCRIPTION
Refresh `grandParent` and `parent` entities in `NoteGraphServiceTest` to fix a flaky test.

The test `shouldIncludeParentSiblingsInRelatedNotes()` was failing intermittently in parallel due to a stale children collection on the `grandParent` entity, leading to a race condition where not all parent siblings were found. Refreshing the entities ensures the persistence context is up-to-date.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764763651577299?thread_ts=1764763651.577299&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-8a9c18a0-3d95-417d-8ac4-e2148452028b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a9c18a0-3d95-417d-8ac4-e2148452028b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

