### PR TITLE
CLI: remove fixed timeouts from InteractiveCliApp unit tests; document rule

### DIFF
--- a/.cursor/rules/cli.mdc
+++ b/.cursor/rules/cli.mdc
@@ -44,6 +44,8 @@ The roadmap services as a guideline for growing the architecture. It is not for 
 
 For **interactive** behavior, prefer **`runInteractive`** with a **mock TTY** stdin and assert **stdout** / visible output — the test may **not import** the adapter or helper you changed; coverage through the CLI surface is enough. Use **`processInput`** + mock **`OutputAdapter`** for the **default console adapter** contract, helpers, or when there is no stable TTY hook. See **Testing strategy → Observable behavior first** in `.cursor/rules/planning.mdc`.
 
+**No fixed-time waits in unit tests** — Do not use `sleep`, `setTimeout(…, N)` with a duration, or similar wall-clock delays to “let Ink/React catch up.” Prefer driving the real async surface: `setImmediate` / microtask turns in a loop until an **observable** condition holds (e.g. `frames` or stdout contains the expected text), with a **turn-count** cap and a clear failure message if the condition never becomes true. E2E may still use bounded retries where appropriate; Vitest unit tests under `cli/tests/` should stay deterministic without arbitrary milliseconds.
+
 ## Domain terminology
 
 Vocabulary for Cucumber steps and page objects (`e2e_test/start/pageObjects/cli/`). **Exact TTY behavior** (past messages, user input history, cursor, rendering) lives in code + Vitest; **scenario-shaped coverage** in `e2e_test/features/cli/*.feature`.

--- a/cli/tests/InteractiveCliApp.test.tsx
+++ b/cli/tests/InteractiveCliApp.test.tsx
@@ -8,6 +8,26 @@ function stripAnsi(s: string): string {
   return s.replace(new RegExp(`${esc}\\[[0-9;?]*[a-zA-Z]`, 'g'), '')
 }
 
+/** Advance the event loop until `predicate` holds or `maxTicks` is exhausted (no fixed wall-clock sleep). */
+async function waitForFrames(
+  getCombined: () => string,
+  predicate: (combined: string) => boolean,
+  maxTicks = 5000,
+): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (predicate(getCombined())) {
+      return
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve)
+    })
+  }
+  const combined = getCombined()
+  throw new Error(
+    `Output condition not met within ${maxTicks} event-loop turns. Last frames:\n${combined}`,
+  )
+}
+
 describe('InteractiveCliApp (ink-testing-library)', () => {
   test('shows version in the first frame', () => {
     const { lastFrame } = render(<InteractiveCliApp />)
@@ -18,9 +38,11 @@ describe('InteractiveCliApp (ink-testing-library)', () => {
     const { stdin, frames } = render(<InteractiveCliApp />)
 
     stdin.write('hello\r')
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
-    })
+    await waitForFrames(
+      () => frames.join('\n'),
+      (c) =>
+        c.includes('hello') && c.includes('Not supported') && c.includes('\x1b[100m'),
+    )
 
     const combined = frames.join('\n')
     expect(combined).toContain('hello')
@@ -33,9 +55,11 @@ describe('InteractiveCliApp (ink-testing-library)', () => {
     expect(lastFrame()).toContain(formatVersionOutput())
 
     stdin.write('/exit\r')
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
-    })
+    await waitForFrames(
+      () => frames.join('\n'),
+      (c) =>
+        c.includes('/exit') && c.includes('Bye.') && c.includes('\x1b[100m'),
+    )
 
     const combined = frames.join('\n')
     expect(combined).toContain('/exit')
@@ -47,10 +71,6 @@ describe('InteractiveCliApp (ink-testing-library)', () => {
     const { lastFrame, stdin, frames } = render(<InteractiveCliApp />)
     expect(lastFrame()).toContain(formatVersionOutput())
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
-    })
-
     for (const ch of '/exit') {
       stdin.write(ch)
       await new Promise<void>((r) => {
@@ -58,9 +78,11 @@ describe('InteractiveCliApp (ink-testing-library)', () => {
       })
     }
     stdin.write('\r')
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
-    })
+    await waitForFrames(
+      () => frames.join('\n'),
+      (c) =>
+        c.includes('/exit') && c.includes('Bye.') && c.includes('\x1b[100m'),
+    )
 
     const combined = frames.join('\n')
     expect(combined).toContain('/exit')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaced `setTimeout(..., 50)` waits in `cli/tests/InteractiveCliApp.test.tsx` with `waitForFrames`, which advances the event loop via `setImmediate` until the combined frame output satisfies the same assertions the test already made (or fails with a clear error after a turn-count cap).
- Documented in `.cursor/rules/cli.mdc` that CLI Vitest unit tests must not use wall-clock sleeps for “letting Ink catch up”; prefer observable conditions plus event-loop turns, with E2E as the place for bounded retries where needed.

## Testing

- `pnpm cli:test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f635bde0-66f2-44ea-b4b8-5564e61eab4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f635bde0-66f2-44ea-b4b8-5564e61eab4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

