### PR TITLE
Allow browser caching for notebook book PDF

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/controllers/NotebookBooksController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/NotebookBooksController.java
@@ -23,13 +23,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.http.CacheControl;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.annotation.SessionScope;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -149,14 +152,26 @@ class NotebookBooksController {
 
   @GetMapping(value = "/{notebook}/book/file", produces = MediaType.APPLICATION_PDF_VALUE)
   public ResponseEntity<byte[]> getBookFile(
+      WebRequest request,
       @PathVariable("notebook") @Schema(type = "integer") Notebook notebook)
       throws UnexpectedNoAccessRightException {
     authorizationService.assertReadAuthorization(notebook);
     var pdf = bookService.getBookPdfFile(notebook);
+    String etag = pdf.etag();
+    CacheControl cacheControl =
+        CacheControl.maxAge(365, TimeUnit.DAYS).cachePrivate().mustRevalidate();
+    if (request.checkNotModified(etag)) {
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED)
+          .eTag(etag)
+          .cacheControl(cacheControl)
+          .build();
+    }
     return ResponseEntity.ok()
+        .eTag(etag)
+        .cacheControl(cacheControl)
         .header(
             HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=\"" + pdf.attachmentFileName() + "\"")
+            "inline; filename=\"" + pdf.attachmentFileName() + "\"")
         .contentType(MediaType.APPLICATION_PDF)
         .body(pdf.bytes());
   }

--- a/backend/src/main/java/com/odde/doughnut/services/book/BookPdfFile.java
+++ b/backend/src/main/java/com/odde/doughnut/services/book/BookPdfFile.java
@@ -1,3 +1,3 @@
 package com.odde.doughnut.services.book;
 
-public record BookPdfFile(byte[] bytes, String attachmentFileName) {}
+public record BookPdfFile(byte[] bytes, String attachmentFileName, String etag) {}

--- a/backend/src/main/java/com/odde/doughnut/services/book/BookService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/book/BookService.java
@@ -23,9 +23,11 @@ import com.odde.doughnut.entities.repositories.BookUserLastReadPositionRepositor
 import com.odde.doughnut.exceptions.ApiException;
 import com.odde.doughnut.factoryServices.EntityPersister;
 import com.odde.doughnut.testability.TestabilitySettings;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.util.DigestUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -199,7 +201,11 @@ public class BookService {
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Resource not found"));
     String attachmentFileName = sanitizeFileName(book.getBookName()) + ".pdf";
-    return new BookPdfFile(bytes, attachmentFileName);
+    return new BookPdfFile(bytes, attachmentFileName, etagForSourceRef(ref));
+  }
+
+  private static String etagForSourceRef(String ref) {
+    return "\"" + DigestUtils.md5DigestAsHex(ref.getBytes(StandardCharsets.UTF_8)) + "\"";
   }
 
   private static String sanitizeFileName(String fileName) {

--- a/backend/src/test/java/com/odde/doughnut/controllers/NotebookBooksControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/NotebookBooksControllerTest.java
@@ -18,6 +18,7 @@ import com.odde.doughnut.exceptions.ApiException;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
 import com.odde.doughnut.services.book.BookReadingWireConstants;
 import com.odde.doughnut.services.book.BookStorage;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -30,7 +31,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.DigestUtils;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -83,6 +87,10 @@ class NotebookBooksControllerTest extends ControllerTestBase {
 
   private static MultipartFile pdfFile(byte[] content) {
     return new MockMultipartFile("file", "book.pdf", "application/pdf", content);
+  }
+
+  private static ServletWebRequest webRequest() {
+    return new ServletWebRequest(new MockHttpServletRequest());
   }
 
   private static List<BookRange> rootRangesSorted(Book book) {
@@ -170,7 +178,7 @@ class NotebookBooksControllerTest extends ControllerTestBase {
       assertThat(detailRoot.getId(), equalTo(outRoot.getId()));
       assertThat(childrenOf(detail, detailRoot), hasSize(2));
 
-      ResponseEntity<byte[]> fileRes = controller.getBookFile(nb);
+      ResponseEntity<byte[]> fileRes = controller.getBookFile(webRequest(), nb);
       assertThat(fileRes.getStatusCode(), equalTo(HttpStatus.OK));
       assertThat(fileRes.getBody(), equalTo(pdfBytes));
     }
@@ -280,50 +288,79 @@ class NotebookBooksControllerTest extends ControllerTestBase {
     @Test
     void returns404WhenNotebookHasNoBook() throws UnexpectedNoAccessRightException {
       Notebook nb = myNotebook();
-      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(nb));
+      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(webRequest(), nb));
     }
 
     @Test
     void returns404WhenBookHasNoSourceFile() {
       Notebook nb = notebookWithBook();
       setSourceFileRef(nb, null);
-      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(nb));
+      assertThrows(
+          ResponseStatusException.class, () -> controller.getBookFile(webRequest(), nb));
     }
 
     @Test
     void rejectsNotebookWithoutReadAccess() {
       Notebook otherNb = otherUsersNotebook();
-      assertThrows(UnexpectedNoAccessRightException.class, () -> controller.getBookFile(otherNb));
+      assertThrows(
+          UnexpectedNoAccessRightException.class,
+          () -> controller.getBookFile(webRequest(), otherNb));
     }
 
     @Test
     void returnsPdfWhenSourceFileRefPointsAtBlob() throws UnexpectedNoAccessRightException {
       Notebook nb = notebookWithBook();
       byte[] pdfBytes = new byte[] {0x25, 0x50, 0x44, 0x46};
-      setSourceFileRef(nb, bookStorage.put(pdfBytes));
+      String ref = bookStorage.put(pdfBytes);
+      setSourceFileRef(nb, ref);
+      String expectedEtag =
+          "\"" + DigestUtils.md5DigestAsHex(ref.getBytes(StandardCharsets.UTF_8)) + "\"";
 
-      ResponseEntity<byte[]> res = controller.getBookFile(nb);
+      ResponseEntity<byte[]> res = controller.getBookFile(webRequest(), nb);
 
       assertThat(res.getStatusCode(), equalTo(HttpStatus.OK));
       assertThat(res.getBody(), equalTo(pdfBytes));
       assertThat(res.getHeaders().getContentType(), equalTo(MediaType.APPLICATION_PDF));
+      assertThat(res.getHeaders().getETag(), equalTo(expectedEtag));
       assertThat(
           res.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION),
-          equalTo("attachment; filename=\"Linear Algebra.pdf\""));
+          equalTo("inline; filename=\"Linear Algebra.pdf\""));
+      assertThat(res.getHeaders().getCacheControl(), containsString("private"));
+      assertThat(res.getHeaders().getCacheControl(), containsString("max-age="));
+    }
+
+    @Test
+    void returns304WhenIfNoneMatchMatchesEtag() throws UnexpectedNoAccessRightException {
+      Notebook nb = notebookWithBook();
+      byte[] pdfBytes = new byte[] {0x25, 0x50, 0x44, 0x46};
+      String ref = bookStorage.put(pdfBytes);
+      setSourceFileRef(nb, ref);
+      String etag =
+          "\"" + DigestUtils.md5DigestAsHex(ref.getBytes(StandardCharsets.UTF_8)) + "\"";
+
+      MockHttpServletRequest req = new MockHttpServletRequest();
+      req.addHeader(HttpHeaders.IF_NONE_MATCH, etag);
+      ResponseEntity<byte[]> res = controller.getBookFile(new ServletWebRequest(req), nb);
+
+      assertThat(res.getStatusCode(), equalTo(HttpStatus.NOT_MODIFIED));
+      assertThat(res.getBody(), nullValue());
+      assertThat(res.getHeaders().getETag(), equalTo(etag));
     }
 
     @Test
     void returns404WhenSourceFileRefIsNotNumeric() {
       Notebook nb = notebookWithBook();
       setSourceFileRef(nb, "not-an-id");
-      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(nb));
+      assertThrows(
+          ResponseStatusException.class, () -> controller.getBookFile(webRequest(), nb));
     }
 
     @Test
     void returns404WhenSourceFileRefBlobMissing() {
       Notebook nb = notebookWithBook();
       setSourceFileRef(nb, String.valueOf(Integer.MAX_VALUE));
-      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(nb));
+      assertThrows(
+          ResponseStatusException.class, () -> controller.getBookFile(webRequest(), nb));
     }
   }
 
@@ -339,7 +376,8 @@ class NotebookBooksControllerTest extends ControllerTestBase {
       assertThat(bookRepository.findByNotebook_Id(nb.getId()).isEmpty(), equalTo(true));
       assertThat(bookStorage.get(ref).isEmpty(), equalTo(true));
       assertThrows(ResponseStatusException.class, () -> controller.getBook(nb));
-      assertThrows(ResponseStatusException.class, () -> controller.getBookFile(nb));
+      assertThrows(
+          ResponseStatusException.class, () -> controller.getBookFile(webRequest(), nb));
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The book reader loads the PDF via `GET /api/notebooks/{id}/book/file`. That response did not advertise cacheability and used `Content-Disposition: attachment`, which is oriented toward downloads rather than in-app viewing.

## Changes

- **`Cache-Control`**: `private`, long `max-age` (365 days), `must-revalidate` so the client can reuse the response while still revalidating when appropriate.
- **`ETag`**: Derived from the stable storage ref (`source_file_ref`), so it changes when the underlying blob changes without hashing the full PDF on every request.
- **`If-None-Match`**: Returns **304 Not Modified** when the client sends a matching ETag.
- **`Content-Disposition`**: Switched from `attachment` to **`inline`** so browsers treat the resource as viewable in-page (the app still uses `fetch` + pdf.js; filename is preserved for save-as if needed).

## Tests

- Extended `NotebookBooksControllerTest` for cache headers, ETag, and 304 behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1775652892789599?thread_ts=1775652892.789599&cid=D092E33M7FG)

<div><a href="https://cursor.com/agents/bc-76ee7335-f1f0-5a6d-bb51-396b5a85ccc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76ee7335-f1f0-5a6d-bb51-396b5a85ccc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

