### PR TITLE
Katawara cloze text issue

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
@@ -43,15 +43,23 @@ record ClozeReplacement(
     return noteTitle.stream().reduce(processed, replacer, (x, y) -> y);
   }
 
-  String maskPronunciationsAndTitles(String originalContent1, List<NoteTitle> noteTitles1) {
+  String maskPronunciationsAndTitles(
+      String originalContent1, List<NoteTitle> noteTitles1, boolean followsNonWhitespace) {
     final String internalPronunciationReplacement = "__p_r_o_n_u_n_c__";
     final Pattern pattern =
         Pattern.compile(
             "/[^\\s/][^/\\n]*/(?!\\w)", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+    // If this segment follows a non-whitespace character in the original HTML,
+    // prepend a zero-width marker so suffix patterns can match at segment start
+    String contentToProcess = originalContent1;
+    if (followsNonWhitespace) {
+      contentToProcess = HtmlOrMarkdown.NON_WHITESPACE_CONTEXT_MARKER + originalContent1;
+    }
     String pronunciationsReplaced =
-        pattern.matcher(originalContent1).replaceAll(internalPronunciationReplacement);
+        pattern.matcher(contentToProcess).replaceAll(internalPronunciationReplacement);
     return noteTitles1.stream()
         .reduce(pronunciationsReplaced, this::replaceTitleFragments, (s, s2) -> s)
-        .replace(internalPronunciationReplacement, pronunciationReplacement);
+        .replace(internalPronunciationReplacement, pronunciationReplacement)
+        .replace(HtmlOrMarkdown.NON_WHITESPACE_CONTEXT_MARKER, "");
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozedString.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozedString.java
@@ -51,7 +51,10 @@ public class ClozedString {
 
   private String cloze(String content) {
     return new HtmlOrMarkdown(content)
-        .replaceText(text -> clozeReplacement.maskPronunciationsAndTitles(text, noteTitles));
+        .replaceTextWithContext(
+            (text, followsNonWhitespace) ->
+                clozeReplacement.maskPronunciationsAndTitles(
+                    text, noteTitles, followsNonWhitespace));
   }
 
   private String htmlContent() {

--- a/backend/src/main/java/com/odde/doughnut/algorithms/HtmlOrMarkdown.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/HtmlOrMarkdown.java
@@ -1,15 +1,48 @@
 package com.odde.doughnut.algorithms;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public record HtmlOrMarkdown(String htmlOrMarkdown) {
+  // Zero-width space used as a marker to indicate that the segment follows a non-whitespace char
+  static final String NON_WHITESPACE_CONTEXT_MARKER = "\u200B";
+
   public String replaceText(Function<String, String> callback) {
+    return replaceTextWithContext((text, context) -> callback.apply(text));
+  }
+
+  public String replaceTextWithContext(BiFunction<String, Boolean, String> callback) {
     Pattern pattern = Pattern.compile("(?s)(?<=^|>)[^><]+?(?=<|$)");
     Matcher matcher = pattern.matcher(htmlOrMarkdown);
     return matcher.replaceAll(
-        matchResult -> Matcher.quoteReplacement(callback.apply(matchResult.group())));
+        matchResult -> {
+          String text = matchResult.group();
+          int start = matchResult.start();
+          // Check if this segment follows a non-whitespace character (before the preceding tag)
+          boolean followsNonWhitespace = checkPrecedingNonWhitespace(start);
+          return Matcher.quoteReplacement(callback.apply(text, followsNonWhitespace));
+        });
+  }
+
+  private boolean checkPrecedingNonWhitespace(int segmentStart) {
+    if (segmentStart == 0) return false;
+    // Find the character before any preceding tag
+    int i = segmentStart - 1;
+    // Skip backwards past the closing '>' if present
+    if (i >= 0 && htmlOrMarkdown.charAt(i) == '>') {
+      // Find the matching '<' of this tag
+      while (i > 0 && htmlOrMarkdown.charAt(i) != '<') {
+        i--;
+      }
+      // Now check the character before the tag
+      if (i > 0) {
+        char precedingChar = htmlOrMarkdown.charAt(i - 1);
+        return !Character.isWhitespace(precedingChar) && precedingChar != '>';
+      }
+    }
+    return false;
   }
 
   public boolean isBlank() {

--- a/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
@@ -57,6 +57,7 @@ class ClozeDescriptionTest {
     "cat/dog(animal/weather), dog day is a hot weather,   [...] day is a hot <...>",
     "6,               6year,                              [...]year",
     "cat,             <p class='cat'>a cat</p>,           <p class='cat'>a [...]</p>",
+    "～かたわら,        彼女は猫を可愛がる*かたわら*、犬に対してはなぜか冷たい。,  [...]",
   })
   void clozeDescription(String title, String details, String expectedClozeDescription) {
     assertThat(


### PR DESCRIPTION
Fixes cloze text function to correctly mask words within HTML/markdown tags, particularly for Japanese suffix matching.

The `ClozePatternCreator`'s suffix pattern `(?<=[^\s])` failed to match words like `かたわら` when they were isolated within `<em>` tags (e.g., from `*かたわら*`). This was because the lookbehind assertion couldn't find a preceding non-whitespace character at the start of the HTML text segment. The solution introduces context tracking in `HtmlOrMarkdown` to determine if a segment follows a non-whitespace character in the original HTML, prepending a temporary zero-width marker to allow the suffix regex to succeed.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1770075601077009?thread_ts=1770075601.077009&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-7ddee74d-cff4-54da-a90d-d2f0f9c99dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ddee74d-cff4-54da-a90d-d2f0f9c99dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core text-replacement behavior across all HTML segments and introduces a zero-width marker, which could subtly affect regex matching or edge-case rendering if not fully covered by tests.
> 
> **Overview**
> Fixes cloze masking for suffix-based patterns when the target text is split by HTML/markdown tags (e.g., `*かたわら*` rendering into `<em>`), by tracking whether each text segment follows a non-whitespace character in the original HTML.
> 
> `HtmlOrMarkdown` now exposes `replaceTextWithContext` to pass this context into cloze processing; `ClozeReplacement.maskPronunciationsAndTitles` uses it to prepend a temporary zero-width marker so `ClozePatternCreator`’s suffix lookbehind can still match at segment boundaries, then strips the marker. Adds a regression test for `～かたわら`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6beb99b00b08fb019c4f49711fa47351307cf6e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->