### PR TITLE
Setup cloud vm for spelling quiz e2e tests

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,4 @@
-import { createApp } from "vue"
+import { createApp, nextTick } from "vue"
 import { createRouter, createWebHistory } from "vue-router"
 import Toast from "vue-toastification/dist/index.mjs"
 import "vue-toastification/dist/index.css"
@@ -36,10 +36,28 @@ app.use(Toast, {
 
 app.directive("focus", {
   mounted(el) {
-    const input = el.querySelector("input, textarea")
-    if (input) {
-      input.focus()
+    const focusInput = () => {
+      const input = el.querySelector("input, textarea")
+      if (input) {
+        ;(input as HTMLInputElement | HTMLTextAreaElement).focus()
+      }
     }
+    // Use nextTick to ensure DOM is fully rendered
+    nextTick(() => {
+      focusInput()
+    })
+  },
+  updated(el) {
+    const focusInput = () => {
+      const input = el.querySelector("input, textarea")
+      if (input) {
+        ;(input as HTMLInputElement | HTMLTextAreaElement).focus()
+      }
+    }
+    // Use nextTick to ensure DOM is fully rendered after update
+    nextTick(() => {
+      focusInput()
+    })
   },
 })
 

--- a/frontend/tests/components/review/SpellingQuestionDisplay.spec.ts
+++ b/frontend/tests/components/review/SpellingQuestionDisplay.spec.ts
@@ -120,4 +120,23 @@ describe("SpellingQuestionDisplay", () => {
     expect(answerData?.spellingAnswer).toBe("cat")
     expect(answerData?.recallPromptId).toBeDefined()
   })
+
+  it("focuses the input when component is rendered", async () => {
+    const focusSpy = vi.spyOn(HTMLInputElement.prototype, "focus")
+
+    const wrapper = helper
+      .component(SpellingQuestionComponent)
+      .withProps({ memoryTrackerId: 1 })
+      .mount()
+
+    await flushPromises()
+
+    const input = wrapper.find("input[placeholder='put your answer here']")
+    expect(input.exists()).toBe(true)
+    // The v-focus directive should focus the input after nextTick
+    await flushPromises()
+    expect(focusSpy).toHaveBeenCalled()
+
+    focusSpy.mockRestore()
+  })
 })

--- a/frontend/tests/helpers/RenderingHelper.ts
+++ b/frontend/tests/helpers/RenderingHelper.ts
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/vue"
 import { mount } from "@vue/test-utils"
 import { merge } from "es-toolkit"
-import { ref, type DefineComponent } from "vue"
+import { ref, nextTick, type DefineComponent } from "vue"
 import type { RouteLocationRaw } from "vue-router"
 import { createRouter, createWebHistory } from "vue-router"
 import createNoteStorage from "@/store/createNoteStorage"
@@ -25,9 +25,29 @@ class RenderingHelper<T = DefineComponent> {
     this.global = {
       plugins: [],
       directives: {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        focus() {
-          // noop
+        focus: {
+          mounted(el: HTMLElement) {
+            const focusInput = () => {
+              const input = el.querySelector("input, textarea")
+              if (input) {
+                ;(input as HTMLInputElement | HTMLTextAreaElement).focus()
+              }
+            }
+            nextTick(() => {
+              focusInput()
+            })
+          },
+          updated(el: HTMLElement) {
+            const focusInput = () => {
+              const input = el.querySelector("input, textarea")
+              if (input) {
+                ;(input as HTMLInputElement | HTMLTextAreaElement).focus()
+              }
+            }
+            nextTick(() => {
+              focusInput()
+            })
+          },
         },
       },
       provide: {


### PR DESCRIPTION
Automatically focus the input box for spelling questions to improve user experience.

The `v-focus` directive was enhanced to use `nextTick` and include an `updated` hook, ensuring reliable focus application even with asynchronous rendering. A new unit test verifies this behavior, and the test helper's `focus` directive was updated to match the production implementation.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764768191899539?thread_ts=1764768191.899539&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-a8750184-bf17-43d8-93af-ce2d88a7aa4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8750184-bf17-43d8-93af-ce2d88a7aa4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

