### PR TITLE
Answered prompt frontend guard

### DIFF
--- a/frontend/src/components/recall/SpellingQuestionDisplay.vue
+++ b/frontend/src/components/recall/SpellingQuestionDisplay.vue
@@ -21,6 +21,7 @@
               type="submit"
               value="Answer"
               class="daisy-btn daisy-btn-primary daisy-btn"
+              :disabled="submitted"
             />
           </template>
         </TextInput>
@@ -49,6 +50,7 @@ const emits = defineEmits(["answer"])
 const spellingAnswer = ref("")
 const recallPrompt = ref<RecallPrompt>()
 const loading = ref(true)
+const submitted = ref(false)
 
 const isActiveQuestion = computed(() => !loading.value)
 const { stop } = useQuestionThinkingTime(isActiveQuestion)
@@ -68,6 +70,8 @@ const fetchSpellingQuestion = async () => {
 }
 
 const submitAnswer = () => {
+  if (submitted.value) return
+  submitted.value = true
   const thinkingTimeMs = stop()
   emits("answer", {
     spellingAnswer: spellingAnswer.value,

--- a/frontend/tests/components/recall/SpellingQuestionDisplay.spec.ts
+++ b/frontend/tests/components/recall/SpellingQuestionDisplay.spec.ts
@@ -123,4 +123,64 @@ describe("SpellingQuestionDisplay", () => {
     expect(answerData?.spellingAnswer).toBe("cat")
     expect(answerData?.recallPromptId).toBeDefined()
   })
+
+  it("prevents double submission when form is submitted multiple times", async () => {
+    let rafCallbacks: Array<FrameRequestCallback> = []
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return 1
+      }
+    )
+
+    const wrapper = helper
+      .component(SpellingQuestionDisplay)
+      .withProps({ memoryTrackerId: 1 })
+      .mount()
+
+    await flushPromises()
+    const callbacks = [...rafCallbacks]
+    rafCallbacks = []
+    callbacks.forEach((cb) => cb(performance.now()))
+
+    const input = wrapper.find("input[placeholder='put your answer here']")
+    await input.setValue("cat")
+
+    await wrapper.find("form").trigger("submit")
+    await wrapper.find("form").trigger("submit")
+    await wrapper.find("form").trigger("submit")
+
+    const emitted = wrapper.emitted("answer")
+    expect(emitted).toBeTruthy()
+    expect(emitted!.length).toBe(1)
+  })
+
+  it("disables submit button after form is submitted", async () => {
+    let rafCallbacks: Array<FrameRequestCallback> = []
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return 1
+      }
+    )
+
+    const wrapper = helper
+      .component(SpellingQuestionDisplay)
+      .withProps({ memoryTrackerId: 1 })
+      .mount()
+
+    await flushPromises()
+    const callbacks = [...rafCallbacks]
+    rafCallbacks = []
+    callbacks.forEach((cb) => cb(performance.now()))
+
+    const submitButton = wrapper.find("input[type='submit']")
+    expect(submitButton.attributes("disabled")).toBeUndefined()
+
+    const input = wrapper.find("input[placeholder='put your answer here']")
+    await input.setValue("cat")
+    await wrapper.find("form").trigger("submit")
+
+    expect(submitButton.attributes("disabled")).toBeDefined()
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevent double submission of spelling answers in the frontend.

The backend throws an `IllegalArgumentException` if a recall prompt is answered multiple times. This fix prevents the frontend from sending multiple answer requests and provides visual feedback by disabling the submit button after the first submission.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1772509586244159?thread_ts=1772509586.244159&cid=D092E33M7FG)

<p><a href="https://cursor.com/agents/bc-389e9bda-c221-5d76-a8d4-20659457b9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-389e9bda-c221-5d76-a8d4-20659457b9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->