### PR TITLE
Reorder unanswered trackers

### DIFF
--- a/frontend/src/pages/RecallPage.vue
+++ b/frontend/src/pages/RecallPage.vue
@@ -350,6 +350,30 @@ const handleTreadmillModeChanged = () => {
           currentIndex.value = firstNonSpelling
         }
       }
+    } else {
+      // When treadmill mode is turned off, move unanswered spelling trackers to the end
+      const unansweredSpellingTrackers: MemoryTrackerLite[] = []
+      const nonSpellingTrackers: MemoryTrackerLite[] = []
+
+      // Separate spelling and non-spelling trackers from currentIndex onwards
+      for (let i = currentIndex.value; i < toRepeat.value.length; i++) {
+        const tracker = toRepeat.value[i]
+        if (!tracker) continue
+        if (tracker.spelling) {
+          unansweredSpellingTrackers.push(tracker)
+        } else {
+          nonSpellingTrackers.push(tracker)
+        }
+      }
+
+      // Rebuild the list: answered trackers (before currentIndex) + non-spelling trackers + spelling trackers
+      if (unansweredSpellingTrackers.length > 0) {
+        toRepeat.value = [
+          ...toRepeat.value.slice(0, currentIndex.value),
+          ...nonSpellingTrackers,
+          ...unansweredSpellingTrackers,
+        ]
+      }
     }
     updateToRepeatCount()
   }


### PR DESCRIPTION
Move unanswered spelling memory trackers to the end of the list when treadmill mode is turned off.

This ensures that users will answer any spelling trackers that were previously bypassed while treadmill mode was active.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1765063734398079?thread_ts=1765063734.398079&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-c951f395-5866-43df-9d5c-7aa359cc1b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c951f395-5866-43df-9d5c-7aa359cc1b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

