### PR TITLE
fix: prevent square brackets from being escaped in rich text editor

### DIFF
--- a/frontend/src/components/form/quillHtmlToMarkdown.ts
+++ b/frontend/src/components/form/quillHtmlToMarkdown.ts
@@ -7,6 +7,25 @@ export const turndownService = new TurndownService({
 
 turndownService.use(gfm)
 
+// Turndown escapes [ and ] to prevent markdown link syntax conflicts,
+// but Quill manages links as <a> elements, so plain-text brackets need no escaping.
+turndownService.escape = (string: string) =>
+  (
+    [
+      [/\\/g, "\\\\"],
+      [/\*/g, "\\*"],
+      [/^-/g, "\\-"],
+      [/^\+ /g, "\\+ "],
+      [/^(=+)/g, "\\$1"],
+      [/^(#{1,6}) /g, "\\$1 "],
+      [/`/g, "\\`"],
+      [/^~~~/g, "\\~~~"],
+      [/^>/g, "\\>"],
+      [/_/g, "\\_"],
+      [/^(\d+)\. /g, "$1\\. "],
+    ] as [RegExp, string][]
+  ).reduce((acc, [pattern, replacement]) => acc.replace(pattern, replacement), string)
+
 turndownService.addRule("quillListItem", {
   filter(node) {
     return node.nodeName === "LI" && node.getAttribute("data-list") != null

--- a/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
+++ b/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
@@ -2,6 +2,12 @@ import { describe, it, expect } from "vitest"
 import htmlToMarkdown from "@/components/form/quillHtmlToMarkdown"
 
 describe("quillHtmlToMarkdown", () => {
+  it("does not escape square brackets in plain text", () => {
+    const html = "<p>Use [this] notation</p>"
+    const result = htmlToMarkdown(html)
+    expect(result).toBe("Use [this] notation")
+  })
+
   it("converts HTML with escaped angle brackets", () => {
     const html = "<p>raw &lt;span&gt; is ok.</p>"
     const result = htmlToMarkdown(html)


### PR DESCRIPTION
## Context

This PR is created to share a bug investigation with the team. The fix is ready but needs review before merging.

**Bug:** When typing `[` in the Rich Text editor (Quill), it gets saved as `\[` in the stored markdown, causing unwanted escape characters in content.

## Root Cause

Turndown library's default `escape()` method applies `[` → `\[` and `]` → `\]` to all text nodes during HTML→Markdown conversion. This is intended to prevent ambiguity with markdown link syntax `[text](url)`, but is unnecessary here since Quill manages links as `<a>` elements.

## Changes

- Override `turndownService.escape` in `quillHtmlToMarkdown.ts` to remove bracket escaping rules
- Add test to verify `[text]` is not escaped in plain text conversion

## Test plan

- [ ] `pnpm frontend:test tests/components/form/quillHtmlToMarkdown.spec.ts` passes
- [ ] Manually verify: type `[test]` in Rich Text editor, save, and confirm it displays as `[test]` (not `\[test\]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)