### PR TITLE
feat: include frontmatter aliases in note search

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/NoteAliasIndexRepository.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/NoteAliasIndexRepository.java
@@ -1,13 +1,21 @@
 package com.odde.doughnut.entities.repositories;
 
+import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.NoteAliasIndex;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface NoteAliasIndexRepository extends JpaRepository<NoteAliasIndex, Integer> {
+
+  String selectNoteFromAliasIndex = "SELECT DISTINCT n FROM NoteAliasIndex i JOIN i.note n";
+  String aliasExactWhere =
+      " WHERE i.aliasLookupKey = :lookupKey AND n.deletedAt IS NULL ";
+  String aliasPartialWhere =
+      " WHERE i.aliasLookupKey LIKE :pattern AND n.deletedAt IS NULL ";
 
   @Modifying
   @Query("DELETE FROM NoteAliasIndex i WHERE i.note.id = :noteId")
@@ -27,4 +35,68 @@ public interface NoteAliasIndexRepository extends JpaRepository<NoteAliasIndex, 
               + " ORDER BY n.id ASC")
   List<NoteAliasIndex> findByNotebookNameAndAliasLookupKeyOrderByNoteIdAsc(
       @Param("notebookName") String notebookName, @Param("aliasLookupKey") String aliasLookupKey);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + aliasExactWhere
+              + " AND n.notebook.ownership.user.id = :userId")
+  List<Note> searchExactForUserInAllMyNotebooks(
+      @Param("userId") Integer userId, @Param("lookupKey") String lookupKey);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + " JOIN n.notebook.subscriptions s ON s.user.id = :userId "
+              + aliasExactWhere)
+  List<Note> searchExactForUserInAllMySubscriptions(
+      @Param("userId") Integer userId, @Param("lookupKey") String lookupKey);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + " JOIN n.notebook.ownership.circle.members m ON m.id = :userId "
+              + aliasExactWhere)
+  List<Note> searchExactForUserInAllMyCircle(
+      @Param("userId") Integer userId, @Param("lookupKey") String lookupKey);
+
+  @Query(value = selectNoteFromAliasIndex + aliasExactWhere + " AND n.notebook.id = :notebookId")
+  List<Note> searchExactInNotebook(
+      @Param("notebookId") Integer notebookId, @Param("lookupKey") String lookupKey);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + aliasPartialWhere
+              + " AND n.notebook.ownership.user.id = :userId")
+  List<Note> searchForUserInAllMyNotebooks(
+      @Param("userId") Integer userId,
+      @Param("pattern") String pattern,
+      Pageable pageable);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + " JOIN n.notebook.subscriptions s ON s.user.id = :userId "
+              + aliasPartialWhere)
+  List<Note> searchForUserInAllMySubscriptions(
+      @Param("userId") Integer userId,
+      @Param("pattern") String pattern,
+      Pageable pageable);
+
+  @Query(
+      value =
+          selectNoteFromAliasIndex
+              + " JOIN n.notebook.ownership.circle.members m ON m.id = :userId "
+              + aliasPartialWhere)
+  List<Note> searchForUserInAllMyCircle(
+      @Param("userId") Integer userId,
+      @Param("pattern") String pattern,
+      Pageable pageable);
+
+  @Query(value = selectNoteFromAliasIndex + aliasPartialWhere + " AND n.notebook.id = :notebookId")
+  List<Note> searchInNotebook(
+      @Param("notebookId") Integer notebookId,
+      @Param("pattern") String pattern,
+      Pageable pageable);
 }

--- a/backend/src/main/java/com/odde/doughnut/services/search/NoteSearchService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/search/NoteSearchService.java
@@ -1,5 +1,6 @@
 package com.odde.doughnut.services.search;
 
+import com.odde.doughnut.algorithms.FrontmatterAliases;
 import com.odde.doughnut.controllers.dto.NoteSearchResult;
 import com.odde.doughnut.controllers.dto.RelationshipLiteralSearchHit;
 import com.odde.doughnut.controllers.dto.SearchTerm;
@@ -8,13 +9,16 @@ import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.Notebook;
 import com.odde.doughnut.entities.User;
 import com.odde.doughnut.entities.repositories.FolderRepository;
+import com.odde.doughnut.entities.repositories.NoteAliasIndexRepository;
 import com.odde.doughnut.entities.repositories.NoteEmbeddingJdbcRepository;
 import com.odde.doughnut.entities.repositories.NoteRepository;
 import com.odde.doughnut.entities.repositories.NotebookRepository;
 import com.odde.doughnut.services.EmbeddingService;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.util.Strings;
@@ -28,8 +32,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class NoteSearchService {
   private static final int FOLDER_LITERAL_MATCH_CAP = 12;
   private static final int NOTEBOOK_LITERAL_MATCH_CAP = 12;
+  private static final float TITLE_EXACT_DISTANCE = 0.0f;
+  private static final float ALIAS_EXACT_DISTANCE = 0.05f;
+  private static final float PARTIAL_DISTANCE = 0.9f;
 
   private final NoteRepository noteRepository;
+  private final NoteAliasIndexRepository noteAliasIndexRepository;
   private final FolderRepository folderRepository;
   private final NotebookRepository notebookRepository;
   private final NoteEmbeddingJdbcRepository noteEmbeddingJdbcRepository;
@@ -37,11 +45,13 @@ public class NoteSearchService {
 
   public NoteSearchService(
       NoteRepository noteRepository,
+      NoteAliasIndexRepository noteAliasIndexRepository,
       FolderRepository folderRepository,
       NotebookRepository notebookRepository,
       NoteEmbeddingJdbcRepository noteEmbeddingJdbcRepository,
       EmbeddingService embeddingService) {
     this.noteRepository = noteRepository;
+    this.noteAliasIndexRepository = noteAliasIndexRepository;
     this.folderRepository = folderRepository;
     this.notebookRepository = notebookRepository;
     this.noteEmbeddingJdbcRepository = noteEmbeddingJdbcRepository;
@@ -53,10 +63,12 @@ public class NoteSearchService {
       return List.of();
     }
 
-    List<Note> exactMatches = searchExactMatches(user, searchTerm, null);
+    List<Note> exactTitleMatches = searchExactTitleMatches(user, searchTerm, null);
+    List<Note> exactAliasMatches = searchExactAliasMatches(user, searchTerm, null);
     List<Note> partialMatches = searchPartialMatches(user, searchTerm, null);
     List<NoteSearchResult> noteResults =
-        combineExactAndPartialMatches(exactMatches, partialMatches, null, null);
+        combineExactAndPartialMatches(
+            exactTitleMatches, exactAliasMatches, partialMatches, null, null);
     return mergeNoteAndFolderLiteralHits(user, searchTerm, null, noteResults);
   }
 
@@ -68,10 +80,12 @@ public class NoteSearchService {
     Integer avoidNoteId = note != null ? note.getId() : null;
     Integer notebookId = note != null ? note.getNotebook().getId() : null;
 
-    List<Note> exactMatches = searchExactMatches(user, searchTerm, notebookId);
+    List<Note> exactTitleMatches = searchExactTitleMatches(user, searchTerm, notebookId);
+    List<Note> exactAliasMatches = searchExactAliasMatches(user, searchTerm, notebookId);
     List<Note> partialMatches = searchPartialMatches(user, searchTerm, notebookId);
     List<NoteSearchResult> noteResults =
-        combineExactAndPartialMatches(exactMatches, partialMatches, avoidNoteId, notebookId);
+        combineExactAndPartialMatches(
+            exactTitleMatches, exactAliasMatches, partialMatches, avoidNoteId, notebookId);
     return mergeNoteAndFolderLiteralHits(user, searchTerm, notebookId, noteResults);
   }
 
@@ -381,7 +395,7 @@ public class NoteSearchService {
     return sortByDistanceThenNotebook(results, notebookId);
   }
 
-  private List<Note> searchExactMatches(User user, SearchTerm searchTerm, Integer notebookId) {
+  private List<Note> searchExactTitleMatches(User user, SearchTerm searchTerm, Integer notebookId) {
     String exactSearchKey = searchTerm.getTrimmedSearchKey();
     if (Strings.isBlank(exactSearchKey)) {
       return List.of();
@@ -389,17 +403,17 @@ public class NoteSearchService {
 
     if (Boolean.TRUE.equals(searchTerm.getAllMyCircles())) {
       return Stream.concat(
-              searchExactMatchesInMyNotebooksAndSubscriptions(user, searchTerm).stream(),
+              searchExactTitleMatchesInMyNotebooksAndSubscriptions(user, searchTerm).stream(),
               noteRepository.searchExactForUserInAllMyCircle(user.getId(), exactSearchKey).stream())
           .toList();
     }
     if (Boolean.TRUE.equals(searchTerm.getAllMyNotebooksAndSubscriptions())) {
-      return searchExactMatchesInMyNotebooksAndSubscriptions(user, searchTerm);
+      return searchExactTitleMatchesInMyNotebooksAndSubscriptions(user, searchTerm);
     }
     return noteRepository.searchExactInNotebook(notebookId, exactSearchKey);
   }
 
-  private List<Note> searchExactMatchesInMyNotebooksAndSubscriptions(
+  private List<Note> searchExactTitleMatchesInMyNotebooksAndSubscriptions(
       User user, SearchTerm searchTerm) {
     return Stream.concat(
             noteRepository
@@ -412,15 +426,54 @@ public class NoteSearchService {
         .toList();
   }
 
+  private List<Note> searchExactAliasMatches(User user, SearchTerm searchTerm, Integer notebookId) {
+    String lookupKey = normalizedAliasLookupKey(searchTerm);
+    if (Strings.isBlank(lookupKey)) {
+      return List.of();
+    }
+
+    if (Boolean.TRUE.equals(searchTerm.getAllMyCircles())) {
+      return Stream.concat(
+              searchExactAliasMatchesInMyNotebooksAndSubscriptions(user, lookupKey).stream(),
+              noteAliasIndexRepository
+                  .searchExactForUserInAllMyCircle(user.getId(), lookupKey)
+                  .stream())
+          .toList();
+    }
+    if (Boolean.TRUE.equals(searchTerm.getAllMyNotebooksAndSubscriptions())) {
+      return searchExactAliasMatchesInMyNotebooksAndSubscriptions(user, lookupKey);
+    }
+    return noteAliasIndexRepository.searchExactInNotebook(notebookId, lookupKey);
+  }
+
+  private List<Note> searchExactAliasMatchesInMyNotebooksAndSubscriptions(
+      User user, String lookupKey) {
+    return Stream.concat(
+            noteAliasIndexRepository
+                .searchExactForUserInAllMyNotebooks(user.getId(), lookupKey)
+                .stream(),
+            noteAliasIndexRepository
+                .searchExactForUserInAllMySubscriptions(user.getId(), lookupKey)
+                .stream())
+        .toList();
+  }
+
   private List<Note> searchPartialMatches(User user, SearchTerm searchTerm, Integer notebookId) {
     String searchKey = searchTerm.getTrimmedSearchKey();
     if (Strings.isBlank(searchKey)) {
       return List.of();
     }
 
+    List<Note> titlePartial = searchPartialTitleMatches(user, searchTerm, notebookId);
+    List<Note> aliasPartial = searchPartialAliasMatches(user, searchTerm, notebookId);
+    return mergeUniqueNotes(titlePartial, aliasPartial);
+  }
+
+  private List<Note> searchPartialTitleMatches(
+      User user, SearchTerm searchTerm, Integer notebookId) {
     if (Boolean.TRUE.equals(searchTerm.getAllMyCircles())) {
       return Stream.concat(
-              searchPartialMatchesInMyNotebooksAndSubscriptions(user, searchTerm).stream(),
+              searchPartialTitleMatchesInMyNotebooksAndSubscriptions(user, searchTerm).stream(),
               noteRepository
                   .searchForUserInAllMyCircle(
                       user.getId(), getPattern(searchTerm), getLimitPageable())
@@ -428,12 +481,12 @@ public class NoteSearchService {
           .toList();
     }
     if (Boolean.TRUE.equals(searchTerm.getAllMyNotebooksAndSubscriptions())) {
-      return searchPartialMatchesInMyNotebooksAndSubscriptions(user, searchTerm);
+      return searchPartialTitleMatchesInMyNotebooksAndSubscriptions(user, searchTerm);
     }
     return noteRepository.searchInNotebook(notebookId, getPattern(searchTerm), getLimitPageable());
   }
 
-  private List<Note> searchPartialMatchesInMyNotebooksAndSubscriptions(
+  private List<Note> searchPartialTitleMatchesInMyNotebooksAndSubscriptions(
       User user, SearchTerm searchTerm) {
     return Stream.concat(
             noteRepository
@@ -447,33 +500,94 @@ public class NoteSearchService {
         .toList();
   }
 
+  private List<Note> searchPartialAliasMatches(
+      User user, SearchTerm searchTerm, Integer notebookId) {
+    String pattern = normalizedAliasLookupPattern(searchTerm);
+    if (Strings.isBlank(pattern.replace("%", ""))) {
+      return List.of();
+    }
+
+    if (Boolean.TRUE.equals(searchTerm.getAllMyCircles())) {
+      return Stream.concat(
+              searchPartialAliasMatchesInMyNotebooksAndSubscriptions(user, pattern).stream(),
+              noteAliasIndexRepository
+                  .searchForUserInAllMyCircle(user.getId(), pattern, getLimitPageable())
+                  .stream())
+          .toList();
+    }
+    if (Boolean.TRUE.equals(searchTerm.getAllMyNotebooksAndSubscriptions())) {
+      return searchPartialAliasMatchesInMyNotebooksAndSubscriptions(user, pattern);
+    }
+    return noteAliasIndexRepository.searchInNotebook(
+        notebookId, pattern, getLimitPageable());
+  }
+
+  private List<Note> searchPartialAliasMatchesInMyNotebooksAndSubscriptions(
+      User user, String pattern) {
+    return Stream.concat(
+            noteAliasIndexRepository
+                .searchForUserInAllMyNotebooks(user.getId(), pattern, getLimitPageable())
+                .stream(),
+            noteAliasIndexRepository
+                .searchForUserInAllMySubscriptions(user.getId(), pattern, getLimitPageable())
+                .stream())
+        .toList();
+  }
+
+  private static List<Note> mergeUniqueNotes(List<Note> first, List<Note> second) {
+    Set<Integer> seen = new HashSet<>();
+    List<Note> merged = new ArrayList<>();
+    for (Note note : first) {
+      if (seen.add(note.getId())) {
+        merged.add(note);
+      }
+    }
+    for (Note note : second) {
+      if (seen.add(note.getId())) {
+        merged.add(note);
+      }
+    }
+    return merged;
+  }
+
   private List<NoteSearchResult> combineExactAndPartialMatches(
-      List<Note> exactMatches, List<Note> partialMatches, Integer avoidNoteId, Integer notebookId) {
-    List<Note> filteredExactMatches = exactMatches;
-    List<Note> filteredPartialMatchesInput = partialMatches;
+      List<Note> titleExactMatches,
+      List<Note> aliasExactMatches,
+      List<Note> partialMatches,
+      Integer avoidNoteId,
+      Integer notebookId) {
+    Set<Integer> titleExactIds =
+        titleExactMatches.stream().map(Note::getId).collect(Collectors.toSet());
+    List<Note> aliasOnlyExactMatches =
+        aliasExactMatches.stream().filter(note -> !titleExactIds.contains(note.getId())).toList();
+    Set<Integer> allExactIds = new HashSet<>(titleExactIds);
+    aliasOnlyExactMatches.forEach(note -> allExactIds.add(note.getId()));
 
     List<Note> filteredPartialMatches =
-        filteredPartialMatchesInput.stream()
-            .filter(
-                note ->
-                    filteredExactMatches.stream()
-                        .noneMatch(exact -> exact.getId().equals(note.getId())))
-            .toList();
+        partialMatches.stream().filter(note -> !allExactIds.contains(note.getId())).toList();
 
     List<NoteSearchResult> results =
-        filteredExactMatches.stream()
+        titleExactMatches.stream()
             .filter(note -> !note.getId().equals(avoidNoteId))
-            .map(note -> noteToSearchResult(note, 0.0f))
-            .collect(Collectors.toList());
+            .map(note -> noteToSearchResult(note, TITLE_EXACT_DISTANCE))
+            .collect(Collectors.toCollection(ArrayList::new));
 
-    int remainingSlots = filteredExactMatches.isEmpty() ? 20 : 20 + filteredExactMatches.size();
+    aliasOnlyExactMatches.stream()
+        .filter(note -> !note.getId().equals(avoidNoteId))
+        .map(note -> noteToSearchResult(note, ALIAS_EXACT_DISTANCE))
+        .forEach(results::add);
+
+    int remainingSlots =
+        titleExactMatches.isEmpty() && aliasOnlyExactMatches.isEmpty()
+            ? 20
+            : 20 + titleExactMatches.size() + aliasOnlyExactMatches.size();
 
     if (remainingSlots > 0) {
       results.addAll(
           filteredPartialMatches.stream()
               .limit(remainingSlots)
               .filter(note -> !note.getId().equals(avoidNoteId))
-              .map(note -> noteToSearchResult(note, 0.9f))
+              .map(note -> noteToSearchResult(note, PARTIAL_DISTANCE))
               .collect(Collectors.toList()));
     }
 
@@ -508,5 +622,13 @@ public class NoteSearchService {
 
   private String getPattern(SearchTerm searchTerm) {
     return "%" + searchTerm.getTrimmedSearchKey() + "%";
+  }
+
+  private static String normalizedAliasLookupKey(SearchTerm searchTerm) {
+    return FrontmatterAliases.normalizedLookupKey(searchTerm.getTrimmedSearchKey());
+  }
+
+  private static String normalizedAliasLookupPattern(SearchTerm searchTerm) {
+    return "%" + normalizedAliasLookupKey(searchTerm) + "%";
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/controllers/SearchControllerTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/SearchControllerTests.java
@@ -10,6 +10,7 @@ import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.Notebook;
 import com.odde.doughnut.entities.User;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
+import com.odde.doughnut.services.NoteAliasIndexService;
 import com.odde.doughnut.testability.RelationshipLiteralSearchHits;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,7 @@ import org.springframework.web.server.ResponseStatusException;
 class SearchControllerTests extends ControllerTestBase {
   @Autowired SearchController controller;
   @Autowired EntityManager entityManager;
+  @Autowired NoteAliasIndexService noteAliasIndexService;
 
   @BeforeEach
   void setup() {
@@ -158,6 +160,109 @@ class SearchControllerTests extends ControllerTestBase {
                           && "Recipe Ideas".equals(h.getNotebookName())
                           && h.getNotebookId() != null),
           is(true));
+    }
+
+    @Test
+    void shouldReturnMatchingNotesByFrontmatterAlias() throws UnexpectedNoAccessRightException {
+      User user = currentUser.getUser();
+      Notebook notebook = makeMe.aNotebook().creatorAndOwner(user).please();
+      Note aliasTarget =
+          makeMe
+              .aNote()
+              .title("Canonical Title")
+              .notebook(notebook)
+              .content("---\naliases:\n  - SearchAlias\n---\n\nbody")
+              .please();
+      noteAliasIndexService.refreshForNote(aliasTarget);
+
+      SearchTerm searchTerm = new SearchTerm();
+      searchTerm.setSearchKey("SearchAlias");
+      searchTerm.setAllMyNotebooksAndSubscriptions(true);
+
+      var result = controller.searchForRelationshipTarget(searchTerm);
+
+      var notes = RelationshipLiteralSearchHits.noteMatches(result);
+      assertThat(notes, hasSize(1));
+      assertThat(notes.get(0).getNoteTopology().getTitle(), equalTo("Canonical Title"));
+      assertThat(notes.get(0).getNoteTopology().getId(), equalTo(aliasTarget.getId()));
+      assertThat(notes.get(0).getDistance(), equalTo(0.05f));
+    }
+
+    @Test
+    void shouldReturnPartialMatchesForFrontmatterAlias() throws UnexpectedNoAccessRightException {
+      User user = currentUser.getUser();
+      Notebook notebook = makeMe.aNotebook().creatorAndOwner(user).please();
+      Note aliasTarget =
+          makeMe
+              .aNote()
+              .title("Canonical Title")
+              .notebook(notebook)
+              .content("---\naliases:\n  - Programming Language\n---\n\nbody")
+              .please();
+      noteAliasIndexService.refreshForNote(aliasTarget);
+
+      SearchTerm searchTerm = new SearchTerm();
+      searchTerm.setSearchKey("gram");
+      searchTerm.setAllMyNotebooksAndSubscriptions(true);
+
+      var result = controller.searchForRelationshipTarget(searchTerm);
+
+      var notes = RelationshipLiteralSearchHits.noteMatches(result);
+      assertThat(notes, hasSize(1));
+      assertThat(notes.get(0).getNoteTopology().getId(), equalTo(aliasTarget.getId()));
+      assertThat(notes.get(0).getDistance(), equalTo(0.9f));
+    }
+
+    @Test
+    void shouldPreferTitleExactMatchOverAliasExactMatch() throws UnexpectedNoAccessRightException {
+      User user = currentUser.getUser();
+      Notebook notebook = makeMe.aNotebook().creatorAndOwner(user).please();
+      Note byTitle = makeMe.aNote("color").notebook(notebook).please();
+      Note byAlias =
+          makeMe
+              .aNote()
+              .title("colour")
+              .notebook(notebook)
+              .content("---\naliases:\n  - color\n---\n\nbody")
+              .please();
+      noteAliasIndexService.refreshForNote(byAlias);
+
+      SearchTerm searchTerm = new SearchTerm();
+      searchTerm.setSearchKey("color");
+      searchTerm.setAllMyNotebooksAndSubscriptions(true);
+
+      var result = controller.searchForRelationshipTarget(searchTerm);
+
+      var notes = RelationshipLiteralSearchHits.noteMatches(result);
+      assertThat(notes, hasSize(2));
+      assertThat(notes.get(0).getNoteTopology().getId(), equalTo(byTitle.getId()));
+      assertThat(notes.get(0).getDistance(), equalTo(0.0f));
+      assertThat(notes.get(1).getNoteTopology().getId(), equalTo(byAlias.getId()));
+      assertThat(notes.get(1).getDistance(), equalTo(0.05f));
+    }
+
+    @Test
+    void shouldMatchAliasCaseInsensitively() throws UnexpectedNoAccessRightException {
+      User user = currentUser.getUser();
+      Notebook notebook = makeMe.aNotebook().creatorAndOwner(user).please();
+      Note aliasTarget =
+          makeMe
+              .aNote()
+              .title("Canonical Title")
+              .notebook(notebook)
+              .content("---\naliases:\n  - SearchAlias\n---\n\nbody")
+              .please();
+      noteAliasIndexService.refreshForNote(aliasTarget);
+
+      SearchTerm searchTerm = new SearchTerm();
+      searchTerm.setSearchKey("searchalias");
+      searchTerm.setAllMyNotebooksAndSubscriptions(true);
+
+      var result = controller.searchForRelationshipTarget(searchTerm);
+
+      var notes = RelationshipLiteralSearchHits.noteMatches(result);
+      assertThat(notes, hasSize(1));
+      assertThat(notes.get(0).getNoteTopology().getId(), equalTo(aliasTarget.getId()));
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Note search now matches frontmatter `aliases` in addition to note titles, using the existing `note_alias_index` table and the same NFKC lowercase normalization as wiki-link resolution.

## Behavior

- **Exact alias match** — distance `0.05` (title exact matches remain `0.0`)
- **Partial alias match** — distance `0.9`, same as partial title matches
- **Title over alias** — when both a title and an alias exactly match the search key, the title match ranks first
- **Case-insensitive** — alias search uses normalized lookup keys

## Changes

- `NoteAliasIndexRepository` — added scoped exact and partial search queries mirroring `NoteRepository` access patterns
- `NoteSearchService` — merges title and alias results for literal search
- `SearchControllerTests` — added coverage for exact alias, partial alias, title-over-alias priority, and case insensitivity
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f175d-1433-7287-a32d-68b37b5ba5b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f175d-1433-7287-a32d-68b37b5ba5b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

