### PR TITLE
Aiq question reevaluation during recall

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,6 +49,9 @@ spring:
     token: ${GITHUB_FOR_ISSUES_API_TOKEN:-token_not_set}
   openai:
     token: ${OPENAI_API_TOKEN:-token_not_set}
+question:
+  regeneration:
+    times: 0
 server:
   forward-headers-strategy: FRAMEWORK
   port: 8081
@@ -115,6 +118,9 @@ spring:
     token: ${GITHUB_FOR_ISSUES_API_TOKEN:-token_not_set}
   openai:
     token: ${OPENAI_API_TOKEN:-token_not_set}
+question:
+  regeneration:
+    times: 1
 server:
   forward-headers-strategy: FRAMEWORK
   port: 9081
@@ -187,6 +193,9 @@ spring:
     token: ${GITHUB_FOR_ISSUES_API_TOKEN}
   openai:
     token: ${OPENAI_API_TOKEN}
+question:
+  regeneration:
+    times: 0
 server:
   error:
     include-stacktrace: never
@@ -242,6 +251,9 @@ spring:
     token: ${GITHUB_FOR_ISSUES_API_TOKEN:-token_not_set}
   openai:
     token: ${OPENAI_API_TOKEN:-token_not_set}
+question:
+  regeneration:
+    times: 0
 server:
   forward-headers-strategy: FRAMEWORK
   port: 8081

--- a/backend/src/test/java/com/odde/doughnut/entities/PredefinedQuestionTest.java
+++ b/backend/src/test/java/com/odde/doughnut/entities/PredefinedQuestionTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -30,6 +31,10 @@ class PredefinedQuestionTest {
   @Autowired EntityPersister entityPersister;
   @Autowired PredefinedQuestionService predefinedQuestionService;
   @MockitoBean AiQuestionGenerator aiQuestionGenerator;
+
+  @Value("${question.regeneration.times:1}")
+  int regenerationTimes;
+
   User user;
 
   @BeforeEach
@@ -152,6 +157,6 @@ class PredefinedQuestionTest {
   }
 
   private PredefinedQuestionService createPredefinedQuestionService(EntityPersister persister) {
-    return new PredefinedQuestionService(persister, aiQuestionGenerator);
+    return new PredefinedQuestionService(persister, aiQuestionGenerator, regenerationTimes);
   }
 }

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -4,3 +4,4 @@ logging.level.org.springframework.web=ERROR
 logging.level.org.springframework.test.web.servlet.result=ERROR
 spring.github_for_issues.token=xxx
 spring.openai.token=test_token_for_openai
+question.regeneration.times=1


### PR DESCRIPTION
Make AI question regeneration times configurable to disable auto-contest in production and enable it for testing.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764850528363239?thread_ts=1764850528.363239&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-91e62bf7-66a7-4bf5-9cbd-167cda0b01d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91e62bf7-66a7-4bf5-9cbd-167cda0b01d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

