### PR TITLE
Wikidata search null handling

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/services/wikidataApis/thirdPartyEntities/WikidataSearchResult.java
+++ b/backend/src/main/java/com/odde/doughnut/services/wikidataApis/thirdPartyEntities/WikidataSearchResult.java
@@ -1,6 +1,7 @@
 package com.odde.doughnut.services.wikidataApis.thirdPartyEntities;
 
 import com.odde.doughnut.controllers.dto.WikidataSearchEntity;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,6 +10,9 @@ public class WikidataSearchResult {
   public List<Map<String, Object>> search;
 
   public List<WikidataSearchEntity> getWikidataSearchEntities() {
+    if (search == null) {
+      return Collections.emptyList();
+    }
     return search.stream().map(WikidataSearchEntity::new).collect(Collectors.toList());
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/controllers/WikidataControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/WikidataControllerTests.java
@@ -147,5 +147,14 @@ class WikidataControllerTests extends ControllerTestBase {
               URI.create(
                   "https://www.wikidata.org/w/api.php?action=wbsearchentities&search=%E6%A2%B5%E6%88%91%E4%B8%80%E5%A6%82&format=json&language=en&uselang=en&type=item&limit=10"));
     }
+
+    @Test
+    void shouldReturnEmptyListWhenSearchFieldIsNull()
+        throws IOException, InterruptedException, BindException {
+      Mockito.when(httpClientAdapter.getResponseString(any()))
+          .thenReturn("{\"searchinfo\":{\"search\":\"\"}}");
+      List<WikidataSearchEntity> result = controller.searchWikidata("");
+      assertThat(result.size(), is(0));
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix `NullPointerException` in Wikidata search when the `search` field is null in the API response.

The `search` field in the Wikidata API response can be null, particularly for empty search queries, causing a `NullPointerException`. This PR handles the null case by returning an empty list.

---
[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1772511109472619?thread_ts=1772511109.472619&cid=D092E33M7FG)

<p><a href="https://cursor.com/agents/bc-5fe9fa0b-6d01-5fae-bf45-3c07d211e74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fe9fa0b-6d01-5fae-bf45-3c07d211e74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->