### PR TITLE
Update recall paused state and menu

### DIFF
--- a/frontend/src/composables/useNavigationItems.ts
+++ b/frontend/src/composables/useNavigationItems.ts
@@ -14,7 +14,7 @@ import { messageCenterConversations } from "@/store/messageStore"
 export function useNavigationItems() {
   const route = useRoute()
   const { dueCount } = useAssimilationCount()
-  const { toRepeatCount, isRecallPaused } = useRecallData()
+  const { toRepeatCount, isRecallPaused, currentIndex } = useRecallData()
 
   const upperNavItems = computed(() => {
     const baseItems = [
@@ -44,7 +44,14 @@ export function useNavigationItems() {
       },
     ]
 
-    if (isRecallPaused.value) {
+    // Recall is paused if:
+    // 1. previousAnsweredQuestionCursor is set (viewing answered question), OR
+    // 2. currentIndex > 0 (not at first memory tracker) AND not on recall page
+    const isPausedByCursor = isRecallPaused.value
+    const isPausedByIndex = currentIndex.value > 0 && route.name !== "recall"
+    const shouldShowResume = isPausedByCursor || isPausedByIndex
+
+    if (shouldShowResume) {
       return [
         {
           name: "resumeRecall",

--- a/frontend/src/composables/useRecallData.ts
+++ b/frontend/src/composables/useRecallData.ts
@@ -7,6 +7,7 @@ const totalAssimilatedCount = ref<number | undefined>(undefined)
 const isRecallPaused = ref(false)
 const shouldResumeRecall = ref(false)
 const treadmillMode = ref<boolean>(false)
+const currentIndex = ref(0)
 
 export function useRecallData() {
   const router = useRouter()
@@ -46,6 +47,10 @@ export function useRecallData() {
     treadmillMode.value = enabled
   }
 
+  const setCurrentIndex = (index: number) => {
+    currentIndex.value = index
+  }
+
   return {
     toRepeatCount,
     recallWindowEndAt,
@@ -53,6 +58,7 @@ export function useRecallData() {
     isRecallPaused,
     shouldResumeRecall,
     treadmillMode,
+    currentIndex,
     setToRepeatCount,
     setRecallWindowEndAt,
     setTotalAssimilatedCount,
@@ -61,5 +67,6 @@ export function useRecallData() {
     clearShouldResumeRecall,
     decrementToRepeatCount,
     setTreadmillMode,
+    setCurrentIndex,
   }
 }

--- a/frontend/src/pages/RecallPage.vue
+++ b/frontend/src/pages/RecallPage.vue
@@ -116,6 +116,7 @@ const {
   shouldResumeRecall,
   clearShouldResumeRecall,
   treadmillMode,
+  setCurrentIndex,
 } = useRecallData()
 
 defineProps({
@@ -128,6 +129,15 @@ const previousAnsweredQuestions = ref<(RecallResult | undefined)[]>([])
 const previousAnsweredQuestionCursor = ref<number | undefined>(undefined)
 const isProgressBarVisible = ref(true)
 const showTooltip = ref(false)
+
+// Sync currentIndex with useRecallData
+watch(
+  () => currentIndex.value,
+  (index) => {
+    setCurrentIndex(index)
+  },
+  { immediate: true }
+)
 
 // Computed list of memory trackers that should not be modified
 const memoryTrackers = computed(() => toRepeat.value ?? [])

--- a/frontend/tests/components/recall/Assimilation.spec.ts
+++ b/frontend/tests/components/recall/Assimilation.spec.ts
@@ -41,6 +41,7 @@ beforeEach(() => {
     isRecallPaused: ref(false),
     shouldResumeRecall: ref(false),
     treadmillMode: ref(false),
+    currentIndex: ref(0),
     setToRepeatCount: vi.fn(),
     setRecallWindowEndAt: vi.fn(),
     setTotalAssimilatedCount: vi.fn(),
@@ -49,6 +50,7 @@ beforeEach(() => {
     clearShouldResumeRecall: vi.fn(),
     decrementToRepeatCount: vi.fn(),
     setTreadmillMode: vi.fn(),
+    setCurrentIndex: vi.fn(),
   })
 
   vi.mocked(useAssimilationCount).mockReturnValue({

--- a/frontend/tests/toolbars/MainMenu.spec.ts
+++ b/frontend/tests/toolbars/MainMenu.spec.ts
@@ -58,6 +58,7 @@ const createMenuData = (overrides?: Partial<typeof defaultMenuData>) => {
 const createUseRecallDataMock = (overrides?: {
   toRepeatCount?: number
   isRecallPaused?: boolean
+  currentIndex?: number
   resumeRecall?: () => void
 }) => {
   return {
@@ -67,6 +68,7 @@ const createUseRecallDataMock = (overrides?: {
     isRecallPaused: ref(overrides?.isRecallPaused ?? false),
     shouldResumeRecall: ref(false),
     treadmillMode: ref(false),
+    currentIndex: ref(overrides?.currentIndex ?? 0),
     setToRepeatCount: vi.fn(),
     setRecallWindowEndAt: vi.fn(),
     setTotalAssimilatedCount: vi.fn(),
@@ -75,6 +77,7 @@ const createUseRecallDataMock = (overrides?: {
     clearShouldResumeRecall: vi.fn(),
     decrementToRepeatCount: vi.fn(),
     setTreadmillMode: vi.fn(),
+    setCurrentIndex: vi.fn(),
   }
 }
 
@@ -496,6 +499,66 @@ describe("main menu", () => {
 
       const resumeCount = queryByText("0")
       expect(resumeCount).not.toBeInTheDocument()
+    })
+
+    it("shows resume recall menu item when currentIndex > 0 and not on recall page", async () => {
+      useRouteValue.name = "notebooks"
+      vi.mocked(useRecallData).mockReturnValue(
+        createUseRecallDataMock({
+          isRecallPaused: false,
+          currentIndex: 1,
+        })
+      )
+
+      await renderComponent()
+
+      const resumeRecallLink = screen.getByLabelText("Resume")
+      expect(resumeRecallLink).toBeInTheDocument()
+    })
+
+    it("does not show resume recall menu item when currentIndex > 0 but on recall page", async () => {
+      useRouteValue.name = "recall"
+      vi.mocked(useRecallData).mockReturnValue(
+        createUseRecallDataMock({
+          isRecallPaused: false,
+          currentIndex: 1,
+        })
+      )
+
+      await renderComponent()
+
+      const resumeRecallLink = screen.queryByLabelText("Resume")
+      expect(resumeRecallLink).not.toBeInTheDocument()
+    })
+
+    it("does not show resume recall menu item when currentIndex is 0 and not on recall page", async () => {
+      useRouteValue.name = "notebooks"
+      vi.mocked(useRecallData).mockReturnValue(
+        createUseRecallDataMock({
+          isRecallPaused: false,
+          currentIndex: 0,
+        })
+      )
+
+      await renderComponent()
+
+      const resumeRecallLink = screen.queryByLabelText("Resume")
+      expect(resumeRecallLink).not.toBeInTheDocument()
+    })
+
+    it("shows resume recall menu item when both isRecallPaused and currentIndex > 0 conditions are true", async () => {
+      useRouteValue.name = "notebooks"
+      vi.mocked(useRecallData).mockReturnValue(
+        createUseRecallDataMock({
+          isRecallPaused: true,
+          currentIndex: 2,
+        })
+      )
+
+      await renderComponent()
+
+      const resumeRecallLink = screen.getByLabelText("Resume")
+      expect(resumeRecallLink).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Update recall pause logic to show "Resume" in the main menu when the user has answered questions and is not on the recall page.

---
<a href="https://cursor.com/background-agent?bcId=bc-96bcc23b-f391-419b-ae80-f289d6a229b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96bcc23b-f391-419b-ae80-f289d6a229b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

