### PR TITLE
Recalling button visibility

### DIFF
--- a/frontend/src/composables/useNavigationItems.ts
+++ b/frontend/src/composables/useNavigationItems.ts
@@ -14,8 +14,13 @@ import { messageCenterConversations } from "@/store/messageStore"
 export function useNavigationItems() {
   const route = useRoute()
   const { dueCount } = useAssimilationCount()
-  const { toRepeatCount, isRecallPaused, currentIndex, diligentMode } =
-    useRecallData()
+  const {
+    toRepeatCount,
+    toRepeat,
+    isRecallPaused,
+    currentIndex,
+    diligentMode,
+  } = useRecallData()
 
   const upperNavItems = computed(() => {
     const baseItems = [
@@ -50,11 +55,15 @@ export function useNavigationItems() {
     // Recall is paused if:
     // 1. previousAnsweredQuestionCursor is set (viewing answered question), OR
     // 2. currentIndex > 0 (not at first memory tracker) AND not on recall page
-    // Resume button should only show when there are memory trackers to recall (toRepeatCount > 0)
+    // Resume button shows when:
+    // - isPausedByCursor is true AND memory trackers are loaded (viewing previously answered question)
+    // - isPausedByIndex is true AND there are memory trackers remaining to recall
+    const hasLoadedTrackers = (toRepeat.value?.length ?? 0) > 0
     const isPausedByCursor = isRecallPaused.value
     const isPausedByIndex = currentIndex.value > 0 && route.name !== "recall"
     const shouldShowResume =
-      (isPausedByCursor || isPausedByIndex) && toRepeatCount.value > 0
+      (isPausedByCursor && hasLoadedTrackers) ||
+      (isPausedByIndex && toRepeatCount.value > 0)
 
     if (shouldShowResume) {
       return [

--- a/frontend/tests/toolbars/MainMenu.spec.ts
+++ b/frontend/tests/toolbars/MainMenu.spec.ts
@@ -607,7 +607,7 @@ describe("main menu", () => {
       },
       {
         description:
-          "does not show resume recall menu item when toRepeatCount is 0 even if currentIndex > 0",
+          "does not show resume recall menu item when toRepeatCount is 0 and not paused even if currentIndex > 0",
         routeName: "notebooks",
         isRecallPaused: false,
         currentIndex: 5,
@@ -616,6 +616,18 @@ describe("main menu", () => {
           spelling?: boolean
         }>,
         shouldShow: false,
+      },
+      {
+        description:
+          "shows resume recall menu item when viewing last answered question (isRecallPaused true) even if toRepeatCount is 0",
+        routeName: "notebooks",
+        isRecallPaused: true,
+        currentIndex: 5,
+        toRepeat: Array(5).fill({}) as Array<{
+          memoryTrackerId?: number
+          spelling?: boolean
+        }>,
+        shouldShow: true,
       },
     ])("$description", async ({
       routeName,


### PR DESCRIPTION
Fixes the "Resume Recalling" button not appearing when viewing the last answered memory tracker.

The previous condition for showing the "Resume Recalling" button (`(isPausedByCursor || isPausedByIndex) && toRepeatCount > 0`) incorrectly hid the button when viewing the last answered question because `toRepeatCount` became 0. The updated logic now correctly displays the button if recall is paused and memory trackers are loaded, regardless of whether there are remaining unanswered items.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1769124307009599?thread_ts=1769124307.009599&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-476cd0e8-dfc1-4b8b-9cdd-2823298d491e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-476cd0e8-dfc1-4b8b-9cdd-2823298d491e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines when the `Resume` nav item appears during recall.
> 
> - Updates `useNavigationItems` to derive `shouldShowResume` as `(isPausedByCursor && hasLoadedTrackers) || (isPausedByIndex && toRepeatCount > 0)`, using `toRepeat` length to detect loaded trackers
> - Extends `useRecallData` usage to include `toRepeat`
> - Updates `MainMenu.spec` to cover paused-by-cursor with zero `toRepeatCount`, adjusts descriptions, and adds assertions for the new visibility behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90d0c928aee4edfb33365a83011f7605b7f58af8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->