### PR TITLE
Setup cloud agent and run tests

### DIFF
--- a/scripts/cloud_agent_setup.sh
+++ b/scripts/cloud_agent_setup.sh
@@ -112,22 +112,22 @@ export SPRING_DATASOURCE_PASSWORD="doughnut"
 # Export environment variable for e2e tests (backend uses INPUT_DB_URL when running with e2e profile)
 export INPUT_DB_URL="jdbc:mysql://localhost:3306/doughnut_e2e_test?allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true"
 
-# Run database migration for test database
-echo "==> Running database migration for test database..."
-cd /workspace
-if ./backend/gradlew -p backend migrateTestDB -Dspring.profiles.active=test > /tmp/migrate.log 2>&1; then
-    echo "==> Test database migration completed successfully"
-else
-    echo "ERROR: Test database migration failed. Check /tmp/migrate.log"
-    exit 1
-fi
-
 # Verify e2e database connection (migration will happen automatically when backend starts with e2e profile)
 echo "==> Verifying e2e database connection..."
 if mysql -u doughnut -pdoughnut -S /tmp/mysql.sock -e "USE doughnut_e2e_test; SELECT 1" > /dev/null 2>&1; then
     echo "==> E2E database connection verified"
 else
     echo "ERROR: E2E database connection failed"
+    exit 1
+fi
+
+# Run database migration for test database (at the end)
+echo "==> Running database migration for test database..."
+cd /workspace
+if ./backend/gradlew -p backend migrateTestDB -Dspring.profiles.active=test > /tmp/migrate.log 2>&1; then
+    echo "==> Test database migration completed successfully"
+else
+    echo "ERROR: Test database migration failed. Check /tmp/migrate.log"
     exit 1
 fi
 


### PR DESCRIPTION
Move `migrateTestDB` to the end of `cloud_agent_setup.sh` to ensure it runs as the final database setup step.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1764890930725779?thread_ts=1764890930.725779&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-3c75f76f-09be-44f6-87b5-aaa922532f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c75f76f-09be-44f6-87b5-aaa922532f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

