### PR TITLE
Disable flaky note graph test

### DIFF
--- a/backend/src/test/java/com/odde/doughnut/services/NoteGraphServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/NoteGraphServiceTest.java
@@ -728,6 +728,7 @@ public class NoteGraphServiceTest {
     }
 
     @Test
+    @Disabled("Flaky test")
     void shouldIncludeParentSiblingsInRelatedNotes() {
       GraphRAGResult result = noteGraphService.retrieve(focusNote, 1000);
 


### PR DESCRIPTION
Disable flaky test `NoteGraphServiceTest.shouldIncludeParentSiblingsInRelatedNotes()`.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764765169581529?thread_ts=1764765169.581529&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-0b95cabd-7da2-479a-971e-63d0511d5428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b95cabd-7da2-479a-971e-63d0511d5428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

