### PR TITLE
Show warning toast before sign-in redirect on API 401

### DIFF
--- a/frontend/src/managedApi/clientSetup.ts
+++ b/frontend/src/managedApi/clientSetup.ts
@@ -9,6 +9,16 @@ import assignBadRequestProperties from "./window/assignBadRequestProperties"
 import loginOrRegisterAndHaltThisThread from "./window/loginOrRegisterAndHaltThisThread"
 import { useToast } from "vue-toastification"
 
+function apiRequestLabel(request: Request): string {
+  const method = request.method?.toUpperCase() ?? "?"
+  try {
+    const u = new URL(request.url)
+    return `${method} ${u.pathname}${u.search}`
+  } catch {
+    return `${method} ${request.url}`
+  }
+}
+
 // Global apiStatusHandler instance (set by setupGlobalClient)
 let apiStatusHandler: ApiStatusHandler | undefined
 
@@ -82,13 +92,19 @@ export function setupGlobalClient(apiStatus: ApiStatus) {
   globalClient.interceptors.response.use((response, request) => {
     if (response.status === 401) {
       const method = request.method
-      if (
+      const willRedirect =
         method === "GET" ||
         // eslint-disable-next-line no-alert
         window.confirm(
           "You are logged out. Do you want to log in (and lose the current changes)?"
         )
-      ) {
+      if (willRedirect) {
+        const apiName = apiRequestLabel(request)
+        const toast = useToast()
+        toast.warning(
+          `This page will reload to sign you in again. Reason: unauthorized response from ${apiName}.`,
+          { timeout: 8000, pauseOnFocusLoss: true, pauseOnHover: true }
+        )
         loginOrRegisterAndHaltThisThread()
       }
     }

--- a/frontend/tests/managedApi/clientSetup.spec.ts
+++ b/frontend/tests/managedApi/clientSetup.spec.ts
@@ -1,5 +1,6 @@
 import type { ApiStatus } from "@/managedApi/ApiStatusHandler"
 import { apiCallWithLoading, setupGlobalClient } from "@/managedApi/clientSetup"
+import loginOrRegisterAndHaltThisThread from "@/managedApi/window/loginOrRegisterAndHaltThisThread"
 import { UserController } from "@generated/doughnut-backend-api/sdk.gen"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import createFetchMock from "vitest-fetch-mock"
@@ -9,10 +10,15 @@ fetchMock.enableMocks()
 
 const mockToast = {
   error: vi.fn(),
+  warning: vi.fn(),
 }
 
 vi.mock("vue-toastification", () => ({
   useToast: () => mockToast,
+}))
+
+vi.mock("@/managedApi/window/loginOrRegisterAndHaltThisThread", () => ({
+  default: vi.fn(),
 }))
 
 describe("clientSetup", () => {
@@ -23,6 +29,8 @@ describe("clientSetup", () => {
     fetchMock.resetMocks()
     apiStatus.states = []
     mockToast.error.mockClear()
+    mockToast.warning.mockClear()
+    vi.mocked(loginOrRegisterAndHaltThisThread).mockClear()
     // Setup global client before each test
     setupGlobalClient(apiStatus)
   })
@@ -200,6 +208,43 @@ describe("clientSetup", () => {
 
       // All should be cleared
       expect(apiStatus.states.length).toBe(0)
+    })
+  })
+
+  describe("401 unauthorized — redirect to sign-in", () => {
+    it("shows warning toast with API path then redirects on GET 401", async () => {
+      const confirmSpy = vi.spyOn(window, "confirm").mockImplementation(() => {
+        throw new Error("confirm must not be used for GET")
+      })
+      fetchMock.mockResponse(JSON.stringify({}), {
+        url: `${baseUrl}/api/user`,
+        status: 401,
+      })
+
+      await UserController.getUserProfile({})
+
+      expect(mockToast.warning).toHaveBeenCalledWith(
+        expect.stringContaining("GET /api/user"),
+        expect.objectContaining({ timeout: 8000 })
+      )
+      expect(loginOrRegisterAndHaltThisThread).toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    it("does not redirect when user declines login on mutating 401", async () => {
+      vi.spyOn(window, "confirm").mockReturnValue(false)
+      fetchMock.mockResponse(JSON.stringify({}), {
+        url: `${baseUrl}/api/user`,
+        status: 401,
+        method: "POST",
+      })
+
+      await UserController.createUser({
+        body: { name: "x" } as never,
+      })
+
+      expect(mockToast.warning).not.toHaveBeenCalled()
+      expect(loginOrRegisterAndHaltThisThread).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When the global API client receives a 401 and the user is sent to the sign-in flow (same as before: GET redirects immediately; non-GET still uses the existing confirm dialog), the app now shows a **warning** toast first. The message states that the page will reload to sign in again, gives the reason (unauthorized response), and includes the **HTTP method and API path** (e.g. `GET /api/user`).

Tests: extended `clientSetup.spec.ts` with a GET 401 case (toast + redirect mock) and a POST 401 case where the user declines confirm (no toast, no redirect).

Note: `window.location.reload()` after successful Obsidian import is unchanged; that path is success-only, not an API failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1777332756723509?thread_ts=1777332756.723509&cid=D092E33M7FG)

<div><a href="https://cursor.com/agents/bc-70302576-34fb-59c2-beff-25a34da24dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70302576-34fb-59c2-beff-25a34da24dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

