### PR TITLE
Update cursor rules for local development

### DIFF
--- a/.cursor/rules/backend-development.mdc
+++ b/.cursor/rules/backend-development.mdc
@@ -17,11 +17,9 @@ alwaysApply: false
 
 ## Run Test in Terminal
 
-**For general command execution details (cloud agent vs local), see the `cloud-agent-setup` rule.**
+**For general command execution details, see the `cloud-agent-setup` rule.**
 
-### Local Development (with Nix)
-
-To run the tests in local development environment with Nix, at the root folder level run command:
+To run the tests at the root folder level:
 
 ```bash
 CURSOR_DEV=true nix develop -c pnpm backend:verify
@@ -32,36 +30,6 @@ or, when there's no db migration needed, run the follow will be faster:
 ```bash
 CURSOR_DEV=true nix develop -c pnpm backend:test_only
 ```
-
-### Cursor Cloud Agent (without Nix)
-
-**IMPORTANT**: When running as a Cursor Cloud Agent (remote environment without Nix), use the setup script first:
-
-```bash
-# One-time setup (installs Java 24 and MySQL)
-source /workspace/scripts/cloud_agent_setup.sh
-
-# Run database migration (required before first test run or after schema changes)
-./backend/gradlew -p backend migrateTestDB -Dspring.profiles.active=test
-
-# Run tests
-./backend/gradlew -p backend test -Dspring.profiles.active=test --build-cache --parallel
-```
-
-The cloud_agent_setup.sh script:
-- Downloads and installs Azul Zulu Java 24 (required by the project)
-- Downloads and sets up MySQL 8.4 server
-- Initializes doughnut test databases
-- Exports necessary environment variables (JAVA_HOME, MYSQL_HOME, SPRING_DATASOURCE_*)
-
-**Environment Details**:
-- Java 24 installed to: `/tmp/java24/zulu24.32.13-ca-jdk24.0.2-linux_x64`
-- MySQL installed to: `/tmp/mysql-8.4.3-linux-glibc2.28-x86_64`
-- MySQL data directory: `/tmp/mysql_data`
-- MySQL socket: `/tmp/mysql.sock`
-- MySQL port: 3306
-
-**Note**: The setup script is idempotent and can be run multiple times safely. It will skip steps that are already completed.
 
 Always run all unit tests instead of just sepected file or test case, unlike for e2e test.
 

--- a/.cursor/rules/e2e_test.mdc
+++ b/.cursor/rules/e2e_test.mdc
@@ -28,16 +28,10 @@ All services automatically restart when code changes are made. The developer doe
 
 ## Run E2E Test in Terminal
 
-**For command execution details (cloud agent vs local), see the `cloud-agent-setup` rule.**
+**For command execution details, see the `cloud-agent-setup` rule.**
 
 We usually don't run all the e2e tests locally, since it will take too much time. To run one feature file:
 
-**Cloud Agent:**
-```bash
-pnpm cypress run --spec e2e_test/features/ai_generated_recall_questions/question_contest.feature
-```
-
-**Local Development:**
 ```bash
 CURSOR_DEV=true nix develop -c pnpm cypress run --spec e2e_test/features/ai_generated_recall_questions/question_contest.feature
 ```

--- a/.cursor/rules/frontend.mdc
+++ b/.cursor/rules/frontend.mdc
@@ -17,16 +17,10 @@ alwaysApply: false
 
 ## Run Test in Terminal
 
-**For command execution details (cloud agent vs local), see the `cloud-agent-setup` rule.**
+**For command execution details, see the `cloud-agent-setup` rule.**
 
 ### Running All Tests
 
-**Cloud Agent:**
-```bash
-pnpm frontend:test
-```
-
-**Local Development:**
 ```bash
 CURSOR_DEV=true nix develop -c pnpm frontend:test
 ```

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -5,9 +5,9 @@ alwaysApply: true
 
 # The use of nix
 
-**CRITICAL: This project uses nix to manage the development environment locally.**
+**CRITICAL: This project uses nix to manage the development environment.**
 
-**YOU MUST ALWAYS prefix commands with `CURSOR_DEV=true nix develop -c` (unless you are on a Cursor Cloud VM):**
+**YOU MUST ALWAYS prefix commands with `CURSOR_DEV=true nix develop -c`:**
 
 **For how to run commands on Cloud VM see the `cloud-agent-setup` rule.**
 
@@ -41,11 +41,10 @@ This command starts:
 
 ## Running Commands in Terminal
 
-**For detailed instructions on running tests and commands (cloud agent vs local development), see the `cloud-agent-setup` rule.**
+**For detailed instructions on running tests and commands, see the `cloud-agent-setup` rule.**
 
 **Quick reference:**
-- **Cloud agents:** Run commands directly without nix prefix (e.g., `pnpm frontend:test`)
-- **Local development:** Always use `CURSOR_DEV=true nix develop -c` prefix (e.g., `CURSOR_DEV=true nix develop -c pnpm frontend:test`)
+- Always use `CURSOR_DEV=true nix develop -c` prefix (e.g., `CURSOR_DEV=true nix develop -c pnpm frontend:test`)
 
 # Development preferences
 

--- a/.cursor/rules/generated-backend-api-code-for-frontend.mdc
+++ b/.cursor/rules/generated-backend-api-code-for-frontend.mdc
@@ -14,14 +14,8 @@ You are a full stack developer who prefer to change backend code and frontend co
 
 When a backend controller signature is changed, or a backend data type that is used by any controller signature is changed, we need to re-generate the backend API call code for frontend.
 
-**For local development:**
 ```bash
 CURSOR_DEV=true nix develop -c pnpm generateTypeScript
-```
-
-**For cloud agents:**
-```bash
-pnpm generateTypeScript
 ```
 
 ## detecting related changed
@@ -42,14 +36,8 @@ When `pnpm openapi:lint` or `pnpm format:all` fails with OpenAPI validation erro
 
 3. **How to Regenerate**:
    
-   **For local development:**
    ```bash
    CURSOR_DEV=true nix develop -c pnpm generateTypeScript
-   ```
-   
-   **For cloud agents:**
-   ```bash
-   pnpm generateTypeScript
    ```
    
    This command:

--- a/.cursor/rules/linting_formating.mdc
+++ b/.cursor/rules/linting_formating.mdc
@@ -27,16 +27,10 @@ This project uses multiple linting tools to ensure code quality:
 
 ## Running Linting
 
-**For command execution details (cloud agent vs local), see the `cloud-agent-setup` rule.**
+**For command execution details, see the `cloud-agent-setup` rule.**
 
 ### Lint All Code
 
-**Cloud Agent:**
-```bash
-pnpm lint:all
-```
-
-**Local Development:**
 ```bash
 CURSOR_DEV=true nix develop -c pnpm lint:all
 ```
@@ -68,8 +62,9 @@ The OpenAPI specification (`open_api_docs.yaml`) is validated using Redocly CLI.
 1. **DO NOT** edit `open_api_docs.yaml` directly - it is auto-generated
 2. **Fix the issue** in the backend Java controller that generates the problematic endpoint
 3. **Regenerate** the OpenAPI spec:
-   - **Cloud Agent**: `pnpm generateTypeScript`
-   - **Local Development**: `CURSOR_DEV=true nix develop -c pnpm generateTypeScript`
+   ```bash
+   CURSOR_DEV=true nix develop -c pnpm generateTypeScript
+   ```
 4. **Verify** by running `pnpm openapi:lint` again
 
 ### Common OpenAPI Issues


### PR DESCRIPTION
Remove cloud VM-specific commands from cursor rules to simplify instructions and centralize cloud agent details in `cloud-agent-setup.mdc`.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764770272899609?thread_ts=1764770272.899609&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-b5e0313d-b4dc-4279-8514-ac44668f6b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5e0313d-b4dc-4279-8514-ac44668f6b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

