### PR TITLE
Cloze: show Japanese auxiliary kana after stem mask

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
@@ -19,7 +19,9 @@ record ClozeReplacement(
         replaceTitlesWithInternalPlaceholder(
             noteTitle.getTitles(),
             pronunciationMasked,
-            (p, t) -> t.replaceLiteralWords(p, internalFullMatchReplacement));
+            (p, t) ->
+                t.replaceLiteralWords(
+                    p, internalFullMatchReplacement, internalPartialMatchReplacement));
     String step2 =
         replaceTitlesWithInternalPlaceholder(
             noteTitle.getTitles(),

--- a/backend/src/main/java/com/odde/doughnut/algorithms/JapaneseAuxiliarySuffix.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/JapaneseAuxiliarySuffix.java
@@ -1,0 +1,106 @@
+package com.odde.doughnut.algorithms;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Longest-match auxiliary endings (hiragana/katakana) immediately after a cloze stem match so the
+ * mask can leave trailing morphemes visible (e.g. after matching {@code 食べ} in {@code 食べた},
+ * keep {@code た} outside the mask).
+ */
+final class JapaneseAuxiliarySuffix {
+
+  private static final String[] SUFFIXES = {
+    "ませんでした",
+    "ではありませんでした",
+    "じゃありませんでした",
+    "ではなかった",
+    "じゃなかった",
+    "でありませんでした",
+    "でいませんでした",
+    "でありません",
+    "でいません",
+    "でありました",
+    "でいました",
+    "であります",
+    "でいます",
+    "でした",
+    "だった",
+    "でしょう",
+    "だろう",
+    "ません",
+    "ました",
+    "ましょうか",
+    "ましょう",
+    "でしょうか",
+    "ではない",
+    "じゃない",
+    "ありません",
+    "なかった",
+    "なければ",
+    "ちゃった",
+    "ちゃう",
+    "じゃう",
+    "すぎる",
+    "ください",
+    "ければ",
+    "けれど",
+    "がる",
+    "そう",
+    "かった",
+    "くない",
+    "であり",
+    "でいる",
+    "である",
+    "であった",
+    "です",
+    "ます",
+    "ない",
+    "った",
+    "って",
+    "んで",
+    "して",
+    "いで",
+    "た",
+    "て",
+    "だ",
+    "で",
+    "じゃ",
+  };
+
+  private static final List<String> BY_LENGTH_DESC =
+      Arrays.stream(SUFFIXES)
+          .sorted(Comparator.comparingInt(String::length).reversed())
+          .distinct()
+          .toList();
+
+  private JapaneseAuxiliarySuffix() {}
+
+  /**
+   * Longest known auxiliary that is a prefix of {@code remainder} (must start with kana), or
+   * empty.
+   */
+  static String longestPrefixRemainder(String remainder) {
+    if (remainder == null || remainder.isEmpty()) {
+      return "";
+    }
+    int first = remainder.codePointAt(0);
+    if (!isKanaCodePoint(first)) {
+      return "";
+    }
+    for (String suffix : BY_LENGTH_DESC) {
+      if (remainder.startsWith(suffix)
+          && suffix.chars().allMatch(JapaneseAuxiliarySuffix::isKanaCodePoint)) {
+        return suffix;
+      }
+    }
+    return "";
+  }
+
+  private static boolean isKanaCodePoint(int cp) {
+    Character.UnicodeScript script = Character.UnicodeScript.of(cp);
+    return script == Character.UnicodeScript.HIRAGANA
+        || script == Character.UnicodeScript.KATAKANA;
+  }
+}

--- a/backend/src/main/java/com/odde/doughnut/algorithms/TitleFragment.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/TitleFragment.java
@@ -36,14 +36,81 @@ record TitleFragment(boolean suffix, String stem) {
   }
 
   public String replaceLiteralWords(String details, final String replacement) {
-    Pattern pattern = getClozePatternCreator().getPattern(stem);
-    return pattern.matcher(details).replaceAll(replacement);
+    return replaceEachMatchKeepingJapaneseAuxiliaryTail(
+        getClozePatternCreator().getPattern(stem),
+        details,
+        replacement,
+        replacement,
+        stem,
+        suffix,
+        false);
+  }
+
+  /**
+   * Like {@link #replaceLiteralWords} but when a suffix-title stem keeps a following auxiliary
+   * visible, use {@code partialWhenAuxiliaryTail} so the recall stem shows a partial cloze
+   * ([..~]) rather than a full one ([...]).
+   */
+  public String replaceLiteralWords(
+      String details, String fullReplacement, String partialWhenAuxiliaryTail) {
+    return replaceEachMatchKeepingJapaneseAuxiliaryTail(
+        getClozePatternCreator().getPattern(stem),
+        details,
+        fullReplacement,
+        partialWhenAuxiliaryTail,
+        stem,
+        suffix,
+        false);
   }
 
   public String replaceSimilar(String literal, String replacement) {
     String substring = stem.substring(0, (stem.length() + 1) * 3 / 4);
-    Pattern pattern = getClozePatternCreator().getPattern(substring);
-    return pattern.matcher(literal).replaceAll(replacement);
+    return replaceEachMatchKeepingJapaneseAuxiliaryTail(
+        getClozePatternCreator().getPattern(substring),
+        literal,
+        replacement,
+        replacement,
+        stem,
+        suffix,
+        true);
+  }
+
+  /**
+   * When the match is a strict prefix of the note title stem (partial match pass), or the title
+   * uses suffix mode ({@code ~stem}) on the literal pass, keep a following auxiliary visible (e.g.
+   * {@code 食べ} + {@code た}).
+   */
+  private static String replaceEachMatchKeepingJapaneseAuxiliaryTail(
+      Pattern pattern,
+      String details,
+      String defaultMaskReplacement,
+      String partialWhenAuxiliaryTail,
+      String fullStem,
+      boolean suffixTitle,
+      boolean fromSimilarPass) {
+    Matcher matcher = pattern.matcher(details);
+    StringBuilder out = new StringBuilder();
+    int lastAppend = 0;
+    while (matcher.find()) {
+      String matched = matcher.group();
+      int matchEnd = matcher.end();
+      String remainder = details.substring(matchEnd);
+      String auxiliaryTail = JapaneseAuxiliarySuffix.longestPrefixRemainder(remainder);
+      boolean allowAuxiliaryTail =
+          fromSimilarPass
+              ? matched.length() < fullStem.length()
+              : suffixTitle && !auxiliaryTail.isEmpty();
+      String tail = allowAuxiliaryTail ? auxiliaryTail : "";
+      String maskReplacement =
+          !tail.isEmpty() && suffixTitle && !fromSimilarPass
+              ? partialWhenAuxiliaryTail
+              : defaultMaskReplacement;
+      out.append(details, lastAppend, matcher.start());
+      out.append(maskReplacement).append(tail);
+      lastAppend = matchEnd + tail.length();
+    }
+    out.append(details, lastAppend, details.length());
+    return out.toString();
   }
 
   public int length() {

--- a/backend/src/test/java/com/odde/doughnut/algorithms/JapaneseAuxiliaryClozeTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/JapaneseAuxiliaryClozeTest.java
@@ -1,0 +1,75 @@
+package com.odde.doughnut.algorithms;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.jupiter.api.Test;
+
+class JapaneseAuxiliaryClozeTest {
+
+  private static final ClozeReplacement CLOZE =
+      new ClozeReplacement("[..~]", "[...]", "/.../", "<...>");
+
+  @Test
+  void suffixTitle_keepsAuxiliaryAfterStemMatch() {
+    String result =
+        new ClozedString(CLOZE, "昨日は魚を食べた。")
+            .hide(new NoteTitle("~食べ"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]た。"));
+  }
+
+  @Test
+  void suffixTitle_teForm_keepsTe() {
+    String result =
+        new ClozedString(CLOZE, "魚を食べてください。")
+            .hide(new NoteTitle("~食べ"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]てください。"));
+  }
+
+  @Test
+  void suffixTitle_politeNegative_keepsFullAuxiliary() {
+    String result =
+        new ClozedString(CLOZE, "彼は食べませんでした。")
+            .hide(new NoteTitle("~食べ"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]ませんでした。"));
+  }
+
+  @Test
+  void suffixTitle_iAdjective_keepsKuNai() {
+    String result =
+        new ClozedString(CLOZE, "この部屋は高くない。")
+            .hide(new NoteTitle("~高"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]くない。"));
+  }
+
+  @Test
+  void suffixTitle_naAdjectiveCopula_keepsDa() {
+    String result =
+        new ClozedString(CLOZE, "この町は静かだ。")
+            .hide(new NoteTitle("~静か"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]だ。"));
+  }
+
+  @Test
+  void suffixTitle_naAdjectiveNegative_keepsDeHaNai() {
+    String result =
+        new ClozedString(CLOZE, "ここは静かではない。")
+            .hide(new NoteTitle("~静か"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]ではない。"));
+  }
+
+  @Test
+  void suffixTitle_passive_keepsTaAfterRareruStem() {
+    String result =
+        new ClozedString(CLOZE, "彼は認められた。")
+            .hide(new NoteTitle("~認められ"))
+            .maskedDetailsAsMarkdown();
+    assertThat(result, containsString("[..~]た。"));
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Recall cloze masking for Japanese now keeps a **longest-match auxiliary** immediately after a **suffix-title** stem (`~…`) outside the mask, and uses the **partial** cloze placeholder (`[..~]`) when that happens so the stem is not treated as a full literal match.

Examples (title → recall text behavior):

- `~食べ` + `食べた` → `[..~]た`
- `~食べ` + `食べてください` → `[..~]てください` (consumes `て` as auxiliary prefix of remainder)
- `~食べ` + `食べませんでした` → `[..~]ませんでした`
- `~静か` + `静かだ` / `静かではない` → `[..~]だ` / `[..~]ではない`
- `~高` + `高くない` → `[..~]くない` (i-adjective stem is `高` + `い`; users title with `~高` for this pattern)

## Implementation

- `JapaneseAuxiliarySuffix`: ordered list of common auxiliaries (verbs, adjectives, copula); longest prefix of text after the regex match.
- `TitleFragment`: manual replace loop consumes matched span + auxiliary tail; suffix titles use partial placeholder when a tail is peeled.
- `ClozeReplacement`: literal pass passes both full and partial internal placeholders.

## Tests

- `JapaneseAuxiliaryClozeTest` covers tense, te-form, polite negative chain, i-adjective `くない`, na-adjective copula/negative, passive with `~認められ`.

## Note for users

For **ichidan** verbs in dictionary form (e.g. `食べる`), use a **suffix stem** title such as `~食べ` so the matcher can stop before inflection. Plain `食べる` still fully masks conjugated forms (unchanged behavior).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1776298139177849?thread_ts=1776298139.177849&cid=D092E33M7FG)

<div><a href="https://cursor.com/agents/bc-3dce2720-59d8-5fb8-b247-1b0037ef8d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dce2720-59d8-5fb8-b247-1b0037ef8d7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

