### PR TITLE
Frontend style enhancement daisy ui

### DIFF
--- a/frontend/src/components/recall/Assimilation.vue
+++ b/frontend/src/components/recall/Assimilation.vue
@@ -34,16 +34,18 @@
     class="daisy-mb-4 daisy-alert daisy-alert-info"
   >
     <div class="daisy-text-sm">
-      <div v-if="shouldShowCategoryMessage" class="daisy-text-base-content/80">
+      <div v-if="shouldShowCategoryMessage" class="daisy-text-base-content">
         No summary requested for category notes.
       </div>
       <template v-else>
-        <div class="daisy-font-semibold daisy-mb-2">Summary:</div>
+        <div class="daisy-font-semibold daisy-mb-2 daisy-text-base-content">
+          Summary:
+        </div>
         <ul class="daisy-list-disc daisy-list-inside daisy-space-y-1">
           <li
             v-for="(point, index) in noteSummaryPoints"
             :key="index"
-            class="daisy-text-base-content/80"
+            class="daisy-text-base-content"
           >
             {{ point }}
           </li>


### PR DESCRIPTION
Improve text contrast in the note details summary section of the Assimilation component.

The previous text and background contrast made the note details summary hard to read, so the text opacity was increased to full for better readability.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1765510392544359?thread_ts=1765510392.544359&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-917af81b-bb29-44d0-9f42-e7f2feac61b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-917af81b-bb29-44d0-9f42-e7f2feac61b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve readability of the note details summary by using full `daisy-text-base-content` instead of reduced-opacity text.
> 
> - **Frontend**
>   - **Assimilation.vue** (`frontend/src/components/recall/Assimilation.vue`):
>     - Increase text contrast in note details summary:
>       - Replace `daisy-text-base-content/80` with `daisy-text-base-content` for category message and summary list items.
>       - Add `daisy-text-base-content` to the "Summary:" header for consistent full-contrast text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 484db78cc7093b49682cbb47f253d103a1f8a891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->