### PR TITLE
Br tag visibility issue

### DIFF
--- a/frontend/src/components/form/markdownToQuillHtml.ts
+++ b/frontend/src/components/form/markdownToQuillHtml.ts
@@ -206,6 +206,21 @@ export default function markdownToQuillHtml(
       /(<\/ol>|<\/ul>)<br class="softbreak">(<p>|<ol>|<ul>|<h[1-6]>|<blockquote>|<pre>|$)/g,
       '$1<p><br class="softbreak"></p>$2'
     )
+    // Match <br class="softbreak"> at the end of content after </p>
+    // Use a loop to handle multiple consecutive <br> tags
+    while (
+      /<\/p><br class="softbreak">(<br class="softbreak">|$)/.test(result)
+    ) {
+      result = result.replace(
+        /<\/p><br class="softbreak">(<br class="softbreak">|$)/g,
+        '</p><p><br class="softbreak"></p>$1'
+      )
+    }
+    // Match standalone <br class="softbreak"> at the very end (after all other processing)
+    result = result.replace(
+      /<br class="softbreak">$/,
+      '<p><br class="softbreak"></p>'
+    )
     return result
   }
 

--- a/frontend/tests/components/form/markdownizer.spec.ts
+++ b/frontend/tests/components/form/markdownizer.spec.ts
@@ -207,6 +207,23 @@ describe("Markdown and HTML Conversion Tests", () => {
       expect(html).not.toMatch(/<br[^>]*>\n/)
     })
 
+    it("renders <br> correctly in round-trip conversion without escaping", () => {
+      // Bug fix: Multiple <br> tags at end of content were being escaped
+      // after round-trip conversion (markdown -> HTML -> markdown -> HTML)
+      const originalMarkdown = "A\n\n<br>\n\n<br>"
+      const html1 = markdownizer.markdownToHtml(originalMarkdown)
+      // First HTML should have <br class="softbreak"> wrapped in <p> tags
+      expect(html1).toContain('<br class="softbreak">')
+
+      const markdown = markdownizer.htmlToMarkdown(html1)
+      expect(markdown).toContain("<br>")
+
+      const html2 = markdownizer.markdownToHtml(markdown)
+      // The <br> tags should NOT be escaped as &lt;br&gt;
+      expect(html2).not.toContain("&lt;br&gt;")
+      expect(html2).toContain("<br")
+    })
+
     it("joins single newlines in alphabetical text with space", () => {
       const markdown = "hello\nwork"
       const html = markdownizer.markdownToHtml(markdown)


### PR DESCRIPTION
Correctly render `<br>` tags in round-trip markdown conversion to prevent them from being escaped.

The `wrapStandaloneBrInParagraph` function in `markdownToQuillHtml.ts` failed to correctly wrap `<br>` tags appearing at the end of content after `</p>` or multiple consecutive `<br>` tags. This resulted in the `<br>` tags being escaped as `&lt;br&gt;` during a markdown -> HTML -> markdown -> HTML round-trip, making them visible as text instead of rendering as line breaks.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1770335133094339?thread_ts=1770335133.094339&cid=D092E33M7FG)

<p><a href="https://cursor.com/background-agent?bcId=bc-66383fdf-06df-53f1-b947-afb07bd25eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66383fdf-06df-53f1-b947-afb07bd25eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

