### PR TITLE
Confirm link and image removal in htmlToMarkdown

### DIFF
--- a/frontend/src/composables/useInterruptingHtmlToMarkdown.ts
+++ b/frontend/src/composables/useInterruptingHtmlToMarkdown.ts
@@ -5,40 +5,62 @@ export function useInterruptingHtmlToMarkdown() {
   const htmlToMarkdown = (html: string) => {
     let markdown = markdownizer.htmlToMarkdown(html)
 
-    // Parse markdown into tokens to detect links
+    // Parse markdown into tokens to detect links and images
     const tokens = marked.lexer(markdown)
     let linkCount = 0
+    let imageCount = 0
 
-    // Count links using marked's walkTokens
+    // Count links and images separately using marked's walkTokens
     marked.walkTokens(tokens, (token) => {
-      if (token.type === "link" || token.type === "image") {
+      if (token.type === "link") {
         linkCount++
+      } else if (token.type === "image") {
+        imageCount++
       }
     })
 
+    let shouldRemoveLinks = false
+    let shouldRemoveImages = false
+
+    // Ask for confirmation separately for links
     if (linkCount > 2) {
-      const confirmed = window.confirm(
+      shouldRemoveLinks = window.confirm(
         `Shall I remove the ${linkCount} links from the pasting content?`
       )
+    }
 
-      if (confirmed) {
-        // Remove links by converting them to text tokens
-        marked.walkTokens(tokens, (token) => {
-          if (token.type === "link" || token.type === "image") {
-            const linkToken = token as Tokens.Link
-            // Replace link/image token with text token
-            Object.assign(token, {
-              type: "text",
-              raw: linkToken.text || "",
-              text: linkToken.text || "",
-            } as Tokens.Text)
-          }
-        })
+    // Ask for confirmation separately for images
+    if (imageCount > 2) {
+      shouldRemoveImages = window.confirm(
+        `Shall I remove the ${imageCount} images from the pasting content?`
+      )
+    }
 
-        // Convert tokens back to markdown via HTML
-        const html = marked.parser(tokens)
-        markdown = markdownizer.htmlToMarkdown(html).trim()
-      }
+    // Remove links and/or images if confirmed
+    if (shouldRemoveLinks || shouldRemoveImages) {
+      marked.walkTokens(tokens, (token) => {
+        if (token.type === "link" && shouldRemoveLinks) {
+          const linkToken = token as Tokens.Link
+          // Replace link token with text token
+          Object.assign(token, {
+            type: "text",
+            raw: linkToken.text || "",
+            text: linkToken.text || "",
+          } as Tokens.Text)
+        } else if (token.type === "image" && shouldRemoveImages) {
+          const imageToken = token as Tokens.Image
+          // Replace image token with text token (using alt text)
+          Object.assign(token, {
+            type: "text",
+            raw: imageToken.text || "",
+            text: imageToken.text || "",
+          } as Tokens.Text)
+        }
+      })
+
+      // Convert tokens back to markdown via HTML
+      const html = marked.parser(tokens)
+      markdown = markdownizer.htmlToMarkdown(html).trim()
     }
 
     return markdown


### PR DESCRIPTION
Implement separate user confirmation for removing links and images during HTML to Markdown conversion and fix an image token property.

---
<a href="https://cursor.com/background-agent?bcId=bc-b29f9d1f-351a-4f7e-9514-d0856da2eee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b29f9d1f-351a-4f7e-9514-d0856da2eee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

