### PR TITLE
Center testability button and format

### DIFF
--- a/frontend/src/components/commons/TestMenu.vue
+++ b/frontend/src/components/commons/TestMenu.vue
@@ -83,15 +83,17 @@ export default defineComponent({
 <style lang="scss" scoped>
 .testability-wrapper {
   position: fixed;
-  bottom: 20px;
-  left: 20px;
+  top: 50%;
+  right: 20px;
+  transform: translateY(-50%);
   z-index: 99999;
 }
 
 .feature-toggle-alert {
   position: fixed;
-  bottom: 80px;
-  left: 20px;
+  top: calc(50% - 60px);
+  right: 20px;
+  transform: translateY(-50%);
   z-index: 99999;
 }
 


### PR DESCRIPTION
Move the testability button and its associated alert to the center right of the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-e01ddd5f-594c-4218-8fd4-54a01a522027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e01ddd5f-594c-4218-8fd4-54a01a522027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

