### PR TITLE
Set up Cursor Cloud dev environment + document cloud startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,18 @@ Portable digest (details live in the cited always-applied rules — keep `AGENTS
 - **GSD** for milestones (`/gsd-onboard`, `/gsd-plan-phase`, `/gsd-execute-phase`, …); **slice-planning** + **execute-plan** for ad-hoc slices under `.planning/quick/`.
 - **Test optimization:** `test-optimization` skill — plans under `.planning/phases/` or `quick/`, run via execute-plan.
 - **Non-compatible local overlays** (must keep): documented in `.cursor/rules/gsd-coexistence.mdc`.
+
+## Cursor Cloud specific instructions
+
+On the Cloud VM there is **no Nix** — run commands directly (drop the `CURSOR_DEV=true nix develop -c` prefix). Full details: `.agents/skills/cloud-vm-setup/SKILL.md`.
+
+- **Dependency refresh is automatic; system services are not.** The startup update script only runs `pnpm --frozen-lockfile recursive install`. It does **not** install Java/MySQL/Redis or start any service. Before running backend tests, E2E tests, or the app, run the idempotent setup script:
+  ```bash
+  source /workspace/scripts/cloud_agent_setup.sh
+  ```
+  It installs Java 25, MySQL 8.4 (port 3309), Redis (port 6380), and xvfb, initializes the `doughnut_test` / `doughnut_e2e_test` databases, and runs the test-DB migration.
+- **`source` it, don't execute it.** The script exports env vars (`JAVA_HOME`, `MYSQL_HOME`, `PATH`, `SPRING_DATASOURCE_URL`, `INPUT_DB_URL`, `CI=1`) into the current shell only. Any new shell that runs Gradle/backend/E2E must `source` it first, or those commands won't find Java/MySQL.
+- **Node engine warning is benign.** `package.json` wants Node `>=26.7` but the VM ships Node v22; there is no `engine-strict`, so install, lint, unit tests, build, and the app all work on the preinstalled Node. Do not spend time upgrading Node unless a task truly needs a v26 runtime feature.
+- **Run the app (full dev stack):** after sourcing the setup script, `SUT_TIMEOUT_MS=360000 pnpm sut` (first boot can exceed the 120s default). App (local LB) → http://localhost:5173/, Vite → 5174, backend → 9081, Mountebank → 2525. Health: `pnpm sut:healthcheck`; restart: `pnpm sut:restart`. `pnpm sut` spawns services detached and returns once healthy.
+- **Local login for manual testing:** open http://localhost:5173/, click Login (or go to `/users/identify`), then use a seeded account — `old_learner` / `password`, `another_old_learner` / `password`, or `admin` / `password` (form fields `id=username`, `id=password`, `id=login-button`).
+- **Common commands:** frontend unit tests `pnpm frontend:test`; backend unit tests `./backend/gradlew -p backend test -Dspring.profiles.active=test --build-cache --parallel`; lint everything `pnpm lint:all`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Cloud Agent development environment for Doughnut (Spring Boot backend, Vue3 frontend, TypeScript CLI/MCP), and records durable cloud-specific startup guidance in `AGENTS.md`.

No product code was changed — the only diff is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment

- **Update script (VM startup):** `pnpm --frozen-lockfile recursive install` — minimal, idempotent dependency refresh only.
- **System deps + services** (Java 25, MySQL 8.4 on 3309, Redis on 6380, xvfb, test-DB init/migrate) come from the existing idempotent `scripts/cloud_agent_setup.sh`, which is `source`d per session for backend/E2E/app work. This is kept out of the update script because it starts services and runs a migration.
- Node engine warning (`wanted >=26.7`, VM has v22) is benign — no `engine-strict`, so install/lint/test/build/app all succeed.

## Verified in this session

| Concern | Command | Result |
| --- | --- | --- |
| Dependencies | `pnpm --frozen-lockfile recursive install` | Done in 16s |
| Lint | `pnpm lint:all` | Pass |
| Frontend unit tests | `pnpm frontend:test` | 1780 passed (319 files) |
| Backend unit tests | `./backend/gradlew -p backend test -Dspring.profiles.active=test` | BUILD SUCCESSFUL |
| Run app | `SUT_TIMEOUT_MS=360000 pnpm sut` + `pnpm sut:healthcheck` | All services healthy (5173/5174/9081/2525) |
| Hello-world | Login as `old_learner` → create notebook "Hello World from Cloud Agent" | Success |

## Demo

[doughnut_login_and_create_note.mp4](https://cursor.com/agents/bc-ba8b7326-0f2b-4bcd-9725-3e5a953a931c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdoughnut_login_and_create_note.mp4)

[Created notebook visible after login](https://cursor.com/agents/bc-ba8b7326-0f2b-4bcd-9725-3e5a953a931c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnote_created_final.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba8b7326-0f2b-4bcd-9725-3e5a953a931c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba8b7326-0f2b-4bcd-9725-3e5a953a931c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

