### PR TITLE
Recall memory tracker order

### DIFF
--- a/frontend/src/pages/RecallPage.vue
+++ b/frontend/src/pages/RecallPage.vue
@@ -83,9 +83,7 @@ import {
 } from "@generated/backend/sdk.gen"
 import usePopups from "@/components/commons/Popups/usePopups"
 import { apiCallWithLoading } from "@/managedApi/clientSetup"
-import getEnvironment from "@/managedApi/window/getEnvironment"
 import timezoneParam from "@/managedApi/window/timezoneParam"
-import { shuffle } from "es-toolkit"
 import {
   computed,
   ref,
@@ -250,17 +248,9 @@ const loadMore = async (dueInDays?: number) => {
       },
     })
     if (!error && response) {
-      let trackers = response.toRepeat
       currentIndex.value = 0
       setDiligentMode((dueInDays ?? 0) > 0)
-      if (trackers?.length === 0) {
-        setToRepeat(trackers)
-        return response
-      }
-      if (getEnvironment() !== "testing" && trackers) {
-        trackers = shuffle(trackers)
-      }
-      setToRepeat(trackers)
+      setToRepeat(response.toRepeat)
       return response
     }
     return undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove conditional shuffle logic from `RecallPage.vue` to ensure memory trackers are consistently ordered by due time across all environments.

The previous implementation had a conditional shuffle that only applied in production (`odd-e.com`), causing memory trackers to be randomized there but ordered by due time in other environments. This PR aligns the behavior everywhere to be consistently ordered by due time, as requested.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1772506237631639?thread_ts=1772506237.631639&cid=D092E33M7FG)

<p><a href="https://cursor.com/agents/bc-f14bd04c-f563-5057-b574-a07f12f4a706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f14bd04c-f563-5057-b574-a07f12f4a706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->