### PR TITLE
Node graph truncation limit

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/graphRAG/GraphRAGConstants.java
+++ b/backend/src/main/java/com/odde/doughnut/services/graphRAG/GraphRAGConstants.java
@@ -1,6 +1,6 @@
 package com.odde.doughnut.services.graphRAG;
 
 public class GraphRAGConstants {
-  public static final int RELATED_NOTE_DETAILS_TRUNCATE_LENGTH = 250;
+  public static final int RELATED_NOTE_DETAILS_TRUNCATE_LENGTH = 500;
   public static final double CHARACTERS_PER_TOKEN = 3.75;
 }

--- a/backend/src/test/java/com/odde/doughnut/services/graphRAG/GraphRAGResultTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/graphRAG/GraphRAGResultTest.java
@@ -214,8 +214,8 @@ class GraphRAGResultTest {
 
     @Test
     void shouldIncludeDetailsTruncatedAsTrueWhenDetailsAreTruncated() throws Exception {
-      // Arrange - create details longer than truncation limit (250 bytes)
-      String longDetails = "x".repeat(300); // 300 characters should exceed 250 bytes
+      // Arrange - create details longer than truncation limit (500 bytes)
+      String longDetails = "x".repeat(600); // 600 characters should exceed 500 bytes
       Note note = makeMe.aNote().title("Long Note").details(longDetails).please();
       BareNote bareNote = BareNote.fromNote(note, RelationshipToFocusNote.Child);
 


### PR DESCRIPTION
Double the truncation size limit for related node details in the node graph generation to provide more context.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1770081394230619?thread_ts=1770081394.230619&cid=D092E33M7FG)

<a href="https://cursor.com/background-agent?bcId=bc-f9a268c0-fe16-5015-b45a-7e5a798af14a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9a268c0-fe16-5015-b45a-7e5a798af14a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

