### PR TITLE
Cloud VM thinking time

### DIFF
--- a/frontend/src/components/recall/QuestionDisplay.vue
+++ b/frontend/src/components/recall/QuestionDisplay.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="quiz-instruction daisy-relative daisy-max-w-6xl daisy-mx-auto" data-test="question-section">
     <QuestionStem :stem="multipleChoicesQuestion.f0__stem" />
+    <div v-if="!disabled && currentTimeMs > 0" class="daisy-text-sm daisy-text-base-content/70 daisy-mt-2">
+      Thinking time: {{ formatThinkingTime(currentTimeMs) }}
+    </div>
     <QuestionChoices
       v-if="multipleChoicesQuestion.f1__choices"
       :choices="multipleChoicesQuestion.f1__choices"
@@ -36,7 +39,20 @@ defineProps({
 
 const emits = defineEmits(["answer"])
 
-const { start, stop } = useThinkingTimeTracker()
+const { start, stop, currentTimeMs } = useThinkingTimeTracker()
+
+const formatThinkingTime = (ms: number): string => {
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  const seconds = ms / 1000
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${minutes}m ${remainingSeconds}s`
+}
 
 onMounted(() => {
   start()

--- a/frontend/src/components/recall/SpellingQuestionComponent.vue
+++ b/frontend/src/components/recall/SpellingQuestionComponent.vue
@@ -7,6 +7,9 @@
           <NotebookLink :notebook="recallPrompt.spellingQuestion.notebook" />
         </div>
         <QuestionStem :stem="stem" />
+        <div v-if="currentTimeMs > 0" class="daisy-text-sm daisy-text-base-content/70 daisy-mt-2">
+          Thinking time: {{ formatThinkingTime(currentTimeMs) }}
+        </div>
       </div>
       <form @submit.prevent="submitAnswer" class="daisy-sticky daisy-bottom-0 daisy-bg-base-100 daisy-pt-4 daisy-pb-4">
         <TextInput
@@ -51,11 +54,24 @@ const spellingAnswer = ref("")
 const recallPrompt = ref<RecallPrompt>()
 const loading = ref(true)
 
-const { start, stop } = useThinkingTimeTracker()
+const { start, stop, currentTimeMs } = useThinkingTimeTracker()
 
 const stem = computed(() => {
   return recallPrompt.value?.spellingQuestion?.stem || ""
 })
+
+const formatThinkingTime = (ms: number): string => {
+  if (ms < 1000) {
+    return `${ms}ms`
+  }
+  const seconds = ms / 1000
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`
+  }
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = Math.floor(seconds % 60)
+  return `${minutes}m ${remainingSeconds}s`
+}
 
 const fetchSpellingQuestion = async () => {
   loading.value = true

--- a/frontend/src/composables/useThinkingTimeTracker.ts
+++ b/frontend/src/composables/useThinkingTimeTracker.ts
@@ -5,6 +5,8 @@ export function useThinkingTimeTracker() {
   const runningStart = ref<number | null>(null)
   const isRunning = ref(false)
   const hasStopped = ref(false)
+  const currentTimeMs = ref(0)
+  let updateInterval: number | null = null
 
   const pause = () => {
     if (!isRunning.value || runningStart.value === null) return
@@ -29,11 +31,14 @@ export function useThinkingTimeTracker() {
     requestAnimationFrame(() => {
       if (!hasStopped.value) {
         resume()
+        startUpdateInterval()
       }
     })
   }
 
   const stop = (): number => {
+    stopUpdateInterval()
+
     if (hasStopped.value) {
       return accumulatedMs.value
     }
@@ -47,6 +52,7 @@ export function useThinkingTimeTracker() {
       isRunning.value = false
     }
 
+    updateCurrentTime()
     return Math.round(accumulatedMs.value)
   }
 
@@ -66,6 +72,18 @@ export function useThinkingTimeTracker() {
     resume()
   }
 
+  const updateCurrentTime = () => {
+    if (hasStopped.value) {
+      currentTimeMs.value = Math.round(accumulatedMs.value)
+    } else if (isRunning.value && runningStart.value !== null) {
+      currentTimeMs.value = Math.round(
+        accumulatedMs.value + (performance.now() - runningStart.value)
+      )
+    } else {
+      currentTimeMs.value = Math.round(accumulatedMs.value)
+    }
+  }
+
   const setupEventListeners = () => {
     document.addEventListener("visibilitychange", handleVisibilityChange)
     window.addEventListener("blur", handleBlur)
@@ -78,10 +96,25 @@ export function useThinkingTimeTracker() {
     window.removeEventListener("focus", handleFocus)
   }
 
+  const startUpdateInterval = () => {
+    if (updateInterval !== null) return
+    updateInterval = window.setInterval(() => {
+      updateCurrentTime()
+    }, 100)
+  }
+
+  const stopUpdateInterval = () => {
+    if (updateInterval !== null) {
+      clearInterval(updateInterval)
+      updateInterval = null
+    }
+  }
+
   setupEventListeners()
 
   onUnmounted(() => {
     removeEventListeners()
+    stopUpdateInterval()
     pause()
   })
 
@@ -90,5 +123,6 @@ export function useThinkingTimeTracker() {
     stop,
     accumulatedMs,
     isRunning,
+    currentTimeMs,
   }
 }


### PR DESCRIPTION
Display real-time thinking time under recall questions for debugging purposes.

The `useThinkingTimeTracker` interval was adjusted to start only when explicitly called and stop on unmount, resolving an infinite loop issue in frontend unit tests.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1766105814412799?thread_ts=1766105814.412799&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-4ad54f62-cac5-42e0-8d1d-2e1629c79134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ad54f62-cac5-42e0-8d1d-2e1629c79134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show live "thinking time" under recall questions and update the tracker to expose/currentTimeMs with interval-based updates and proper lifecycle cleanup.
> 
> - **Frontend (Recall UI)**:
>   - Show real-time thinking time under `QuestionDisplay.vue` (hidden when `disabled` or `0ms`) and `SpellingQuestionComponent.vue`.
>   - Add local `formatThinkingTime(ms)` formatter in both components.
> - **Composable `useThinkingTimeTracker`**:
>   - Expose `currentTimeMs` with 100ms interval updates via `startUpdateInterval`/`stopUpdateInterval` and `updateCurrentTime`.
>   - Start interval on `start()`, stop on `stop()` and unmount; ensure accurate pause/resume on visibility/blur/focus events.
>   - Return `currentTimeMs` in API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ec36cacfde023acb1151f44234e396bef97cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->