### PR TITLE
Update recall navigation and menu

### DIFF
--- a/e2e_test/features/recall/browse_answer_and_notes_while_recalling.feature
+++ b/e2e_test/features/recall/browse_answer_and_notes_while_recalling.feature
@@ -33,7 +33,8 @@ Feature: Browse answers and notes while recalling
     And I type my answer "riot"
     And I should see that my spelling answer "riot" is incorrect
     When I visit all my notebooks
-    And I go to the recalls page
+    Then I should see the resume recall menu item
+    And I click resume recall from the menu
     Then I should see that my spelling answer "riot" is incorrect
 
   Scenario: I can remove a note from further recalls

--- a/e2e_test/step_definitions/recall.ts
+++ b/e2e_test/step_definitions/recall.ts
@@ -201,6 +201,14 @@ Then('choose to remove the last memory tracker from recalls', () => {
     .removeMemoryTrackerFromReview('normal')
 })
 
+Then('I should see the resume recall menu item', () => {
+  cy.findByLabelText('Resume Recall').should('exist')
+})
+
+When('I click resume recall from the menu', () => {
+  cy.findByLabelText('Resume Recall').click()
+})
+
 When(
   'I have the true false question {string} rated as a good example',
   (questionStem: string) => {

--- a/frontend/src/components/navigation/NavigationItem.vue
+++ b/frontend/src/components/navigation/NavigationItem.vue
@@ -7,7 +7,7 @@
     }"
   >
     <router-link
-      v-if="name && !hasDropdown"
+      v-if="name && !hasDropdown && name !== 'resumeRecall'"
       :to="{ name: name }"
       :aria-label="label"
       class="daisy-flex daisy-flex-col daisy-items-center"
@@ -20,6 +20,20 @@
       </div>
       <span class="label">{{ label }}</span>
     </router-link>
+    <a
+      v-else-if="name === 'resumeRecall' && !hasDropdown"
+      :aria-label="label"
+      class="daisy-flex daisy-flex-col daisy-items-center"
+      @click.prevent="$emit('resumeRecall')"
+    >
+      <div class="icon-container">
+        <component :is="icon" width="24" height="24" />
+        <div v-if="badge" :class="badgeClass">
+          {{ badge }}
+        </div>
+      </div>
+      <span class="label">{{ label }}</span>
+    </a>
 
     <details v-if="hasDropdown" ref="dropdownTrigger" class="daisy-dropdown daisy-dropdown-bottom daisy-dropdown-end lg:daisy-dropdown-top lg:daisy-dropdown-right">
       <summary
@@ -54,6 +68,10 @@ const props = defineProps<{
   badge?: number
   badgeClass?: string
   hasDropdown?: boolean
+}>()
+
+defineEmits<{
+  (e: "resumeRecall"): void
 }>()
 
 const dropdownTrigger = ref<HTMLDetailsElement | null>(null)

--- a/frontend/src/components/review/RecallProgressBar.vue
+++ b/frontend/src/components/review/RecallProgressBar.vue
@@ -1,7 +1,6 @@
 <template>
   <ProgressBar
     v-bind="{ title: `Recalling: `, finished, toRepeatCount }"
-    @resume="$emit('viewLastAnsweredQuestion', undefined)"
     @showMore="$emit('showMore')"
   >
     <template #buttons>
@@ -21,14 +20,6 @@
             "
           >
             <SvgBackward />
-          </button>
-
-          <button
-            class="btn large-btn"
-            title="view next answered question"
-            @click="$emit('viewLastAnsweredQuestion', undefined)"
-          >
-            <SvgResume />
           </button>
         </template>
         <button
@@ -58,7 +49,6 @@
 import ProgressBar from "../commons/ProgressBar.vue"
 import SvgPause from "../svgs/SvgPause.vue"
 import SvgBackward from "../svgs/SvgBackward.vue"
-import SvgResume from "../svgs/SvgResume.vue"
 import SvgSkip from "../svgs/SvgSkip.vue"
 
 defineProps({

--- a/frontend/src/components/toolbars/HorizontalMenu.vue
+++ b/frontend/src/components/toolbars/HorizontalMenu.vue
@@ -21,7 +21,7 @@
           <template v-if="!shouldShowExpanded && hasActiveItem && !isHomePage && activeItem">
             <li class="daisy-menu-item active-item-only">
               <div @click.capture.stop.prevent="handleActiveItemClick" class="active-item-wrapper">
-                <NavigationItem v-bind="{ ...activeItem }" />
+                <NavigationItem v-bind="{ ...activeItem }" @resumeRecall="resumeRecall" />
               </div>
             </li>
           </template>
@@ -30,7 +30,7 @@
           <ul v-if="shouldShowExpanded" class="top-menu daisy-menu daisy-flex-1">
         <template v-if="!isHomePage">
           <li v-for="item in upperNavItems" :title="item.label" :key="item.name" class="daisy-menu-item">
-            <NavigationItem v-bind="{ ...item }" />
+            <NavigationItem v-bind="{ ...item }" @resumeRecall="resumeRecall" />
           </li>
         </template>
 
@@ -72,6 +72,7 @@ import LoginButton from "@/components/toolbars/LoginButton.vue"
 import NavigationItem from "@/components/navigation/NavigationItem.vue"
 import AccountMenuItem from "@/components/toolbars/AccountMenuItem.vue"
 import SvgChevronRight from "@/components/svgs/SvgChevronRight.vue"
+import { useRecallData } from "@/composables/useRecallData"
 
 type NavigationItemType = {
   name?: string
@@ -137,9 +138,18 @@ const handleMenuContentClick = () => {
   }
 }
 
+const { resumeRecall } = useRecallData()
+
 const handleActiveItemClick = (event: MouseEvent) => {
   // When collapsed, clicking the active item should expand the menu, not navigate
+  // Exception: "resumeRecall" should resume without expanding
   if (!shouldShowExpanded.value && props.user) {
+    if (activeItem.value?.name === "resumeRecall") {
+      event.preventDefault()
+      event.stopPropagation()
+      resumeRecall()
+      return
+    }
     event.preventDefault()
     event.stopPropagation()
     expandMenu()

--- a/frontend/src/components/toolbars/VerticalMenu.vue
+++ b/frontend/src/components/toolbars/VerticalMenu.vue
@@ -4,7 +4,7 @@
       <ul v-if="user" class="top-menu daisy-menu daisy-w-full daisy-flex-1">
         <template v-if="!isHomePage">
           <li v-for="item in upperNavItems" :title="item.label" :key="item.name" class="daisy-menu-item">
-            <NavigationItem v-bind="{ ...item }" />
+            <NavigationItem v-bind="{ ...item }" @resumeRecall="handleResumeRecall" />
           </li>
         </template>
 
@@ -47,6 +47,7 @@ import type { PropType, Component } from "vue"
 import LoginButton from "@/components/toolbars/LoginButton.vue"
 import NavigationItem from "@/components/navigation/NavigationItem.vue"
 import AccountMenuItem from "@/components/toolbars/AccountMenuItem.vue"
+import { useRecallData } from "@/composables/useRecallData"
 
 type NavigationItemType = {
   name?: string
@@ -75,6 +76,11 @@ defineProps({
   },
   logout: { type: Function as PropType<() => void>, required: true },
 })
+
+const { resumeRecall } = useRecallData()
+const handleResumeRecall = () => {
+  resumeRecall()
+}
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/composables/useNavigationItems.ts
+++ b/frontend/src/composables/useNavigationItems.ts
@@ -5,6 +5,7 @@ import { useRecallData } from "@/composables/useRecallData"
 import SvgNote from "@/components/svgs/SvgNote.vue"
 import SvgAssimilate from "@/components/svgs/SvgAssimilate.vue"
 import SvgCalendarCheck from "@/components/svgs/SvgCalendarCheck.vue"
+import SvgResume from "@/components/svgs/SvgResume.vue"
 import SvgShop from "@/components/svgs/SvgShop.vue"
 import SvgPeople from "@/components/svgs/SvgPeople.vue"
 import SvgChat from "@/components/svgs/SvgChat.vue"
@@ -13,34 +14,50 @@ import { messageCenterConversations } from "@/store/messageStore"
 export function useNavigationItems() {
   const route = useRoute()
   const { dueCount } = useAssimilationCount()
-  const { toRepeatCount } = useRecallData()
+  const { toRepeatCount, isRecallPaused } = useRecallData()
 
-  const upperNavItems = computed(() => [
-    {
-      name: "notebooks",
-      label: "Note",
-      icon: SvgNote,
-      isActive: ["notebooks", "noteShow", "notebookEdit"].includes(
-        route.name as string
-      ),
-    },
-    {
-      name: "assimilate",
-      label: "Assimilate",
-      icon: SvgAssimilate,
-      badge: dueCount.value,
-      badgeClass: "due-count",
-      isActive: ["assimilate"].includes(route.name as string),
-    },
-    {
-      name: "recall",
-      label: "Recall",
-      icon: SvgCalendarCheck,
-      badge: toRepeatCount.value,
-      badgeClass: "recall-count",
-      isActive: ["recall"].includes(route.name as string),
-    },
-  ])
+  const upperNavItems = computed(() => {
+    const baseItems = [
+      {
+        name: "notebooks",
+        label: "Note",
+        icon: SvgNote,
+        isActive: ["notebooks", "noteShow", "notebookEdit"].includes(
+          route.name as string
+        ),
+      },
+      {
+        name: "assimilate",
+        label: "Assimilate",
+        icon: SvgAssimilate,
+        badge: dueCount.value,
+        badgeClass: "due-count",
+        isActive: ["assimilate"].includes(route.name as string),
+      },
+      {
+        name: "recall",
+        label: "Recall",
+        icon: SvgCalendarCheck,
+        badge: toRepeatCount.value,
+        badgeClass: "recall-count",
+        isActive: ["recall"].includes(route.name as string),
+      },
+    ]
+
+    if (isRecallPaused.value) {
+      return [
+        {
+          name: "resumeRecall",
+          label: "Resume Recall",
+          icon: SvgResume,
+          isActive: true,
+        },
+        ...baseItems,
+      ]
+    }
+
+    return baseItems
+  })
 
   const lowerNavItems = computed(() => [
     {

--- a/frontend/src/composables/useRecallData.ts
+++ b/frontend/src/composables/useRecallData.ts
@@ -1,10 +1,15 @@
 import { ref } from "vue"
+import { useRouter } from "vue-router"
 
 const toRepeatCount = ref<number | undefined>(undefined)
 const recallWindowEndAt = ref<string | undefined>(undefined)
 const totalAssimilatedCount = ref<number | undefined>(undefined)
+const isRecallPaused = ref(false)
+const shouldResumeRecall = ref(false)
 
 export function useRecallData() {
+  const router = useRouter()
+
   const setToRepeatCount = (count: number | undefined) => {
     toRepeatCount.value = count
   }
@@ -17,6 +22,19 @@ export function useRecallData() {
     totalAssimilatedCount.value = count
   }
 
+  const setIsRecallPaused = (paused: boolean) => {
+    isRecallPaused.value = paused
+  }
+
+  const resumeRecall = () => {
+    shouldResumeRecall.value = true
+    router.push({ name: "recall" })
+  }
+
+  const clearShouldResumeRecall = () => {
+    shouldResumeRecall.value = false
+  }
+
   const decrementToRepeatCount = () => {
     if (toRepeatCount.value !== undefined && toRepeatCount.value > 0) {
       toRepeatCount.value -= 1
@@ -27,9 +45,14 @@ export function useRecallData() {
     toRepeatCount,
     recallWindowEndAt,
     totalAssimilatedCount,
+    isRecallPaused,
+    shouldResumeRecall,
     setToRepeatCount,
     setRecallWindowEndAt,
     setTotalAssimilatedCount,
+    setIsRecallPaused,
+    resumeRecall,
+    clearShouldResumeRecall,
     decrementToRepeatCount,
   }
 }

--- a/frontend/src/pages/RecallPage.vue
+++ b/frontend/src/pages/RecallPage.vue
@@ -84,7 +84,14 @@ import {} from "@/managedApi/clientSetup"
 import getEnvironment from "@/managedApi/window/getEnvironment"
 import timezoneParam from "@/managedApi/window/timezoneParam"
 import { shuffle } from "es-toolkit"
-import { computed, onMounted, ref, onActivated, onDeactivated } from "vue"
+import {
+  computed,
+  onMounted,
+  ref,
+  onActivated,
+  onDeactivated,
+  watch,
+} from "vue"
 import { useRecallData } from "@/composables/useRecallData"
 
 export type SpellingResult = SpellingResultDto & { type: "spelling" }
@@ -101,6 +108,9 @@ const {
   recallWindowEndAt,
   setRecallWindowEndAt,
   totalAssimilatedCount,
+  setIsRecallPaused,
+  shouldResumeRecall,
+  clearShouldResumeRecall,
 } = useRecallData()
 
 defineProps({
@@ -138,6 +148,24 @@ const toRepeatCount = computed(
 const viewLastAnsweredQuestion = (cursor: number | undefined) => {
   previousAnsweredQuestionCursor.value = cursor
 }
+
+watch(
+  () => previousAnsweredQuestionCursor.value,
+  (cursor) => {
+    setIsRecallPaused(cursor !== undefined)
+  },
+  { immediate: true }
+)
+
+watch(
+  () => shouldResumeRecall.value,
+  (shouldResume) => {
+    if (shouldResume) {
+      previousAnsweredQuestionCursor.value = undefined
+      clearShouldResumeRecall()
+    }
+  }
+)
 
 const loadMore = async (dueInDays?: number) => {
   const { data: response, error } = await RecallsController.recalling({

--- a/frontend/tests/components/review/Assimilation.spec.ts
+++ b/frontend/tests/components/review/Assimilation.spec.ts
@@ -38,9 +38,14 @@ beforeEach(() => {
     totalAssimilatedCount: mockedTotalAssimilatedCount,
     toRepeatCount: ref(0),
     recallWindowEndAt: ref(undefined),
+    isRecallPaused: ref(false),
+    shouldResumeRecall: ref(false),
     setToRepeatCount: vi.fn(),
     setRecallWindowEndAt: vi.fn(),
     setTotalAssimilatedCount: vi.fn(),
+    setIsRecallPaused: vi.fn(),
+    resumeRecall: vi.fn(),
+    clearShouldResumeRecall: vi.fn(),
     decrementToRepeatCount: vi.fn(),
   })
 

--- a/frontend/tests/toolbars/MainMenu.spec.ts
+++ b/frontend/tests/toolbars/MainMenu.spec.ts
@@ -6,10 +6,18 @@ import helper, { mockSdkService } from "@tests/helpers"
 import { flushPromises } from "@vue/test-utils"
 import timezoneParam from "@/managedApi/window/timezoneParam"
 import { beforeEach, vi } from "vitest"
+import { useRecallData } from "@/composables/useRecallData"
+import { ref } from "vue"
+
+vi.mock("@/composables/useRecallData")
 
 const useRouteValue = { name: "" }
+const mockPush = vi.fn()
 vitest.mock("vue-router", () => ({
   useRoute: () => useRouteValue,
+  useRouter: () => ({
+    push: mockPush,
+  }),
 }))
 
 // Mock window.matchMedia
@@ -45,6 +53,20 @@ describe("main menu", () => {
         totalAssimilatedCount: 0,
       },
       unreadConversations: [],
+    })
+    vi.mocked(useRecallData).mockReturnValue({
+      toRepeatCount: ref(0),
+      recallWindowEndAt: ref(undefined),
+      totalAssimilatedCount: ref(0),
+      isRecallPaused: ref(false),
+      shouldResumeRecall: ref(false),
+      setToRepeatCount: vi.fn(),
+      setRecallWindowEndAt: vi.fn(),
+      setTotalAssimilatedCount: vi.fn(),
+      setIsRecallPaused: vi.fn(),
+      resumeRecall: vi.fn(),
+      clearShouldResumeRecall: vi.fn(),
+      decrementToRepeatCount: vi.fn(),
     })
     user = makeMe.aUser.please()
   })
@@ -244,6 +266,21 @@ describe("main menu", () => {
         unreadConversations: [],
       })
 
+      vi.mocked(useRecallData).mockReturnValue({
+        toRepeatCount: ref(789),
+        recallWindowEndAt: ref(undefined),
+        totalAssimilatedCount: ref(0),
+        isRecallPaused: ref(false),
+        shouldResumeRecall: ref(false),
+        setToRepeatCount: vi.fn(),
+        setRecallWindowEndAt: vi.fn(),
+        setTotalAssimilatedCount: vi.fn(),
+        setIsRecallPaused: vi.fn(),
+        resumeRecall: vi.fn(),
+        clearShouldResumeRecall: vi.fn(),
+        decrementToRepeatCount: vi.fn(),
+      })
+
       const { getByText } = helper
         .component(MainMenu)
         .withProps({ user })
@@ -331,6 +368,147 @@ describe("main menu", () => {
       // The menu might still exist but in collapsed state
       // We can verify by checking that the expand button is still there
       expect(screen.getByLabelText("Toggle menu")).toBeInTheDocument()
+    })
+  })
+
+  describe("resume recall menu item", () => {
+    beforeEach(() => {
+      vi.mocked(useRecallData).mockReturnValue({
+        toRepeatCount: ref(0),
+        recallWindowEndAt: ref(undefined),
+        totalAssimilatedCount: ref(0),
+        isRecallPaused: ref(true),
+        shouldResumeRecall: ref(false),
+        setToRepeatCount: vi.fn(),
+        setRecallWindowEndAt: vi.fn(),
+        setTotalAssimilatedCount: vi.fn(),
+        setIsRecallPaused: vi.fn(),
+        resumeRecall: vi.fn(),
+        clearShouldResumeRecall: vi.fn(),
+        decrementToRepeatCount: vi.fn(),
+      })
+    })
+
+    it("shows resume recall menu item when recall is paused", async () => {
+      helper.component(MainMenu).withProps({ user }).render()
+
+      // If HorizontalMenu is used, expand it first
+      const expandButton = screen.queryByLabelText("Toggle menu")
+      if (expandButton) {
+        await fireEvent.click(expandButton)
+      }
+
+      const resumeRecallLink = screen.getByLabelText("Resume Recall")
+      expect(resumeRecallLink).toBeInTheDocument()
+    })
+
+    it("highlights resume recall menu item when recall is paused", async () => {
+      helper.component(MainMenu).withProps({ user }).render()
+
+      // If HorizontalMenu is used, expand it first
+      const expandButton = screen.queryByLabelText("Toggle menu")
+      if (expandButton) {
+        await fireEvent.click(expandButton)
+      }
+
+      const resumeRecallLink = screen.getByLabelText("Resume Recall")
+      const navItem = resumeRecallLink.closest(".nav-item")
+      expect(navItem).toHaveClass("daisy-text-primary")
+    })
+
+    it("shows resume recall as first item when recall is paused", async () => {
+      helper.component(MainMenu).withProps({ user }).render()
+
+      // If HorizontalMenu is used, expand it first
+      const expandButton = screen.queryByLabelText("Toggle menu")
+      if (expandButton) {
+        await fireEvent.click(expandButton)
+      }
+
+      // Check that resume recall appears before note in the DOM
+      const resumeRecallElement = screen.getByLabelText("Resume Recall")
+      const noteElement = screen.getByLabelText("Note")
+      
+      // Get all navigation items by querying the DOM
+      const allNavItems = Array.from(document.querySelectorAll('.nav-item'))
+      const resumeNavItem = allNavItems.find(
+        (el) => el.querySelector('a[aria-label="Resume Recall"]') || el.querySelector('[aria-label="Resume Recall"]')
+      )
+      const noteNavItem = allNavItems.find(
+        (el) => el.querySelector('a[aria-label="Note"]') || el.querySelector('[aria-label="Note"]')
+      )
+
+      expect(resumeRecallElement).toBeInTheDocument()
+      expect(noteElement).toBeInTheDocument()
+      expect(resumeNavItem).toBeDefined()
+      expect(noteNavItem).toBeDefined()
+      
+      // Check that resume recall appears before note in the DOM order
+      const resumeIndex = allNavItems.indexOf(resumeNavItem!)
+      const noteIndex = allNavItems.indexOf(noteNavItem!)
+      expect(resumeIndex).toBeGreaterThan(-1)
+      expect(noteIndex).toBeGreaterThan(-1)
+      expect(resumeIndex).toBeLessThan(noteIndex)
+    })
+
+    it("does not show resume recall menu item when recall is not paused", async () => {
+      vi.mocked(useRecallData).mockReturnValue({
+        toRepeatCount: ref(0),
+        recallWindowEndAt: ref(undefined),
+        totalAssimilatedCount: ref(0),
+        isRecallPaused: ref(false),
+        shouldResumeRecall: ref(false),
+        setToRepeatCount: vi.fn(),
+        setRecallWindowEndAt: vi.fn(),
+        setTotalAssimilatedCount: vi.fn(),
+        setIsRecallPaused: vi.fn(),
+        resumeRecall: vi.fn(),
+        clearShouldResumeRecall: vi.fn(),
+        decrementToRepeatCount: vi.fn(),
+      })
+
+      helper.component(MainMenu).withProps({ user }).render()
+
+      // If HorizontalMenu is used, expand it first
+      const expandButton = screen.queryByLabelText("Toggle menu")
+      if (expandButton) {
+        await fireEvent.click(expandButton)
+      }
+
+      const resumeRecallLink = screen.queryByLabelText("Resume Recall")
+      expect(resumeRecallLink).not.toBeInTheDocument()
+    })
+
+    it("resumes recall when clicking resume recall in horizontal menu without expanding", async () => {
+      window.matchMedia = createMatchMedia(false)
+      const resumeRecallSpy = vi.fn()
+      vi.mocked(useRecallData).mockReturnValue({
+        toRepeatCount: ref(0),
+        recallWindowEndAt: ref(undefined),
+        totalAssimilatedCount: ref(0),
+        isRecallPaused: ref(true),
+        shouldResumeRecall: ref(false),
+        setToRepeatCount: vi.fn(),
+        setRecallWindowEndAt: vi.fn(),
+        setTotalAssimilatedCount: vi.fn(),
+        setIsRecallPaused: vi.fn(),
+        resumeRecall: resumeRecallSpy,
+        clearShouldResumeRecall: vi.fn(),
+        decrementToRepeatCount: vi.fn(),
+      })
+
+      helper.component(MainMenu).withProps({ user }).render()
+
+      // Menu should be collapsed initially
+      const expandButton = screen.getByLabelText("Toggle menu")
+      expect(expandButton).toBeInTheDocument()
+
+      // Click on the resume recall item (should be visible as active item in collapsed state)
+      const resumeRecallLink = screen.getByLabelText("Resume Recall")
+      await fireEvent.click(resumeRecallLink)
+
+      // Should call resumeRecall
+      expect(resumeRecallSpy).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Add a "Resume Recall" menu item to the global main menu to allow users to resume paused recall sessions from any page.

This change provides a consistent and easily accessible way to resume recall, even when navigating away from the recall page, improving user experience. The menu item is the first and active item when recall is paused and functions correctly in both expanded and collapsed menu states. The dedicated resume button on the recall page has been removed.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764853718059909?thread_ts=1764853718.059909&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-377115e8-5f6b-40f5-ad1c-8c0a70b725b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-377115e8-5f6b-40f5-ad1c-8c0a70b725b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

