### PR TITLE
Refactor note creation in tests to remove `toBeRemoved` method

### DIFF
--- a/backend/src/test/java/com/odde/doughnut/controllers/NoteControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/NoteControllerTests.java
@@ -93,17 +93,10 @@ class NoteControllerTests extends ControllerTestBase {
         throws UnexpectedNoAccessRightException {
       User user = currentUser.getUser();
       Note root = makeMe.aNote().notebookOwnedBy(user).title("root-head").please();
-      Note matched =
-          makeMe
-              .aNote()
-              .title("LinkedPage")
-              .toBeRemoved(user)
-              .notebook(root.getNotebook())
-              .please();
+      Note matched = makeMe.aNote().title("LinkedPage").notebook(root.getNotebook()).please();
       Note viewer =
           makeMe
               .aNote()
-              .toBeRemoved(user)
               .notebook(root.getNotebook())
               .content("Text [[LinkedPage]] and [[NoSuch]].")
               .please();
@@ -122,17 +115,10 @@ class NoteControllerTests extends ControllerTestBase {
         throws UnexpectedNoAccessRightException {
       User user = currentUser.getUser();
       Note root = makeMe.aNote().notebookOwnedBy(user).title("root-head").please();
-      Note matched =
-          makeMe
-              .aNote()
-              .title("Target Title")
-              .toBeRemoved(user)
-              .notebook(root.getNotebook())
-              .please();
+      Note matched = makeMe.aNote().title("Target Title").notebook(root.getNotebook()).please();
       Note viewer =
           makeMe
               .aNote()
-              .toBeRemoved(user)
               .notebook(root.getNotebook())
               .content("Text [[Target Title|friendly label]] end.")
               .please();
@@ -152,15 +138,13 @@ class NoteControllerTests extends ControllerTestBase {
       User user = currentUser.getUser();
       Notebook otherNotebook =
           makeMe.aNotebook().creatorAndOwner(user).name("Other Notebook").please();
-      makeMe.aNote().toBeRemoved(user).notebook(otherNotebook).please();
-      Note targetInOther =
-          makeMe.aNote().title("LinkedPage").toBeRemoved(user).notebook(otherNotebook).please();
+      makeMe.aNote().notebook(otherNotebook).please();
+      Note targetInOther = makeMe.aNote().title("LinkedPage").notebook(otherNotebook).please();
       Notebook mainNotebook = makeMe.aNotebook().creatorAndOwner(user).name("Main").please();
-      makeMe.aNote().toBeRemoved(user).notebook(mainNotebook).please();
+      makeMe.aNote().notebook(mainNotebook).please();
       Note viewer =
           makeMe
               .aNote()
-              .toBeRemoved(user)
               .notebook(mainNotebook)
               .content("See [[Other Notebook:LinkedPage]] for more.")
               .please();
@@ -178,20 +162,13 @@ class NoteControllerTests extends ControllerTestBase {
     void shouldReturnWikiTitlesFromFrontmatterBlocks() throws UnexpectedNoAccessRightException {
       User user = currentUser.getUser();
       Note root = makeMe.aNote().notebookOwnedBy(user).please();
-      Note fromFm =
-          makeMe
-              .aNote()
-              .title("FrontmatterTarget")
-              .toBeRemoved(user)
-              .notebook(root.getNotebook())
-              .please();
+      Note fromFm = makeMe.aNote().title("FrontmatterTarget").notebook(root.getNotebook()).please();
       String markdown =
           "---\n"
               + "see: Summary with [[FrontmatterTarget]]\n"
               + "---\n"
               + "[[FrontmatterTarget]] body\n";
-      Note viewer =
-          makeMe.aNote().toBeRemoved(user).notebook(root.getNotebook()).content(markdown).please();
+      Note viewer = makeMe.aNote().notebook(root.getNotebook()).content(markdown).please();
       wikiTitleCacheService.refreshForNote(viewer, user);
       NoteRealm realm = controller.showNote(viewer);
       assertThat(realm.getWikiTitles(), hasSize(1));
@@ -342,12 +319,7 @@ class NoteControllerTests extends ControllerTestBase {
     @BeforeEach
     void setup() {
       subject = makeMe.aNote().notebookOwnedBy(currentUser.getUser()).please();
-      child =
-          makeMe
-              .aNote("child")
-              .toBeRemoved(currentUser.getUser())
-              .notebook(subject.getNotebook())
-              .please();
+      child = makeMe.aNote("child").notebook(subject.getNotebook()).please();
     }
 
     @Test
@@ -373,7 +345,6 @@ class NoteControllerTests extends ControllerTestBase {
       Note referrer =
           makeMe
               .aNote("Referrer")
-              .toBeRemoved(currentUser.getUser())
               .notebook(nb)
               .content(
                   "---\nsource: \"[[Referrer]]\"\ntarget: \"[[Target]]\"\n---\nBody [[Target]]")

--- a/backend/src/test/java/com/odde/doughnut/controllers/NotebookSharingGroupControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/NotebookSharingGroupControllerTest.java
@@ -55,7 +55,7 @@ class NotebookSharingGroupControllerTest extends NotebookControllerTestBase {
       User anotherUser = makeMe.aUser().please();
       Circle circle1 =
           makeMe.aCircle().hasMember(anotherUser).hasMember(currentUser.getUser()).please();
-      Note note = makeMe.aNote().toBeRemoved(anotherUser).inCircle(circle1).please();
+      Note note = makeMe.aNote().inCircle(circle1).please();
       assertThrows(
           UnexpectedNoAccessRightException.class,
           () -> controller.moveToCircle(note.getNotebook(), makeMe.aCircle().please()));

--- a/backend/src/test/java/com/odde/doughnut/controllers/SubscriptionControllerTest.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/SubscriptionControllerTest.java
@@ -53,12 +53,9 @@ class SubscriptionControllerTest extends ControllerTestBase {
   @Test
   void createdSubscriptionForCircleNotebookSerializesWithoutLegacyNotebookFields()
       throws Exception {
-    User user = currentUser.getUser();
-    Circle circle = makeMe.aCircle().hasMember(user).please();
+    Circle circle = makeMe.aCircle().hasMember(currentUser.getUser()).please();
     Notebook circleNotebook =
-        makeMe
-            .refresh(makeMe.aNote("Circle notebook").toBeRemoved(user).inCircle(circle).please())
-            .getNotebook();
+        makeMe.refresh(makeMe.aNote("Circle notebook").inCircle(circle).please()).getNotebook();
 
     SubscriptionDTO subscriptionDTO = new SubscriptionDTO();
     subscriptionDTO.setDailyTargetOfNewNotes(1);

--- a/backend/src/test/java/com/odde/doughnut/services/AuthorizationServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/AuthorizationServiceTest.java
@@ -39,7 +39,7 @@ public class AuthorizationServiceTest {
     @BeforeEach
     void setup() {
       circle = makeMe.aCircle().please();
-      note = makeMe.aNote().toBeRemoved(makeMe.aUser().please()).inCircle(circle).please();
+      note = makeMe.aNote().inCircle(circle).please();
     }
 
     @Test

--- a/backend/src/test/java/com/odde/doughnut/services/NoteRealmServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/NoteRealmServiceTest.java
@@ -75,7 +75,7 @@ class NoteRealmServiceTest {
 
   @Test
   void omits_cached_target_when_target_note_is_soft_deleted() {
-    Note target = makeMe.aNote().title("Target").toBeRemoved(user).notebook(notebook).please();
+    Note target = makeMe.aNote().title("Target").notebook(notebook).please();
     Note carrier = makeMe.aNote().notebook(notebook).content("[[Target]]").please();
     wikiTitleCacheService.refreshForNote(carrier, user);
 
@@ -96,9 +96,8 @@ class NoteRealmServiceTest {
 
   @Test
   void body_wikilink_carrier_in_references() {
-    Note focal = makeMe.aNote().title("Focal").toBeRemoved(user).notebook(notebook).please();
-    Note carrier =
-        makeMe.aNote().toBeRemoved(user).notebook(notebook).content("[[Focal]]").please();
+    Note focal = makeMe.aNote().title("Focal").notebook(notebook).please();
+    Note carrier = makeMe.aNote().notebook(notebook).content("[[Focal]]").please();
     wikiTitleCacheService.refreshForNote(carrier, user);
 
     NoteRealm realm = noteRealmService.build(focal, user);
@@ -109,8 +108,8 @@ class NoteRealmServiceTest {
 
   @Test
   void parent_yaml_carrier_appears_in_references() {
-    Note focal = makeMe.aNote().title("Focal").toBeRemoved(user).notebook(notebook).please();
-    Note carrier = makeMe.aNote().title("Child").toBeRemoved(user).notebook(notebook).please();
+    Note focal = makeMe.aNote().title("Focal").notebook(notebook).please();
+    Note carrier = makeMe.aNote().title("Child").notebook(notebook).please();
     carrier.setContent("---\nparent: \"[[Focal]]\"\n---\n\nBody.");
     makeMe.entityPersister.merge(carrier);
     makeMe.entityPersister.flush();
@@ -150,9 +149,9 @@ class NoteRealmServiceTest {
     User focalOwner = makeMe.aUser().please();
     User carrierOwner = carrierSharesOwnerWithViewer ? focalOwner : makeMe.aUser().please();
     Notebook mainNb = makeMe.aNotebook().creatorAndOwner(focalOwner).name("MainNb").please();
-    Note focal = makeMe.aNote().title("Focal").toBeRemoved(focalOwner).notebook(mainNb).please();
+    Note focal = makeMe.aNote().title("Focal").notebook(mainNb).please();
     Notebook otherNb = makeMe.aNotebook().creatorAndOwner(carrierOwner).name("OtherNb").please();
-    Note carrier = makeMe.aNote().toBeRemoved(carrierOwner).notebook(otherNb).please();
+    Note carrier = makeMe.aNote().notebook(otherNb).please();
 
     persistWikiLink(carrier, focal, "MainNb:Focal");
 
@@ -177,8 +176,8 @@ class NoteRealmServiceTest {
 
   @Test
   void references_dedupe_multiple_cache_rows_for_same_carrier_note() {
-    Note focal = makeMe.aNote().title("Focal").toBeRemoved(user).notebook(notebook).please();
-    Note carrier = makeMe.aNote().toBeRemoved(user).notebook(notebook).please();
+    Note focal = makeMe.aNote().title("Focal").notebook(notebook).please();
+    Note carrier = makeMe.aNote().notebook(notebook).please();
 
     persistWikiLink(carrier, focal, "one");
     persistWikiLink(carrier, focal, "two");

--- a/backend/src/test/java/com/odde/doughnut/services/focusContext/FocusContextRetrievalServiceTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/focusContext/FocusContextRetrievalServiceTest.java
@@ -51,7 +51,6 @@ class FocusContextRetrievalServiceTest {
       Note note =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .notebook(notebookReadableBy(viewer))
               .title("Solo")
               .content("Some content")
@@ -67,26 +66,12 @@ class FocusContextRetrievalServiceTest {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
       String longContent = "a".repeat(10000);
-      Note longNote =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("Long")
-              .content(longContent)
-              .please();
+      Note longNote = makeMe.aNote().notebook(nb).title("Long").content(longContent).please();
       FocusContextResult longResult = service.retrieve(longNote, viewer, RetrievalConfig.depth1());
       assertThat(longResult.getFocusNote().isContentTruncated(), is(true));
       assertThat(longResult.getFocusNote().getContent().length(), lessThan(longContent.length()));
 
-      Note shortNote =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("Short")
-              .content("Small content")
-              .please();
+      Note shortNote = makeMe.aNote().notebook(nb).title("Short").content("Small content").please();
       FocusContextResult shortResult =
           service.retrieve(shortNote, viewer, RetrievalConfig.depth1());
       assertThat(shortResult.getFocusNote().isContentTruncated(), is(false));
@@ -103,17 +88,9 @@ class FocusContextRetrievalServiceTest {
     void setup() {
       viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      focusNote =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("Focus")
-              .content("See [[Linked]].")
-              .please();
+      focusNote = makeMe.aNote().notebook(nb).title("Focus").content("See [[Linked]].").please();
       makeMe
           .aNote()
-          .toBeRemoved(viewer)
           .underSameNotebookAs(focusNote)
           .title("Linked")
           .content("Linked content")
@@ -147,11 +124,10 @@ class FocusContextRetrievalServiceTest {
     void setup() {
       viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      focusNote = makeMe.aNote().toBeRemoved(viewer).notebook(nb).title("Focus").please();
+      focusNote = makeMe.aNote().notebook(nb).title("Focus").please();
       referrer =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focusNote)
               .title("Referrer")
               .content("Links to [[Focus]].")
@@ -179,12 +155,11 @@ class FocusContextRetrievalServiceTest {
     void setup() {
       viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      focusNote = makeMe.aNote().toBeRemoved(viewer).notebook(nb).title("HubFocus").please();
+      focusNote = makeMe.aNote().notebook(nb).title("HubFocus").please();
       for (int i = 0; i < 10; i++) {
         Note r =
             makeMe
                 .aNote()
-                .toBeRemoved(viewer)
                 .underSameNotebookAs(focusNote)
                 .title("Ref" + i)
                 .content("Links to [[HubFocus]].")
@@ -250,7 +225,6 @@ class FocusContextRetrievalServiceTest {
         Note r =
             makeMe
                 .aNote()
-                .toBeRemoved(viewer)
                 .underSameNotebookAs(focusNote)
                 .title("Extra" + i)
                 .content("Links to [[HubFocus]].")
@@ -265,12 +239,10 @@ class FocusContextRetrievalServiceTest {
 
     @Test
     void depth1InboundExcludesOutgoingTargetsBeforeCap() {
-      Note hub =
-          makeMe.aNote().toBeRemoved(viewer).underSameNotebookAs(focusNote).title("XHub").please();
+      Note hub = makeMe.aNote().underSameNotebookAs(focusNote).title("XHub").please();
       Note shared =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focusNote)
               .title("XShared")
               .content("Links to [[XHub]].")
@@ -280,7 +252,6 @@ class FocusContextRetrievalServiceTest {
       for (int i = 0; i < 8; i++) {
         makeMe
             .aNote()
-            .toBeRemoved(viewer)
             .underSameNotebookAs(focusNote)
             .title("XRef" + i)
             .content("Links to [[XHub]].")
@@ -309,7 +280,6 @@ class FocusContextRetrievalServiceTest {
       Note depth1Ref =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focusNote)
               .title("Depth1Hub")
               .content("Links to [[HubFocus]].")
@@ -319,7 +289,6 @@ class FocusContextRetrievalServiceTest {
         Note d2 =
             makeMe
                 .aNote()
-                .toBeRemoved(viewer)
                 .underSameNotebookAs(focusNote)
                 .title("D2Ref" + i)
                 .content("Links to [[Depth1Hub]].")
@@ -358,18 +327,10 @@ class FocusContextRetrievalServiceTest {
     void noteReachedAsBothOutgoingAndInboundKeepsOutgoingEdgeType() {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      Note focusNote =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("Focus")
-              .content("See [[Both]].")
-              .please();
+      Note focusNote = makeMe.aNote().notebook(nb).title("Focus").content("See [[Both]].").please();
       Note both =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focusNote)
               .title("Both")
               .content("Links back to [[Focus]].")
@@ -403,20 +364,13 @@ class FocusContextRetrievalServiceTest {
       Note focusNote =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .notebook(nb)
               .title("Focus")
               .content(linkLine.toString().trim() + ".")
               .please();
       String largeDetails = "x".repeat(3500);
       for (String title : titles) {
-        makeMe
-            .aNote()
-            .toBeRemoved(viewer)
-            .underSameNotebookAs(focusNote)
-            .title(title)
-            .content(largeDetails)
-            .please();
+        makeMe.aNote().underSameNotebookAs(focusNote).title(title).content(largeDetails).please();
       }
       refreshWikiCache(focusNote, viewer);
 
@@ -433,24 +387,16 @@ class FocusContextRetrievalServiceTest {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
       Note focus =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("ChainRoot")
-              .content("Start [[MidDepth]].")
-              .please();
+          makeMe.aNote().notebook(nb).title("ChainRoot").content("Start [[MidDepth]].").please();
       Note mid =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("MidDepth")
               .content("Bridge [[LeafDepth2]].")
               .please();
       makeMe
           .aNote()
-          .toBeRemoved(viewer)
           .underSameNotebookAs(focus)
           .title("LeafDepth2")
           .content("Only at depth 2")
@@ -481,28 +427,15 @@ class FocusContextRetrievalServiceTest {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
       Note focus =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("ShallowRoot")
-              .content("[[MidShallow]].")
-              .please();
+          makeMe.aNote().notebook(nb).title("ShallowRoot").content("[[MidShallow]].").please();
       Note mid =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("MidShallow")
               .content("[[LeafShallow]].")
               .please();
-      makeMe
-          .aNote()
-          .toBeRemoved(viewer)
-          .underSameNotebookAs(focus)
-          .title("LeafShallow")
-          .content("deep")
-          .please();
+      makeMe.aNote().underSameNotebookAs(focus).title("LeafShallow").content("deep").please();
       refreshWikiCache(focus, viewer);
       refreshWikiCache(mid, viewer);
 
@@ -523,18 +456,10 @@ class FocusContextRetrievalServiceTest {
     void cycleBetweenTwoNotesDoesNotLoop() {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      Note a =
-          makeMe
-              .aNote()
-              .toBeRemoved(viewer)
-              .notebook(nb)
-              .title("CycleA")
-              .content("To [[CycleB]].")
-              .please();
+      Note a = makeMe.aNote().notebook(nb).title("CycleA").content("To [[CycleB]].").please();
       Note b =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(a)
               .title("CycleB")
               .content("Back [[CycleA]].")
@@ -555,14 +480,12 @@ class FocusContextRetrievalServiceTest {
       Note focus =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .notebook(nb)
               .title("ShortFocus")
               .content("[[DirectShort]] [[ViaBridge]].")
               .please();
       makeMe
           .aNote()
-          .toBeRemoved(viewer)
           .underSameNotebookAs(focus)
           .title("DirectShort")
           .content("direct body")
@@ -570,7 +493,6 @@ class FocusContextRetrievalServiceTest {
       Note bridge =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("ViaBridge")
               .content("See [[DirectShort]].")
@@ -595,11 +517,10 @@ class FocusContextRetrievalServiceTest {
     void depthTwoInboundFromExpandedNote() {
       User viewer = makeMe.aUser().please();
       Notebook nb = notebookReadableBy(viewer);
-      Note focus = makeMe.aNote().toBeRemoved(viewer).notebook(nb).title("InboundRoot").please();
+      Note focus = makeMe.aNote().notebook(nb).title("InboundRoot").please();
       Note hub =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("HubInbound")
               .content("Link [[InboundRoot]].")
@@ -607,7 +528,6 @@ class FocusContextRetrievalServiceTest {
       Note depth2Referrer =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("RefersToHub")
               .content("Hub is [[HubInbound]].")
@@ -643,31 +563,22 @@ class FocusContextRetrievalServiceTest {
       Note focus =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .notebook(nb)
               .title("BudgetRoot")
               .content("[[Spend1]] [[Spend2]] [[Spend3]] [[Spend4]] [[Spend5]] [[BridgeBudget]]")
               .please();
       for (int i = 1; i <= 5; i++) {
-        makeMe
-            .aNote()
-            .toBeRemoved(viewer)
-            .underSameNotebookAs(focus)
-            .title("Spend" + i)
-            .content(maxChunk)
-            .please();
+        makeMe.aNote().underSameNotebookAs(focus).title("Spend" + i).content(maxChunk).please();
       }
       Note bridge =
           makeMe
               .aNote()
-              .toBeRemoved(viewer)
               .underSameNotebookAs(focus)
               .title("BridgeBudget")
               .content("[[LeafAfterBudget]].")
               .please();
       makeMe
           .aNote()
-          .toBeRemoved(viewer)
           .underSameNotebookAs(focus)
           .title("LeafAfterBudget")
           .content("never reached")
@@ -710,16 +621,9 @@ class FocusContextRetrievalServiceTest {
         viewer = makeMe.aUser().please();
         Notebook nb = notebookReadableBy(viewer);
         Folder folder = makeMe.aFolder().notebook(nb).please();
-        focus =
-            makeMe
-                .aNote()
-                .toBeRemoved(viewer)
-                .folder(folder)
-                .title("FocusSib")
-                .content("solo")
-                .please();
+        focus = makeMe.aNote().folder(folder).title("FocusSib").content("solo").please();
         for (int i = 0; i < 6; i++) {
-          makeMe.aNote().toBeRemoved(viewer).folder(folder).title("Peer" + i).content("x").please();
+          makeMe.aNote().folder(folder).title("Peer" + i).content("x").please();
         }
       }
 

--- a/backend/src/test/java/com/odde/doughnut/testability/builders/NoteBuilder.java
+++ b/backend/src/test/java/com/odde/doughnut/testability/builders/NoteBuilder.java
@@ -69,10 +69,6 @@ public class NoteBuilder extends EntityBuilder<Note> {
     return this;
   }
 
-  public NoteBuilder toBeRemoved(User user) {
-    return this;
-  }
-
   public NoteBuilder creator(User user) {
     if (entity.getCreator() != null)
       throw new AssertionError("creator already set for " + entity.toString());


### PR DESCRIPTION
- Eliminated the `toBeRemoved` method from the `NoteBuilder` class, simplifying note creation in tests.
- Updated multiple test files to reflect this change, ensuring consistency in how notes are created without the removed method.
- Enhanced clarity and maintainability of the test code by standardizing the approach to note creation across the test suite.
