### PR TITLE
Convert html with pre to markdown and back

### DIFF
--- a/frontend/src/components/form/markdownToQuillHtml.ts
+++ b/frontend/src/components/form/markdownToQuillHtml.ts
@@ -78,6 +78,19 @@ export default function markdownToQuillHtml(
     return `<blockquote>${cleanedBody}</blockquote>`
   }
 
+  // Override the code method to output <pre><code>
+  renderer.code = function (token: Tokens.Code): string {
+    const code = token.text || ""
+    // Escape HTML entities in the code content
+    const escapedCode = code
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")
+    return `<pre><code>${escapedCode}</code></pre>`
+  }
+
   // Set up the parser with the custom renderer
   const parser = new marked.Parser({ renderer })
   renderer.parser = parser

--- a/frontend/src/components/form/quillHtmlToMarkdown.ts
+++ b/frontend/src/components/form/quillHtmlToMarkdown.ts
@@ -48,6 +48,21 @@ const mergeConsecutiveHeaders = (tempDiv: HTMLElement): void => {
   }
 }
 
+turndownService.addRule("pre", {
+  filter: "pre",
+  replacement(_, node: Node) {
+    const codeElement = (node as HTMLElement).querySelector("code")
+    if (codeElement) {
+      // Extract text content from code element, preserving HTML entities
+      const textContent = codeElement.textContent || ""
+      return `\n\n\`\`\`\n${textContent}\n\`\`\`\n\n`
+    }
+    // If no code element, just get the text content
+    const textContent = (node as HTMLElement).textContent || ""
+    return `\n\n\`\`\`\n${textContent}\n\`\`\`\n\n`
+  },
+})
+
 turndownService.addRule("p", {
   filter: "p",
   replacement(_, node: Node) {

--- a/frontend/tests/components/form/markdownizer.spec.ts
+++ b/frontend/tests/components/form/markdownizer.spec.ts
@@ -139,5 +139,38 @@ describe("Markdown and HTML Conversion Tests", () => {
       const headerMatches = markdown.match(/={3,}$/gm)
       expect(headerMatches?.length).toBe(2)
     })
+
+    it("converts <pre><code> blocks to markdown code blocks", () => {
+      const html =
+        "<pre><code>&lt;p class=&quot;p1&quot;&gt;\n  &lt;span class=&quot;s1&quot;&gt;\n    &lt;h1&gt;&lt;b&gt;✅&lt;span class=&quot;Apple-converted-space&quot;&gt; &lt;/span&gt;&lt;/b&gt;&lt;/h1&gt;\n    &lt;h1&gt;&lt;b&gt;Conclusion&lt;/b&gt;&lt;/h1&gt;\n  &lt;/span&gt;\n&lt;/p&gt;</code></pre>"
+      const markdown = markdownizer.htmlToMarkdown(html)
+      // Should contain markdown code block with ```
+      expect(markdown).toContain("```")
+      expect(markdown).toContain('<p class="p1">')
+      expect(markdown).toContain("<h1><b>✅")
+      expect(markdown).toContain("<h1><b>Conclusion</b></h1>")
+    })
+
+    it("converts markdown code blocks back to <pre><code>", () => {
+      const markdown =
+        '```\n<p class="p1">\n  <span class="s1">\n    <h1><b>✅<span class="Apple-converted-space"> </span></b></h1>\n    <h1><b>Conclusion</b></h1>\n  </span>\n</p>\n```'
+      const html = markdownizer.markdownToHtml(markdown)
+      // Should contain <pre><code>
+      expect(html).toContain("<pre><code>")
+      expect(html).toContain("</code></pre>")
+      // HTML entities should be escaped
+      expect(html).toContain("&lt;p")
+      expect(html).toContain("&quot;")
+    })
+
+    it("round-trip conversion: <pre><code> to markdown and back", () => {
+      const originalHtml =
+        "<pre><code>&lt;p class=&quot;p1&quot;&gt;\n  &lt;span class=&quot;s1&quot;&gt;\n    &lt;h1&gt;&lt;b&gt;✅&lt;span class=&quot;Apple-converted-space&quot;&gt; &lt;/span&gt;&lt;/b&gt;&lt;/h1&gt;\n    &lt;h1&gt;&lt;b&gt;Conclusion&lt;/b&gt;&lt;/h1&gt;\n  &lt;/span&gt;\n&lt;/p&gt;</code></pre>"
+      const markdown = markdownizer.htmlToMarkdown(originalHtml)
+      const convertedHtml = markdownizer.markdownToHtml(markdown)
+      // Should contain <pre><code> in the result
+      expect(convertedHtml).toContain("<pre><code>")
+      expect(convertedHtml).toContain("</code></pre>")
+    })
   })
 })


### PR DESCRIPTION
Implement proper conversion of HTML `<pre><code>` blocks to Markdown code blocks and back.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f5c7ece-c282-4122-ab52-52d35339e6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f5c7ece-c282-4122-ab52-52d35339e6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

