### PR TITLE
Fix search UX: show literal matches as soon as they return

### DIFF
--- a/frontend/src/components/search/SearchResults.vue
+++ b/frontend/src/components/search/SearchResults.vue
@@ -83,7 +83,7 @@ import {
 } from "@generated/doughnut-backend-api/sdk.gen"
 import {} from "@/managedApi/clientSetup"
 import { debounce } from "mini-debounce"
-import { ref, computed, watch, onMounted, onBeforeUnmount } from "vue"
+import { ref, computed, watch, onMounted, onBeforeUnmount, shallowRef } from "vue"
 import CheckInput from "../form/CheckInput.vue"
 import SearchResultCards from "./SearchResultCards.vue"
 import NoteTitleWithLink from "../notes/NoteTitleWithLink.vue"
@@ -114,6 +114,8 @@ const oldSearchTerm = ref<SearchTerm>({
 
 const timeoutId = ref<ReturnType<typeof setTimeout>>()
 const model = new SearchResultsModel()
+/** Bumps when a new debounced search starts so late responses from an older run are ignored. */
+const searchGeneration = shallowRef(0)
 
 const trimmedSearchKey = computed(() => searchTerm.value.searchKey.trim())
 const isGlobalSearch = computed(
@@ -140,33 +142,8 @@ const displayState = computed(() =>
   })
 )
 
-const performSearch = async (noteId: number | undefined, term: SearchTerm) => {
-  const [literalRes, semanticRes] = await Promise.all([
-    noteId
-      ? SearchController.searchForRelationshipTargetWithin({
-          path: { note: noteId },
-          body: term,
-        })
-      : SearchController.searchForRelationshipTarget({
-          body: term,
-        }),
-    noteId
-      ? SearchController.semanticSearchWithin({
-          path: { note: noteId },
-          body: term,
-        })
-      : SearchController.semanticSearch({
-          body: term,
-        }),
-  ])
-
-  return {
-    literal: literalRes.error ? [] : literalRes.data || [],
-    semantic: semanticRes.error ? [] : semanticRes.data || [],
-  }
-}
-
-const debounced = debounce((callback) => callback(), 1000)
+const SEARCH_DEBOUNCE_MS = 350
+const debounced = debounce((callback) => callback(), SEARCH_DEBOUNCE_MS)
 
 const fetchRecentNotes = async () => {
   if (
@@ -195,17 +172,54 @@ const search = () => {
   }
 
   timeoutId.value = debounced(async () => {
-    const { literal, semantic } = await performSearch(
-      props.noteId,
-      searchTerm.value
-    )
-    model.mergeAndCacheResults({
-      trimmedSearchKey: trimmedSearchKey.value,
-      isGlobal: isGlobalSearch.value,
-      literalResults: literal,
-      semanticResults: semantic,
-      currentNotebookId: props.notebookId,
+    const gen = ++searchGeneration.value
+    const term = searchTerm.value
+    const snapshotTrimmed = term.searchKey.trim()
+    const snapshotGlobal = term.allMyNotebooksAndSubscriptions === true
+    const snapshotNotebookId = props.notebookId
+
+    const literalPromise = props.noteId
+      ? SearchController.searchForRelationshipTargetWithin({
+          path: { note: props.noteId },
+          body: term,
+        })
+      : SearchController.searchForRelationshipTarget({ body: term })
+    const semanticPromise = props.noteId
+      ? SearchController.semanticSearchWithin({
+          path: { note: props.noteId },
+          body: term,
+        })
+      : SearchController.semanticSearch({ body: term })
+
+    const applyIfCurrent = () =>
+      gen === searchGeneration.value &&
+      snapshotTrimmed === trimmedSearchKey.value &&
+      snapshotGlobal === isGlobalSearch.value
+
+    literalPromise.then((literalRes) => {
+      if (!applyIfCurrent()) return
+      const literal = literalRes.error ? [] : literalRes.data || []
+      model.mergeAndCacheResults({
+        trimmedSearchKey: snapshotTrimmed,
+        isGlobal: snapshotGlobal,
+        literalResults: literal,
+        currentNotebookId: snapshotNotebookId,
+      })
     })
+
+    semanticPromise.then((semanticRes) => {
+      if (!applyIfCurrent()) return
+      const semantic = semanticRes.error ? [] : semanticRes.data || []
+      model.mergeAndCacheResults({
+        trimmedSearchKey: snapshotTrimmed,
+        isGlobal: snapshotGlobal,
+        semanticResults: semantic,
+        currentNotebookId: snapshotNotebookId,
+      })
+    })
+
+    await Promise.all([literalPromise, semanticPromise])
+    if (!applyIfCurrent()) return
     model.completeSearch()
   })
 }

--- a/frontend/src/models/searchResultsModel.ts
+++ b/frontend/src/models/searchResultsModel.ts
@@ -211,19 +211,30 @@ export class SearchResultsModel {
     }
   }
 
+  /**
+   * Merges new result batches into the cache for this search key.
+   * Omit `literalResults` or `semanticResults` (leave undefined) when that
+   * request has not completed yet; pass an array (possibly empty) when it has.
+   */
   mergeAndCacheResults(opts: {
     trimmedSearchKey: string
     isGlobal: boolean
-    literalResults: NoteSearchResult[]
-    semanticResults: NoteSearchResult[]
+    literalResults?: NoteSearchResult[]
+    semanticResults?: NoteSearchResult[]
     currentNotebookId?: number
   }): void {
-    const combined = [...opts.literalResults, ...opts.semanticResults]
     const existing =
       this.getCachedResult(opts.trimmedSearchKey, opts.isGlobal) ?? []
+    const incoming: NoteSearchResult[] = []
+    if (opts.literalResults !== undefined) {
+      incoming.push(...opts.literalResults)
+    }
+    if (opts.semanticResults !== undefined) {
+      incoming.push(...opts.semanticResults)
+    }
     const merged = this.mergeUniqueAndSortByDistance(
       existing,
-      combined,
+      incoming,
       opts.currentNotebookId
     )
     this.setCachedResult(opts.trimmedSearchKey, opts.isGlobal, merged)

--- a/frontend/tests/components/search/SearchResults.spec.ts
+++ b/frontend/tests/components/search/SearchResults.spec.ts
@@ -52,7 +52,7 @@ function setupDelayedSearchMocks() {
 
 async function waitForDebounce() {
   await nextTick()
-  vi.advanceTimersByTime(1100)
+  vi.advanceTimersByTime(400)
   await flushPromises()
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Relationship / link target search used `Promise.all` for the title (literal) and semantic API calls, so the UI waited for **both** to finish—including OpenAI query embedding + KNN—before showing any matches.

## Changes

- Merge **literal** results into the cached list as soon as that request completes; merge **semantic** results when they arrive (still fired in parallel).
- Add a generation guard so responses from an older keystroke do not overwrite a newer search.
- Reduce debounce from **1000 ms** to **350 ms** so requests start sooner while still batching rapid typing.
- `SearchResultsModel.mergeAndCacheResults` now accepts optional `literalResults` / `semanticResults` so partial merges do not wipe the other tier.

## Embedding latency (unchanged in this PR)

Semantic search still calls `EmbeddingService.generateQueryEmbedding` (OpenAI `text-embedding-3-small`) on every request before DB KNN. Further backend gains would need a different design (e.g. cache query embeddings, combine literal+semantic in one endpoint, or async indexing).

## Testing

`pnpm frontend:test tests/components/search/SearchResults.spec.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://odd-e.slack.com/archives/D092E33M7FG/p1777336490621869?thread_ts=1777336490.621869&cid=D092E33M7FG)

<div><a href="https://cursor.com/agents/bc-2ce71f39-37c0-5cbc-91de-42491c83bd29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ce71f39-37c0-5cbc-91de-42491c83bd29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

