### PR TITLE
Memory tracker float migration

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/ForgettingCurve.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/ForgettingCurve.java
@@ -3,21 +3,21 @@ package com.odde.doughnut.entities;
 import com.odde.doughnut.algorithms.SpacedRepetitionAlgorithm;
 
 public class ForgettingCurve {
-  public static final Integer DEFAULT_FORGETTING_CURVE_INDEX = 100;
+  public static final Float DEFAULT_FORGETTING_CURVE_INDEX = 100.0f;
   public static final Integer DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT = 10;
   public static final Integer BASE_THINKING_TIME_MS = 25000; // 25 seconds
   public static final Integer MAX_THINKING_TIME_MS = 60000; // 60 seconds
   private SpacedRepetitionAlgorithm spacedRepetitionAlgorithm;
-  private Integer forgettingCurveIndex;
+  private Float forgettingCurveIndex;
 
   public ForgettingCurve(
-      SpacedRepetitionAlgorithm spacedRepetitionAlgorithm, Integer forgettingCurveIndex) {
+      SpacedRepetitionAlgorithm spacedRepetitionAlgorithm, Float forgettingCurveIndex) {
     this.spacedRepetitionAlgorithm = spacedRepetitionAlgorithm;
     this.forgettingCurveIndex = forgettingCurveIndex;
   }
 
-  private int add(int adjustment) {
-    int newIndex = forgettingCurveIndex + adjustment;
+  private float add(float adjustment) {
+    float newIndex = forgettingCurveIndex + adjustment;
     if (newIndex < DEFAULT_FORGETTING_CURVE_INDEX) {
       newIndex = DEFAULT_FORGETTING_CURVE_INDEX;
     }
@@ -31,24 +31,23 @@ public class ForgettingCurve {
     return spacedRepetitionAlgorithm.getRepeatInHours(index);
   }
 
-  int succeeded(long delayInHours, Integer thinkingTimeMs) {
-    int delayAdjustment = DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT;
+  float succeeded(long delayInHours, Integer thinkingTimeMs) {
+    float delayAdjustment = DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT;
     Integer oldRepeatInHours = getRepeatInHours();
     if (oldRepeatInHours > 0) {
       delayAdjustment =
-          (int)
-              (DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT
-                  - Math.abs(delayInHours)
-                      * DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT
-                      / oldRepeatInHours);
+          DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT
+              - Math.abs(delayInHours)
+                  * DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT
+                  / (float) oldRepeatInHours;
     }
-    int thinkingTimeAdjustment = calculateThinkingTimeAdjustment(thinkingTimeMs);
+    float thinkingTimeAdjustment = calculateThinkingTimeAdjustment(thinkingTimeMs);
     return add(delayAdjustment + thinkingTimeAdjustment);
   }
 
-  private int calculateThinkingTimeAdjustment(Integer thinkingTimeMs) {
+  private float calculateThinkingTimeAdjustment(Integer thinkingTimeMs) {
     if (thinkingTimeMs == null) {
-      return 0;
+      return 0.0f;
     }
     // Clamp thinking time to 0-MAX_THINKING_TIME_MS
     int clampedMs = Math.max(0, Math.min(MAX_THINKING_TIME_MS, thinkingTimeMs));
@@ -64,10 +63,10 @@ public class ForgettingCurve {
       adjustmentValue = -adjustmentValue;
     }
 
-    return (int) Math.round(adjustmentValue);
+    return (float) adjustmentValue;
   }
 
-  public int failed() {
+  public float failed() {
     return add(-DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT * 2);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/entities/MemoryTracker.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/MemoryTracker.java
@@ -65,7 +65,7 @@ public class MemoryTracker extends EntityIdentifiedByIdOnly {
   @Column(name = "forgetting_curve_index")
   @Getter
   @Setter
-  private Integer forgettingCurveIndex = ForgettingCurve.DEFAULT_FORGETTING_CURVE_INDEX;
+  private Float forgettingCurveIndex = ForgettingCurve.DEFAULT_FORGETTING_CURVE_INDEX;
 
   @Column(name = "removed_from_tracking")
   @Getter

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -83,11 +83,11 @@ public class MemoryTrackerService {
     memoryTracker.setUser(currentUser);
     memoryTracker.setAssimilatedAt(currentTime);
     memoryTracker.setLastRecalledAt(currentTime);
-    updateForgettingCurve(memoryTracker, 0);
+    updateForgettingCurve(memoryTracker, 0.0f);
     return memoryTracker;
   }
 
-  public void updateForgettingCurve(MemoryTracker memoryTracker, int adjustment) {
+  public void updateForgettingCurve(MemoryTracker memoryTracker, float adjustment) {
     memoryTracker.setForgettingCurveIndex(memoryTracker.getForgettingCurveIndex() + adjustment);
     memoryTracker.setNextRecallAt(memoryTracker.calculateNextRecallAt());
     entityPersister.save(memoryTracker);

--- a/backend/src/main/resources/db/migration/V300000115__change_forgetting_curve_index_to_float.sql
+++ b/backend/src/main/resources/db/migration/V300000115__change_forgetting_curve_index_to_float.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `memory_tracker` MODIFY COLUMN `forgetting_curve_index` FLOAT NOT NULL DEFAULT 100.0;

--- a/backend/src/test/java/com/odde/doughnut/algorithms/SpacedRepetitionEarlyRewardsAndLatePenaltyTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/SpacedRepetitionEarlyRewardsAndLatePenaltyTest.java
@@ -17,65 +17,65 @@ import com.odde.doughnut.utils.TimestampOperations;
 import org.junit.jupiter.api.Test;
 
 public class SpacedRepetitionEarlyRewardsAndLatePenaltyTest {
-  final int currentForgettingCurveIndex =
+  final float currentForgettingCurveIndex =
       DEFAULT_FORGETTING_CURVE_INDEX + DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT * 2;
-  final int baselineForgettingCurveIndex =
+  final float baselineForgettingCurveIndex =
       DEFAULT_FORGETTING_CURVE_INDEX + DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT * 3;
 
   @Test
   void repeatOnTime() {
-    int index = getNextForgettingCurveIndexWithDelay(0);
+    float index = getNextForgettingCurveIndexWithDelay(0);
     assertThat(index, equalTo(baselineForgettingCurveIndex));
   }
 
   @Test
   void repeatEarly_immediatelyWhichIsImpossible() {
-    int index = getNextForgettingCurveIndexWithDelay(-9 * 24);
+    float index = getNextForgettingCurveIndexWithDelay(-9 * 24);
     assertThat(index, equalTo(currentForgettingCurveIndex));
   }
 
   @Test
   void repeatEarly_inOneHour() {
-    int index = getNextForgettingCurveIndexWithDelay(-9 * 24 + 1);
+    float index = getNextForgettingCurveIndexWithDelay(-9 * 24 + 1);
     assertThat(index, greaterThanOrEqualTo(currentForgettingCurveIndex));
     assertThat(index, lessThan(baselineForgettingCurveIndex));
   }
 
   @Test
   void repeatEarly_OneHourEarlier() {
-    int index = getNextForgettingCurveIndexWithDelay(-1);
+    float index = getNextForgettingCurveIndexWithDelay(-1);
     assertThat(index, greaterThan(currentForgettingCurveIndex));
     assertThat(index, lessThanOrEqualTo(baselineForgettingCurveIndex));
   }
 
   @Test
   void repeatLate_byOneHour() {
-    int index = getNextForgettingCurveIndexWithDelay(1);
+    float index = getNextForgettingCurveIndexWithDelay(1);
     assertThat(index, greaterThan(currentForgettingCurveIndex));
     assertThat(index, lessThanOrEqualTo(baselineForgettingCurveIndex));
   }
 
   @Test
   void repeatLate_byOneDay() {
-    int index = getNextForgettingCurveIndexWithDelay(24);
+    float index = getNextForgettingCurveIndexWithDelay(24);
     assertThat(index, greaterThan(currentForgettingCurveIndex));
     assertThat(index, lessThan(baselineForgettingCurveIndex));
   }
 
   @Test
   void repeatLate_by10Days() {
-    int index = getNextForgettingCurveIndexWithDelay(10 * 24);
+    float index = getNextForgettingCurveIndexWithDelay(10 * 24);
     assertThat(index, lessThan(currentForgettingCurveIndex));
     assertThat(index, greaterThan(DEFAULT_FORGETTING_CURVE_INDEX));
   }
 
   @Test
   void repeatLate_byOneHundredDays() {
-    int index = getNextForgettingCurveIndexWithDelay(100 * 24);
+    float index = getNextForgettingCurveIndexWithDelay(100 * 24);
     assertThat(index, equalTo(DEFAULT_FORGETTING_CURVE_INDEX));
   }
 
-  private int getNextForgettingCurveIndexWithDelay(int delayInHours) {
+  private float getNextForgettingCurveIndexWithDelay(int delayInHours) {
     MakeMe makeMe = MakeMe.makeMeWithoutFactoryService();
     User user = makeMe.aUser().withSpaceIntervals("3, 6, 9, 12, 15").inMemoryPlease();
     Note note = makeMe.aNote().inMemoryPlease();

--- a/backend/src/test/java/com/odde/doughnut/controllers/RecallPromptControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/RecallPromptControllerTests.java
@@ -72,7 +72,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
           makeMe
               .aMemoryTrackerFor(answerNote)
               .by(currentUser.getUser())
-              .forgettingCurveAndNextRecallAt(200)
+              .forgettingCurveAndNextRecallAt(200.0f)
               .please();
       MCQWithAnswer mcqWithAnswer = makeMe.aMCQWithAnswer().please();
       recallPrompt =
@@ -100,7 +100,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void shouldNoteIncreaseIndexIfRepeatImmediately() {
       testabilitySettings.timeTravelTo(memoryTracker.getLastRecalledAt());
-      Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+      Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
       controller.answerQuiz(recallPrompt, answerDTO);
       assertThat(memoryTracker.getForgettingCurveIndex(), equalTo(oldForgettingCurveIndex));
     }
@@ -108,7 +108,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void shouldIncreaseTheIndex() {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+      Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
       controller.answerQuiz(recallPrompt, answerDTO);
       assertThat(memoryTracker.getForgettingCurveIndex(), greaterThan(oldForgettingCurveIndex));
       assertThat(
@@ -118,13 +118,13 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void fastAnswer_shouldIncreaseIndexMoreThanSlowAnswer() {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer baseIndex = memoryTracker.getForgettingCurveIndex();
+      Float baseIndex = memoryTracker.getForgettingCurveIndex();
       Timestamp baseLastRecalledAt = memoryTracker.getLastRecalledAt();
 
       // Fast answer (10 seconds)
       answerDTO.setThinkingTimeMs(10000);
       controller.answerQuiz(recallPrompt, answerDTO);
-      Integer indexWithFastAnswer = memoryTracker.getForgettingCurveIndex();
+      Float indexWithFastAnswer = memoryTracker.getForgettingCurveIndex();
 
       // Reset and try slow answer (40 seconds)
       memoryTracker.setForgettingCurveIndex(baseIndex);
@@ -139,7 +139,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       answerDTO.setThinkingTimeMs(40000);
       answerDTO.setChoiceIndex(0);
       controller.answerQuiz(secondRecallPrompt, answerDTO);
-      Integer indexWithSlowAnswer = memoryTracker.getForgettingCurveIndex();
+      Float indexWithSlowAnswer = memoryTracker.getForgettingCurveIndex();
 
       assertThat(indexWithFastAnswer, greaterThan(indexWithSlowAnswer));
     }
@@ -147,13 +147,13 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void answerWithBaseThinkingTime_shouldHaveNoThinkingTimeAdjustment() {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer baseIndex = memoryTracker.getForgettingCurveIndex();
+      Float baseIndex = memoryTracker.getForgettingCurveIndex();
       Timestamp baseLastRecalledAt = memoryTracker.getLastRecalledAt();
 
       // Answer with base thinking time (base case)
       answerDTO.setThinkingTimeMs(ForgettingCurve.BASE_THINKING_TIME_MS);
       controller.answerQuiz(recallPrompt, answerDTO);
-      Integer indexWithBaseThinkingTime = memoryTracker.getForgettingCurveIndex();
+      Float indexWithBaseThinkingTime = memoryTracker.getForgettingCurveIndex();
 
       // Reset and answer without thinking time
       memoryTracker.setForgettingCurveIndex(baseIndex);
@@ -168,7 +168,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       answerDTO.setThinkingTimeMs(null);
       answerDTO.setChoiceIndex(0);
       controller.answerQuiz(secondRecallPrompt, answerDTO);
-      Integer indexWithoutThinkingTime = memoryTracker.getForgettingCurveIndex();
+      Float indexWithoutThinkingTime = memoryTracker.getForgettingCurveIndex();
 
       assertThat(indexWithBaseThinkingTime, equalTo(indexWithoutThinkingTime));
     }
@@ -202,7 +202,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       void shouldNotChangeTheLastRecalledAtTime() {
         testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
         Timestamp lastRecalledAt = memoryTracker.getLastRecalledAt();
-        Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+        Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
         controller.answerQuiz(recallPrompt, answerDTO);
         assertThat(memoryTracker.getForgettingCurveIndex(), lessThan(oldForgettingCurveIndex));
         assertThat(memoryTracker.getLastRecalledAt(), equalTo(lastRecalledAt));
@@ -372,7 +372,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
           makeMe
               .aMemoryTrackerFor(answerNote)
               .by(currentUser.getUser())
-              .forgettingCurveAndNextRecallAt(200)
+              .forgettingCurveAndNextRecallAt(200.0f)
               .spelling()
               .please();
       recallPrompt = makeMe.aRecallPrompt().forMemoryTracker(memoryTracker).spelling().please();
@@ -444,7 +444,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void shouldNoteIncreaseIndexIfRepeatImmediately() throws UnexpectedNoAccessRightException {
       testabilitySettings.timeTravelTo(memoryTracker.getLastRecalledAt());
-      Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+      Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
       controller.answerSpelling(recallPrompt, answerDTO);
       assertThat(memoryTracker.getForgettingCurveIndex(), equalTo(oldForgettingCurveIndex));
     }
@@ -452,7 +452,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
     @Test
     void shouldIncreaseTheIndex() throws UnexpectedNoAccessRightException {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+      Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
       controller.answerSpelling(recallPrompt, answerDTO);
       assertThat(memoryTracker.getForgettingCurveIndex(), greaterThan(oldForgettingCurveIndex));
       assertThat(
@@ -463,13 +463,13 @@ class RecallPromptControllerTests extends ControllerTestBase {
     void fastAnswer_shouldIncreaseIndexMoreThanSlowAnswer()
         throws UnexpectedNoAccessRightException {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer baseIndex = memoryTracker.getForgettingCurveIndex();
+      Float baseIndex = memoryTracker.getForgettingCurveIndex();
       Timestamp baseLastRecalledAt = memoryTracker.getLastRecalledAt();
 
       // Fast answer (10 seconds)
       answerDTO.setThinkingTimeMs(10000);
       controller.answerSpelling(recallPrompt, answerDTO);
-      Integer indexWithFastAnswer = memoryTracker.getForgettingCurveIndex();
+      Float indexWithFastAnswer = memoryTracker.getForgettingCurveIndex();
 
       // Reset and try slow answer (40 seconds)
       memoryTracker.setForgettingCurveIndex(baseIndex);
@@ -481,7 +481,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       secondAnswerDTO.setSpellingAnswer(answerNote.getTitle());
       secondAnswerDTO.setThinkingTimeMs(40000);
       controller.answerSpelling(secondRecallPrompt, secondAnswerDTO);
-      Integer indexWithSlowAnswer = memoryTracker.getForgettingCurveIndex();
+      Float indexWithSlowAnswer = memoryTracker.getForgettingCurveIndex();
 
       assertThat(indexWithFastAnswer, greaterThan(indexWithSlowAnswer));
     }
@@ -490,13 +490,13 @@ class RecallPromptControllerTests extends ControllerTestBase {
     void answerWithBaseThinkingTime_shouldHaveNoThinkingTimeAdjustment()
         throws UnexpectedNoAccessRightException {
       testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
-      Integer baseIndex = memoryTracker.getForgettingCurveIndex();
+      Float baseIndex = memoryTracker.getForgettingCurveIndex();
       Timestamp baseLastRecalledAt = memoryTracker.getLastRecalledAt();
 
       // Answer with base thinking time (base case)
       answerDTO.setThinkingTimeMs(ForgettingCurve.BASE_THINKING_TIME_MS);
       controller.answerSpelling(recallPrompt, answerDTO);
-      Integer indexWithBaseThinkingTime = memoryTracker.getForgettingCurveIndex();
+      Float indexWithBaseThinkingTime = memoryTracker.getForgettingCurveIndex();
 
       // Reset and answer without thinking time
       memoryTracker.setForgettingCurveIndex(baseIndex);
@@ -508,7 +508,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       secondAnswerDTO.setSpellingAnswer(answerNote.getTitle());
       secondAnswerDTO.setThinkingTimeMs(null);
       controller.answerSpelling(secondRecallPrompt, secondAnswerDTO);
-      Integer indexWithoutThinkingTime = memoryTracker.getForgettingCurveIndex();
+      Float indexWithoutThinkingTime = memoryTracker.getForgettingCurveIndex();
 
       assertThat(indexWithBaseThinkingTime, equalTo(indexWithoutThinkingTime));
     }
@@ -551,7 +551,7 @@ class RecallPromptControllerTests extends ControllerTestBase {
       void shouldNotChangeTheLastRecalledAtTime() throws UnexpectedNoAccessRightException {
         testabilitySettings.timeTravelTo(memoryTracker.getNextRecallAt());
         Timestamp lastRecalledAt = memoryTracker.getLastRecalledAt();
-        Integer oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
+        Float oldForgettingCurveIndex = memoryTracker.getForgettingCurveIndex();
         controller.answerSpelling(recallPrompt, answerDTO);
         assertThat(memoryTracker.getForgettingCurveIndex(), lessThan(oldForgettingCurveIndex));
         assertThat(memoryTracker.getLastRecalledAt(), equalTo(lastRecalledAt));

--- a/backend/src/test/java/com/odde/doughnut/entities/ForgettingCurveThinkingTimeTest.java
+++ b/backend/src/test/java/com/odde/doughnut/entities/ForgettingCurveThinkingTimeTest.java
@@ -14,73 +14,73 @@ import com.odde.doughnut.algorithms.SpacedRepetitionAlgorithm;
 import org.junit.jupiter.api.Test;
 
 public class ForgettingCurveThinkingTimeTest {
-  private ForgettingCurve createForgettingCurve(int forgettingCurveIndex) {
+  private ForgettingCurve createForgettingCurve(float forgettingCurveIndex) {
     return new ForgettingCurve(new SpacedRepetitionAlgorithm(null), forgettingCurveIndex);
   }
 
   @Test
   void baseCase_shouldHaveZeroAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithoutThinkingTime = curve.succeeded(0, null);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWithoutThinkingTime = curve.succeeded(0, null);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
     assertThat(indexWithBaseThinkingTime, equalTo(indexWithoutThinkingTime));
   }
 
   @Test
   void fastAnswer_shouldHavePositiveAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
-    int indexWith10Seconds = curve.succeeded(0, 10000);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWith10Seconds = curve.succeeded(0, 10000);
     assertThat(indexWith10Seconds, greaterThan(indexWithBaseThinkingTime));
   }
 
   @Test
   void slowAnswer_shouldHaveNegativeAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
-    int indexWith40Seconds = curve.succeeded(0, 40000);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWith40Seconds = curve.succeeded(0, 40000);
     assertThat(indexWith40Seconds, lessThan(indexWithBaseThinkingTime));
   }
 
   @Test
   void verySlowAnswer_shouldHaveNegativeAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
-    int indexWithMaxThinkingTime = curve.succeeded(0, MAX_THINKING_TIME_MS);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWithMaxThinkingTime = curve.succeeded(0, MAX_THINKING_TIME_MS);
     assertThat(indexWithMaxThinkingTime, lessThan(indexWithBaseThinkingTime));
   }
 
   @Test
   void veryFastAnswer_shouldHavePositiveAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
-    int indexWith0Seconds = curve.succeeded(0, 0);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWith0Seconds = curve.succeeded(0, 0);
     assertThat(indexWith0Seconds, greaterThan(indexWithBaseThinkingTime));
   }
 
   @Test
   void thinkingTimeAboveMax_shouldBeClamped() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithMaxThinkingTime = curve.succeeded(0, MAX_THINKING_TIME_MS);
-    int indexWith100Seconds = curve.succeeded(0, 100000);
+    float indexWithMaxThinkingTime = curve.succeeded(0, MAX_THINKING_TIME_MS);
+    float indexWith100Seconds = curve.succeeded(0, 100000);
     assertThat(indexWith100Seconds, equalTo(indexWithMaxThinkingTime));
   }
 
   @Test
   void nullThinkingTime_shouldHaveNoAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithNull = curve.succeeded(0, null);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWithNull = curve.succeeded(0, null);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
     assertThat(indexWithNull, equalTo(indexWithBaseThinkingTime));
   }
 
   @Test
   void thinkingTimeAdjustmentCombinedWithDelayAdjustment() {
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexOnTimeWithBase = curve.succeeded(0, BASE_THINKING_TIME_MS);
-    int indexOnTimeWith10Seconds = curve.succeeded(0, 10000);
-    int indexLateWithBase = curve.succeeded(24, BASE_THINKING_TIME_MS);
-    int indexLateWith10Seconds = curve.succeeded(24, 10000);
+    float indexOnTimeWithBase = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexOnTimeWith10Seconds = curve.succeeded(0, 10000);
+    float indexLateWithBase = curve.succeeded(24, BASE_THINKING_TIME_MS);
+    float indexLateWith10Seconds = curve.succeeded(24, 10000);
 
     // Fast thinking time should increase index more than base thinking time
     assertThat(indexOnTimeWith10Seconds, greaterThan(indexOnTimeWithBase));
@@ -96,11 +96,11 @@ public class ForgettingCurveThinkingTimeTest {
     // This test ensures that when BASE_THINKING_TIME_MS is changed in the future,
     // developers will be reminded to adjust the scale if needed
     ForgettingCurve curve = createForgettingCurve(DEFAULT_FORGETTING_CURVE_INDEX + 20);
-    int indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
+    float indexWithBaseThinkingTime = curve.succeeded(0, BASE_THINKING_TIME_MS);
     // 0.001 seconds = 1 millisecond
-    int indexWithVeryFastThinkingTime = curve.succeeded(0, 1);
-    int adjustment = indexWithVeryFastThinkingTime - indexWithBaseThinkingTime;
+    float indexWithVeryFastThinkingTime = curve.succeeded(0, 1);
+    float adjustment = indexWithVeryFastThinkingTime - indexWithBaseThinkingTime;
     // When BASE_THINKING_TIME_MS is changed, the scale may need adjustment
-    assertThat(adjustment, lessThanOrEqualTo(DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT / 2));
+    assertThat(adjustment, lessThanOrEqualTo((float) DEFAULT_FORGETTING_CURVE_INDEX_INCREMENT / 2));
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/services/RecallServiceWithSpacedRepetitionAlgorithmTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/RecallServiceWithSpacedRepetitionAlgorithmTest.java
@@ -100,15 +100,15 @@ public class RecallServiceWithSpacedRepetitionAlgorithmTest {
     class EarlyAndLateReview {
       @ParameterizedTest
       @CsvSource({
-        "0, 0,  100",
-        "0, 1,  110",
-        "2, -1,  115",
-        "2, 0, 120",
-        "2, 1, 115",
-        "2, 100, 100",
+        "0, 0,  100.0",
+        "0, 1,  110.0",
+        "2, -1,  115.0",
+        "2, 0, 120.0",
+        "2, 1, 115.0",
+        "2, 100, 100.0",
       })
       void aMemoryTrackerHasBeenReviewedStrictly(
-          int ntimes, Integer daysDelay, int expectedForgettingCurveIndex) {
+          int ntimes, Integer daysDelay, float expectedForgettingCurveIndex) {
         MemoryTracker memoryTracker =
             makeMe.aMemoryTrackerFor(note).by(user).afterNthStrictRepetition(ntimes).please();
         Timestamp currentUTCTimestamp =

--- a/backend/src/test/java/com/odde/doughnut/testability/builders/MemoryTrackerBuilder.java
+++ b/backend/src/test/java/com/odde/doughnut/testability/builders/MemoryTrackerBuilder.java
@@ -34,7 +34,7 @@ public class MemoryTrackerBuilder extends EntityBuilder<MemoryTracker> {
   @Override
   protected void beforeCreate(boolean needPersist) {}
 
-  public MemoryTrackerBuilder forgettingCurveAndNextRecallAt(int value) {
+  public MemoryTrackerBuilder forgettingCurveAndNextRecallAt(float value) {
     entity.setForgettingCurveIndex(value);
     entity.setNextRecallAt(entity.calculateNextRecallAt());
     return this;

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -4137,8 +4137,8 @@ components:
           type: integer
           format: int32
         forgettingCurveIndex:
-          type: integer
-          format: int32
+          type: number
+          format: float
         removedFromTracking:
           type: boolean
         spelling:


### PR DESCRIPTION
Migrate `forgettingCurveIndex` to a float to enable more precise calculations for early/late penalties and thinking time adjustments.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1766291897520879?thread_ts=1766291897.520879&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-3ba2476e-55c1-4448-8785-4a3ca6742a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ba2476e-55c1-4448-8785-4a3ca6742a68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates `forgettingCurveIndex` from int to float across code, DB, tests, and OpenAPI, refining success/failure and thinking-time calculations.
> 
> - **Backend**:
>   - Convert `ForgettingCurve` index to `Float`; `succeeded`/`failed` now return `float` and use non-rounded thinking-time adjustments.
>   - Update `MemoryTracker.forgettingCurveIndex` to `Float` and `MemoryTrackerService.updateForgettingCurve` to accept `float`.
> - **Database**:
>   - Migration alters `memory_tracker.forgetting_curve_index` to `FLOAT NOT NULL DEFAULT 100.0`.
> - **Tests**:
>   - Adjust tests/builders to use float indices and expectations throughout (`.forgettingCurveAndNextRecallAt(200.0f)`, float assertions).
> - **API**:
>   - OpenAPI: change `MemoryTracker.forgettingCurveIndex` to `number (float)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04f05fe72b05c6f77b8711017fd754d67461f8f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->