### PR TITLE
Marked cjk underscore handling

### DIFF
--- a/frontend/src/components/form/markdownToQuillHtml.ts
+++ b/frontend/src/components/form/markdownToQuillHtml.ts
@@ -1,4 +1,8 @@
 import { marked, type Tokens } from "marked"
+import { markedCjkUnderscoreExtension } from "./markedCjkUnderscoreExtension"
+
+// Apply the CJK underscore extension globally
+marked.use(markedCjkUnderscoreExtension)
 
 export interface MarkdownToHtmlOptions {
   preserve_pre?: boolean

--- a/frontend/src/components/form/markedCjkUnderscoreExtension.ts
+++ b/frontend/src/components/form/markedCjkUnderscoreExtension.ts
@@ -1,0 +1,54 @@
+import type { MarkedExtension } from "marked"
+
+// CJK character ranges:
+// - CJK Unified Ideographs: \u4E00-\u9FFF
+// - Hiragana: \u3040-\u309F
+// - Katakana: \u30A0-\u30FF
+// - Hangul: \uAC00-\uD7AF
+const cjkCharRegex = /[\u4E00-\u9FFF\u3040-\u309F\u30A0-\u30FF\uAC00-\uD7AF]/
+
+// CJK punctuation and fullwidth forms:
+// - CJK Symbols and Punctuation: \u3000-\u303F (includes 。、「」etc.)
+// - Halfwidth and Fullwidth Forms: \uFF00-\uFFEF (includes （）etc.)
+const cjkPunctuationRegex = /[\u3000-\u303F\uFF00-\uFFEF]/
+
+/**
+ * Check if a character is CJK content (character or punctuation)
+ */
+function isCjkContext(char: string | undefined): boolean {
+  return (
+    char !== undefined &&
+    (cjkCharRegex.test(char) || cjkPunctuationRegex.test(char))
+  )
+}
+
+/**
+ * Marked extension to handle CJK underscore emphasis correctly.
+ *
+ * In CJK text, underscores adjacent to CJK characters or punctuation
+ * should NOT be treated as emphasis delimiters. This is because:
+ * 1. CJK languages don't use spaces between words/characters
+ * 2. Users may want to use underscores as visual markers without emphasis
+ * 3. Standard markdown emphasis rules don't work well with CJK punctuation
+ *
+ * This extension prevents underscore-based emphasis when the underscore
+ * is adjacent to CJK content (characters or punctuation like 「」。、（）etc.)
+ */
+export const markedCjkUnderscoreExtension: MarkedExtension = {
+  tokenizer: {
+    emStrong(src: string, _maskedSrc: string, prevChar?: string) {
+      // Only handle underscore-based emphasis
+      if (!src.startsWith("_")) {
+        return false // Let default handle asterisk-based emphasis
+      }
+
+      // Check if in CJK context - prevChar is CJK character or punctuation
+      if (isCjkContext(prevChar)) {
+        // Return undefined to skip emphasis parsing for this underscore
+        return undefined
+      }
+
+      return false // Let default handle it
+    },
+  },
+}

--- a/frontend/tests/components/form/markdownizer.spec.ts
+++ b/frontend/tests/components/form/markdownizer.spec.ts
@@ -200,6 +200,65 @@ describe("Markdown and HTML Conversion Tests", () => {
       expect(html).toBe("<p>hello 世界</p>")
     })
 
+    describe("CJK underscore handling", () => {
+      it("does not treat underscores as emphasis when adjacent to CJK characters", () => {
+        const markdown = "これは_重要_なことです"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>これは_重要_なことです</p>")
+        expect(html).not.toContain("<em>")
+      })
+
+      it("does not treat underscores as emphasis after CJK opening bracket", () => {
+        const markdown = "「_水曜日_」"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>「_水曜日_」</p>")
+        expect(html).not.toContain("<em>")
+      })
+
+      it("does not treat underscores as emphasis after Japanese period", () => {
+        const markdown = "日本語。_日本語_"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>日本語。_日本語_</p>")
+        expect(html).not.toContain("<em>")
+      })
+
+      it("does not treat underscores as emphasis after Japanese comma", () => {
+        const markdown = "、_水曜日_"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>、_水曜日_</p>")
+        expect(html).not.toContain("<em>")
+      })
+
+      it("does not treat underscores as emphasis inside fullwidth parentheses", () => {
+        const markdown = "読むこと（_read_）"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>読むこと（_read_）</p>")
+        expect(html).not.toContain("<em>")
+      })
+
+      it("does not treat underscores as emphasis in the user's original example", () => {
+        const markdown = "てっきり今日は水曜日だ_とばかり思っていました_。"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe(
+          "<p>てっきり今日は水曜日だ_とばかり思っていました_。</p>"
+        )
+        expect(html).not.toContain("<em>")
+      })
+
+      it("still treats underscores as emphasis in regular English text", () => {
+        const markdown = "hello _world_ there"
+        const html = markdownizer.markdownToHtml(markdown)
+        expect(html).toBe("<p>hello <em>world</em> there</p>")
+      })
+
+      it("still treats asterisk-based emphasis normally", () => {
+        const markdown = "これは*重要*です"
+        const html = markdownizer.markdownToHtml(markdown)
+        // Asterisks should still work for emphasis
+        expect(html).toContain("<em>重要</em>")
+      })
+    })
+
     it("converts markdown code block to Quill code block HTML", () => {
       const markdown = "```\nContent\n```"
       const html = markdownizer.markdownToHtml(markdown)


### PR DESCRIPTION
Prevents `marked` from interpreting underscores as emphasis when adjacent to CJK characters or punctuation to avoid incorrect rendering in Japanese text.

Markdown's `_text_` emphasis rule conflicts with common usage in CJK languages where underscores are often intended as literal characters or visual markers. Due to the absence of spaces in CJK, `marked` incorrectly parses these as italics, leading to misinterpretation and rendering issues. This PR introduces a `marked` extension to address this by preventing underscore-based emphasis when in a CJK context.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1767339735992609?thread_ts=1767339735.992609&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-beac1c04-a754-445f-87c3-f4c34d72ae11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-beac1c04-a754-445f-87c3-f4c34d72ae11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `marked` extension to correctly handle underscores in CJK text and applies it globally.
> 
> - Adds `markedCjkUnderscoreExtension` to skip underscore emphasis when adjacent to CJK characters/punctuation
> - Applies the extension in `markdownToQuillHtml` via `marked.use(...)`
> - Extends tests in `markdownizer.spec.ts` to verify CJK underscore behavior, English underscore emphasis, and asterisk emphasis
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1c0fd5d564eb5834c28464d4d5ac6ba4d0f24c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->