### PR TITLE
Verify and fix cloud agent setup

### DIFF
--- a/.cursor/rules/cloud-agent-setup.mdc
+++ b/.cursor/rules/cloud-agent-setup.mdc
@@ -24,27 +24,28 @@ alwaysApply: true
 
 **Command execution:** Run commands **DIRECTLY** without nix prefix
 
-## One-Time Setup for Backend Tests
+## One-Time Setup for Backend and E2E Tests
 
-For backend tests, you may need to set up Java and MySQL:
+For backend and e2e tests, you need to set up Java and MySQL:
 
 ```bash
-# One-time setup (installs Java 24 and MySQL)
+# One-time setup (installs Java 25 and MySQL)
 source /workspace/scripts/cloud_agent_setup.sh
 ```
 
 This script:
-- Downloads and installs Azul Zulu Java 24 (required by the project)
+- Downloads and installs Azul Zulu Java 25 (required by the project)
 - Downloads and sets up MySQL 8.4 server
-- Initializes doughnut test databases
-- Exports necessary environment variables (JAVA_HOME, MYSQL_HOME, SPRING_DATASOURCE_*)
+- Initializes doughnut test databases (doughnut_test, doughnut_development, doughnut_e2e_test)
+- Exports necessary environment variables (JAVA_HOME, MYSQL_HOME, SPRING_DATASOURCE_*, INPUT_DB_URL)
 
 **Environment Details**:
-- Java 24 installed to: `/tmp/java24/zulu24.32.13-ca-jdk24.0.2-linux_x64`
+- Java 25 installed to: `/tmp/java25/zulu25.30.17-ca-jdk25.0.1-linux_x64`
 - MySQL installed to: `/tmp/mysql-8.4.3-linux-glibc2.28-x86_64`
 - MySQL data directory: `/tmp/mysql_data`
 - MySQL socket: `/tmp/mysql.sock`
 - MySQL port: 3306
+- **INPUT_DB_URL**: Set to `jdbc:mysql://localhost:3306/doughnut_e2e_test?allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true` for e2e tests
 
 **Note**: The setup script is idempotent and can be run multiple times safely. It will skip steps that are already completed.
 
@@ -72,7 +73,11 @@ source /workspace/scripts/cloud_agent_setup.sh
 ### E2E Tests
 
 ```bash
-# First, start services in the background (only needed for e2e tests)
+# One-time setup (if not already done) - sets up MySQL and exports INPUT_DB_URL
+source /workspace/scripts/cloud_agent_setup.sh
+
+# Start services in the background (only needed for e2e tests)
+# The setup script exports INPUT_DB_URL which the backend uses when running with e2e profile
 pnpm sut &
 
 # Wait 10 seconds for services to be ready
@@ -82,13 +87,16 @@ sleep 10
 pnpm cypress run --spec e2e_test/features/<feature-file>.feature
 ```
 
+**Note**: The backend runs on port **9081** and frontend on port **5173**. The setup script exports `INPUT_DB_URL` which tells the backend (when using e2e profile) to use the `doughnut_e2e_test` database on port 3306.
+
 ## Key Rules
 
 1. **Do NOT use `CURSOR_DEV=true nix develop -c` prefix** - run commands directly
-2. **Backend tests:** May require one-time setup script for Java and MySQL
-3. **E2E tests:** **MUST start `pnpm sut` in the background first, wait 10 seconds, then run tests** (only needed for e2e tests, not for unit tests)
-4. **Test execution:** Frontend tests work without nix
-5. **Linting errors:** TypeScript/vue-tsc errors may appear but don't prevent test execution
+2. **Backend tests:** Require one-time setup script for Java and MySQL
+3. **E2E tests:** **MUST source the setup script first** (to set INPUT_DB_URL), **then start `pnpm sut` in the background, wait 10 seconds, then run tests** (only needed for e2e tests, not for unit tests)
+4. **Service ports:** Backend runs on **9081**, frontend on **5173**
+5. **Test execution:** Frontend tests work without nix
+6. **Linting errors:** TypeScript/vue-tsc errors may appear but don't prevent test execution
 
 ## Common Commands Reference
 

--- a/scripts/cloud_agent_setup.sh
+++ b/scripts/cloud_agent_setup.sh
@@ -109,13 +109,25 @@ export SPRING_DATASOURCE_URL="jdbc:mysql://localhost:3306/doughnut_test?allowPub
 export SPRING_DATASOURCE_USERNAME="doughnut"
 export SPRING_DATASOURCE_PASSWORD="doughnut"
 
-# Run database migration
-echo "==> Running database migration..."
+# Export environment variable for e2e tests (backend uses INPUT_DB_URL when running with e2e profile)
+export INPUT_DB_URL="jdbc:mysql://localhost:3306/doughnut_e2e_test?allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true"
+
+# Run database migration for test database
+echo "==> Running database migration for test database..."
 cd /workspace
 if ./backend/gradlew -p backend migrateTestDB -Dspring.profiles.active=test > /tmp/migrate.log 2>&1; then
-    echo "==> Database migration completed successfully"
+    echo "==> Test database migration completed successfully"
 else
-    echo "ERROR: Database migration failed. Check /tmp/migrate.log"
+    echo "ERROR: Test database migration failed. Check /tmp/migrate.log"
+    exit 1
+fi
+
+# Verify e2e database connection (migration will happen automatically when backend starts with e2e profile)
+echo "==> Verifying e2e database connection..."
+if mysql -u doughnut -pdoughnut -S /tmp/mysql.sock -e "USE doughnut_e2e_test; SELECT 1" > /dev/null 2>&1; then
+    echo "==> E2E database connection verified"
+else
+    echo "ERROR: E2E database connection failed"
     exit 1
 fi
 


### PR DESCRIPTION
Updates cloud agent setup script and documentation to correctly configure MySQL for e2e tests and ensure services start on expected ports.

The previous setup script did not export `INPUT_DB_URL`, causing the backend to use the incorrect database (`doughnut_test` instead of `doughnut_e2e_test`) during e2e test runs. This PR ensures the correct database is used and updates Java version references and e2e test instructions in the documentation.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764856130033619?thread_ts=1764856130.033619&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-af28e0b4-16cc-42f8-abe7-611074b6461e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-af28e0b4-16cc-42f8-abe7-611074b6461e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

