### PR TITLE
Add discard undo button to confirmation dialog

### DIFF
--- a/frontend/src/components/toolbars/NoteUndoButton.vue
+++ b/frontend/src/components/toolbars/NoteUndoButton.vue
@@ -17,6 +17,7 @@
         :closer="closer"
         @confirm="handleConfirm"
         @cancel="handleCancel"
+        @discard="handleDiscard(closer)"
       />
     </template>
   </PopButton>
@@ -123,5 +124,12 @@ const handleConfirm = async () => {
 
 const handleCancel = () => {
   // PopButton will handle closing the dialog
+}
+
+const handleDiscard = (closer: () => void) => {
+  storageAccessor.value.discardUndo()
+  if (!storageAccessor.value.peekUndo()) {
+    closer()
+  }
 }
 </script>

--- a/frontend/src/components/toolbars/UndoConfirmationDialog.vue
+++ b/frontend/src/components/toolbars/UndoConfirmationDialog.vue
@@ -20,6 +20,9 @@
       <button class="daisy-btn daisy-btn-secondary" @click="handleCancel">
         Cancel
       </button>
+      <button class="daisy-btn daisy-btn-warning" @click="handleDiscard">
+        Discard
+      </button>
       <button class="daisy-btn daisy-btn-success" @click="handleConfirm" v-focus>
         OK
       </button>
@@ -45,6 +48,7 @@ const props = defineProps({
 const emit = defineEmits<{
   confirm: []
   cancel: []
+  discard: []
 }>()
 
 const handleConfirm = () => {
@@ -55,6 +59,10 @@ const handleConfirm = () => {
 const handleCancel = () => {
   emit("cancel")
   props.closer()
+}
+
+const handleDiscard = () => {
+  emit("discard")
 }
 </script>
 

--- a/frontend/src/store/createNoteStorage.ts
+++ b/frontend/src/store/createNoteStorage.ts
@@ -8,6 +8,7 @@ import StoredApiCollection from "./StoredApiCollection"
 interface StorageAccessor extends NoteStorage {
   storedApi(): StoredApi
   peekUndo(): null | HistoryRecord
+  discardUndo(): void
 }
 
 class AccessorImplementation
@@ -31,6 +32,10 @@ class AccessorImplementation
 
   storedApi(): StoredApi {
     return new StoredApiCollection(this.noteEditingHistory, this)
+  }
+
+  discardUndo(): void {
+    this.noteEditingHistory.popUndoHistory()
   }
 }
 

--- a/frontend/tests/toolbars/NoteUndoButton.spec.ts
+++ b/frontend/tests/toolbars/NoteUndoButton.spec.ts
@@ -290,5 +290,146 @@ describe("NoteUndoButton", () => {
 
       expect(mockedPush).not.toHaveBeenCalled()
     })
+
+    describe("discard functionality", () => {
+      it("discards current undo item and shows next item when multiple items exist", async () => {
+        const noteRealm1 = makeMe.aNoteRealm
+          .topicConstructor("First Note")
+          .please()
+        const noteRealm2 = makeMe.aNoteRealm
+          .topicConstructor("Second Note")
+          .please()
+        const storageAccessor = useStorageAccessor()
+        storageAccessor.value.refreshNoteRealm(noteRealm1)
+        storageAccessor.value.refreshNoteRealm(noteRealm2)
+
+        noteEditingHistory.deleteNote(noteRealm2.id)
+        noteEditingHistory.deleteNote(noteRealm1.id)
+        helper.component(NoteUndoButton).render()
+
+        const undoButton = screen.getByTitle("undo delete note")
+        await undoButton.click()
+        await flushPromises()
+
+        // Verify first item is shown (most recent is first)
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("First Note")).toBeInTheDocument()
+
+        // Discard first item
+        const discardButton = screen.getByRole("button", { name: "Discard" })
+        await discardButton.click()
+        await flushPromises()
+
+        // Verify next item is shown
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("Second Note")).toBeInTheDocument()
+        expect(screen.queryByText("First Note")).not.toBeInTheDocument()
+      })
+
+      it("closes dialog when discarding the last undo item", async () => {
+        const note = makeMe.aNote.please()
+        noteEditingHistory.deleteNote(note.id)
+        helper.component(NoteUndoButton).render()
+
+        const undoButton = screen.getByTitle("undo delete note")
+        await undoButton.click()
+        await flushPromises()
+
+        // Verify dialog is shown
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+
+        // Discard last item
+        const discardButton = screen.getByRole("button", { name: "Discard" })
+        await discardButton.click()
+        await flushPromises()
+
+        // Verify dialog is closed
+        expect(screen.queryByText("Confirm Undo")).not.toBeInTheDocument()
+      })
+
+      it("discards edit title item and shows next item", async () => {
+        const noteRealm1 = makeMe.aNoteRealm
+          .topicConstructor("First Note")
+          .please()
+        const noteRealm2 = makeMe.aNoteRealm
+          .topicConstructor("Second Note")
+          .please()
+        const storageAccessor = useStorageAccessor()
+        storageAccessor.value.refreshNoteRealm(noteRealm1)
+        storageAccessor.value.refreshNoteRealm(noteRealm2)
+
+        noteEditingHistory.addEditingToUndoHistory(
+          noteRealm2.id,
+          "edit title",
+          "Old Title 2"
+        )
+        noteEditingHistory.addEditingToUndoHistory(
+          noteRealm1.id,
+          "edit title",
+          "Old Title 1"
+        )
+        helper.component(NoteUndoButton).render()
+
+        const undoButton = screen.getByTitle("undo edit title")
+        await undoButton.click()
+        await flushPromises()
+
+        // Verify first item is shown (most recent is first)
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("First Note")).toBeInTheDocument()
+
+        // Discard first item
+        const discardButton = screen.getByRole("button", { name: "Discard" })
+        await discardButton.click()
+        await flushPromises()
+
+        // Verify next item is shown
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("Second Note")).toBeInTheDocument()
+        expect(screen.queryByText("First Note")).not.toBeInTheDocument()
+      })
+
+      it("discards edit details item and shows next item", async () => {
+        const noteRealm1 = makeMe.aNoteRealm
+          .topicConstructor("First Note")
+          .please()
+        const noteRealm2 = makeMe.aNoteRealm
+          .topicConstructor("Second Note")
+          .please()
+        const storageAccessor = useStorageAccessor()
+        storageAccessor.value.refreshNoteRealm(noteRealm1)
+        storageAccessor.value.refreshNoteRealm(noteRealm2)
+
+        noteEditingHistory.addEditingToUndoHistory(
+          noteRealm2.id,
+          "edit details",
+          "Old Details 2"
+        )
+        noteEditingHistory.addEditingToUndoHistory(
+          noteRealm1.id,
+          "edit details",
+          "Old Details 1"
+        )
+        helper.component(NoteUndoButton).render()
+
+        const undoButton = screen.getByTitle("undo edit details")
+        await undoButton.click()
+        await flushPromises()
+
+        // Verify first item is shown (most recent is first)
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("First Note")).toBeInTheDocument()
+
+        // Discard first item
+        const discardButton = screen.getByRole("button", { name: "Discard" })
+        await discardButton.click()
+        await flushPromises()
+
+        // Verify next item is shown
+        expect(screen.getByText("Confirm Undo")).toBeInTheDocument()
+        expect(screen.getByText("Second Note")).toBeInTheDocument()
+        expect(screen.queryByText("First Note")).not.toBeInTheDocument()
+      })
+    })
   })
 })


### PR DESCRIPTION
Add a "Discard" button to the Undo Confirmation Dialog to allow users to skip the current undo item and show the next, or close the dialog if no more items remain.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9804dc5-5e13-4ab5-b08a-b4eef69c3f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9804dc5-5e13-4ab5-b08a-b4eef69c3f71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

