### PR TITLE
Fix undo note details not refreshing editor after partial save

### DIFF
--- a/frontend/src/components/notes/core/TextContentWrapper.vue
+++ b/frontend/src/components/notes/core/TextContentWrapper.vue
@@ -152,6 +152,21 @@ const handlePropChange = (newValue: string | undefined) => {
     // Check if this is navigation (value changed from current or last saved)
     const normalizedCurrentValue = localValue.value ?? ""
     const normalizedLastSaved = lastSavedValue.value ?? ""
+    if (field === "edit details") {
+      const normalizedNewForDetails = normalizeNoteDetails(normalizedNewValue)
+      const normalizedCurrentForDetails = normalizeNoteDetails(
+        normalizedCurrentValue
+      )
+      const normalizedLastSavedForDetails =
+        normalizeNoteDetails(normalizedLastSaved)
+      if (
+        normalizedNewForDetails === normalizedLastSavedForDetails &&
+        normalizedNewForDetails !== normalizedCurrentForDetails
+      ) {
+        handleNavigation(normalizedNewValue)
+        return
+      }
+    }
     if (
       normalizedNewValue !== normalizedCurrentValue &&
       normalizedNewValue !== normalizedLastSaved

--- a/frontend/tests/notes/NoteEditableDetails.spec.ts
+++ b/frontend/tests/notes/NoteEditableDetails.spec.ts
@@ -229,6 +229,75 @@ describe("NoteEditableDetails", () => {
     wrapper.unmount()
   })
 
+  it("should show reverted details after undo when there is an unsaved edit on top of a saved version", async () => {
+    vi.useFakeTimers()
+
+    const noteId = 1
+    const realmAfterSave = makeMe.aNoteRealm
+      .title("Test")
+      .details("Edited details")
+      .please()
+    const realmAfterUndo = makeMe.aNoteRealm
+      .title("Test")
+      .details("Original details")
+      .please()
+
+    updateNoteDetailsSpy.mockImplementation((async (options) => {
+      if (options.body?.details === "Edited details") {
+        return wrapSdkResponse(realmAfterSave)
+      }
+      if (options.body?.details === "Original details") {
+        return wrapSdkResponse(realmAfterUndo)
+      }
+      return wrapSdkResponse(realmAfterSave)
+      // biome-ignore lint/suspicious/noExplicitAny: Vitest mock typing requires any for implementation functions
+    }) as any)
+
+    const wrapper: VueWrapper<ComponentPublicInstance> = helper
+      .component(NoteEditableDetails)
+      .withCleanStorage()
+      .withProps({
+        noteId,
+        noteDetails: "Original details",
+        readonly: false,
+        asMarkdown: true,
+      })
+      .mount({ attachTo: document.body })
+
+    await flushPromises()
+
+    const detailsEl = wrapper.find("textarea").element as HTMLTextAreaElement
+    detailsEl.value = "Edited details"
+    detailsEl.dispatchEvent(new Event("input"))
+    await flushPromises()
+
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+
+    await wrapper.setProps({
+      noteId,
+      noteDetails: "Edited details",
+      readonly: false,
+    })
+    await flushPromises()
+
+    detailsEl.value = "Edited details (draft)"
+    detailsEl.dispatchEvent(new Event("input"))
+    await flushPromises()
+
+    await wrapper.setProps({
+      noteId,
+      noteDetails: "Original details",
+      readonly: false,
+    })
+    await flushPromises()
+
+    expect(detailsEl.value).toBe("Original details")
+
+    vi.useRealTimers()
+    wrapper.unmount()
+  })
+
   it("should preserve second edit when first save response arrives after second edit", async () => {
     const noteId = 1
     let resolveFirstSave: (() => void) | undefined


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Undo correctly restored note details in storage and popped the undo stack, but the details editor could keep showing a newer unsaved draft. That happened when a save had completed (`version` ahead of `savedVersion`) and the user had typed again: `handlePropChange` treated an incoming value equal to `lastSavedValue` as a no-op and returned without syncing the textarea.

## Changes

- **TextContentWrapper.vue**: For `edit details`, when the incoming prop matches the last saved normalized details but the local normalized content differs, run the same navigation sync path so the editor shows the reverted server value (e.g. after undo).
- **NoteEditableDetails.spec.ts**: Regression test covering save → parent prop refresh → further typing → undo-style prop update.

## Testing

- `pnpm -C frontend test tests/notes/NoteEditableDetails.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1776213107003039?thread_ts=1776213107.003039&cid=D092E33M7FG)

<div><a href="https://cursor.com/agents/bc-15c1adb8-5b8a-57a6-b83a-3ec5b1d97eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15c1adb8-5b8a-57a6-b83a-3ec5b1d97eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

