### PR TITLE
fix: keep the last note title when autosaves overlap

### DIFF
--- a/frontend/src/composables/useDebouncedTextAutosave.ts
+++ b/frontend/src/composables/useDebouncedTextAutosave.ts
@@ -48,8 +48,11 @@ export function useDebouncedTextAutosave(
 
   let persistChain: Promise<void> = Promise.resolve()
 
+  const isCurrentProposal = (nextVersion: number) =>
+    nextVersion === version.value
+
   const persistOne = async (newValue: string, nextVersion: number) => {
-    if (nextVersion !== version.value) {
+    if (!isCurrentProposal(nextVersion)) {
       return
     }
     if (options.beforePersist) {
@@ -57,14 +60,14 @@ export function useDebouncedTextAutosave(
         lastSavedValue.value ?? "",
         newValue
       )
-      if (!proceed || nextVersion !== version.value) {
+      if (!proceed || !isCurrentProposal(nextVersion)) {
         return
       }
     }
     pendingSaveValues.add(newValue)
     try {
       await options.persist(newValue)
-      if (nextVersion === version.value) {
+      if (isCurrentProposal(nextVersion)) {
         if (hasUnsavedChanges()) {
           lastSavedValue.value = newValue
         }
@@ -82,7 +85,6 @@ export function useDebouncedTextAutosave(
   const enqueuePersist = (newValue: string, nextVersion: number) => {
     const run = () => persistOne(newValue, nextVersion)
     persistChain = persistChain.then(run, run)
-    return persistChain
   }
 
   const debouncedPersist = debounce(enqueuePersist, TEXT_AUTOSAVE_DEBOUNCE_MS)

--- a/frontend/src/composables/useDebouncedTextAutosave.ts
+++ b/frontend/src/composables/useDebouncedTextAutosave.ts
@@ -46,21 +46,30 @@ export function useDebouncedTextAutosave(
 
   const isDirty = computed(() => hasUnsavedChanges())
 
-  const persistInner = async (newValue: string, nextVersion: number) => {
+  let persistChain: Promise<void> = Promise.resolve()
+
+  const persistOne = async (newValue: string, nextVersion: number) => {
+    if (nextVersion !== version.value) {
+      return
+    }
     if (options.beforePersist) {
       const proceed = await options.beforePersist(
         lastSavedValue.value ?? "",
         newValue
       )
-      if (!proceed) {
+      if (!proceed || nextVersion !== version.value) {
         return
       }
     }
     pendingSaveValues.add(newValue)
     try {
       await options.persist(newValue)
-      if (hasUnsavedChanges()) {
+      if (nextVersion === version.value) {
+        if (hasUnsavedChanges()) {
+          lastSavedValue.value = newValue
+        }
         savedVersion.value = nextVersion
+      } else if (nextVersion < version.value) {
         lastSavedValue.value = newValue
       }
     } catch (errs: unknown) {
@@ -70,7 +79,13 @@ export function useDebouncedTextAutosave(
     }
   }
 
-  const debouncedPersist = debounce(persistInner, TEXT_AUTOSAVE_DEBOUNCE_MS)
+  const enqueuePersist = (newValue: string, nextVersion: number) => {
+    const run = () => persistOne(newValue, nextVersion)
+    persistChain = persistChain.then(run, run)
+    return persistChain
+  }
+
+  const debouncedPersist = debounce(enqueuePersist, TEXT_AUTOSAVE_DEBOUNCE_MS)
 
   const propose = (newValue: string) => {
     const normalizedNewValue = normalize(newValue)

--- a/frontend/tests/helpers/noteContentDebounceTestSupport.ts
+++ b/frontend/tests/helpers/noteContentDebounceTestSupport.ts
@@ -2,7 +2,7 @@ import { TEXT_AUTOSAVE_DEBOUNCE_MS } from "@/composables/useDebouncedTextAutosav
 import { flushPromises } from "@vue/test-utils"
 import { vi } from "vitest"
 
-/** Matches note body / readmeContent auto-save debounce (`useDebouncedTextAutosave`). */
+/** Matches `useDebouncedTextAutosave` delay. */
 export const NOTE_CONTENT_SAVE_DEBOUNCE_MS = TEXT_AUTOSAVE_DEBOUNCE_MS
 
 export async function advanceNoteContentSaveDebounce() {

--- a/frontend/tests/notes/NoteTextContent.titleEdit.saveRace.spec.ts
+++ b/frontend/tests/notes/NoteTextContent.titleEdit.saveRace.spec.ts
@@ -1,0 +1,78 @@
+import type { Note } from "@generated/doughnut-backend-api"
+import makeMe from "doughnut-test-fixtures/makeMe"
+import { type VueWrapper, flushPromises } from "@vue/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ComponentPublicInstance } from "vue"
+import { TEXT_AUTOSAVE_DEBOUNCE_MS } from "@/composables/useDebouncedTextAutosave"
+import {
+  editTitle,
+  editTitleThenBlur,
+  mockedUpdateTitleCall,
+  mockUpdateNoteTitle,
+  mountNoteTextContent,
+  titleEditorEl,
+} from "./noteTextContentTestSupport"
+
+describe("NoteTextContent title edit save race", () => {
+  let wrapper: VueWrapper<ComponentPublicInstance>
+
+  const mountWith = (note: Note) => {
+    wrapper = mountNoteTextContent(note)
+    return wrapper
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.useFakeTimers()
+    mockUpdateNoteTitle()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    document.body.innerHTML = ""
+    vi.useRealTimers()
+  })
+
+  it("saves the last title after an earlier in-flight save finishes", async () => {
+    const note = makeMe.aNote.title("Dummy Title").please()
+    const releaseSaves: Array<() => void> = []
+    mockedUpdateTitleCall.mockImplementation((options) => {
+      let release!: () => void
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      releaseSaves.push(release)
+      return gate.then(() =>
+        makeMe.aNoteRealm.title(options.body.newTitle).please()
+      )
+    })
+
+    const titleSave = (newTitle: string) => [
+      { path: { note: note.id }, body: { newTitle } },
+    ]
+
+    mountWith(note)
+    await editTitle(wrapper, "ABC")
+    await vi.advanceTimersByTimeAsync(TEXT_AUTOSAVE_DEBOUNCE_MS)
+    await flushPromises()
+
+    expect(mockedUpdateTitleCall.mock.calls).toEqual([titleSave("ABC")])
+
+    await editTitleThenBlur(wrapper, "ABCDEF")
+    await flushPromises()
+
+    expect(mockedUpdateTitleCall.mock.calls).toEqual([titleSave("ABC")])
+
+    releaseSaves[0]?.()
+    await flushPromises()
+
+    expect(mockedUpdateTitleCall.mock.calls).toEqual([
+      titleSave("ABC"),
+      titleSave("ABCDEF"),
+    ])
+
+    releaseSaves[1]?.()
+    await flushPromises()
+    expect(titleEditorEl(wrapper).innerText).toBe("ABCDEF")
+  })
+})

--- a/frontend/tests/notes/NoteTextContent.titleEdit.saveRace.spec.ts
+++ b/frontend/tests/notes/NoteTextContent.titleEdit.saveRace.spec.ts
@@ -1,9 +1,8 @@
-import type { Note } from "@generated/doughnut-backend-api"
 import makeMe from "doughnut-test-fixtures/makeMe"
 import { type VueWrapper, flushPromises } from "@vue/test-utils"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { ComponentPublicInstance } from "vue"
-import { TEXT_AUTOSAVE_DEBOUNCE_MS } from "@/composables/useDebouncedTextAutosave"
+import { advanceNoteContentSaveDebounce } from "@tests/helpers/noteContentDebounceTestSupport"
 import {
   editTitle,
   editTitleThenBlur,
@@ -15,11 +14,6 @@ import {
 
 describe("NoteTextContent title edit save race", () => {
   let wrapper: VueWrapper<ComponentPublicInstance>
-
-  const mountWith = (note: Note) => {
-    wrapper = mountNoteTextContent(note)
-    return wrapper
-  }
 
   beforeEach(() => {
     vi.resetAllMocks()
@@ -51,10 +45,9 @@ describe("NoteTextContent title edit save race", () => {
       { path: { note: note.id }, body: { newTitle } },
     ]
 
-    mountWith(note)
+    wrapper = mountNoteTextContent(note)
     await editTitle(wrapper, "ABC")
-    await vi.advanceTimersByTimeAsync(TEXT_AUTOSAVE_DEBOUNCE_MS)
-    await flushPromises()
+    await advanceNoteContentSaveDebounce()
 
     expect(mockedUpdateTitleCall.mock.calls).toEqual([titleSave("ABC")])
 
@@ -62,16 +55,18 @@ describe("NoteTextContent title edit save race", () => {
     await flushPromises()
 
     expect(mockedUpdateTitleCall.mock.calls).toEqual([titleSave("ABC")])
+    expect(releaseSaves).toHaveLength(1)
 
-    releaseSaves[0]?.()
+    releaseSaves[0]!()
     await flushPromises()
 
     expect(mockedUpdateTitleCall.mock.calls).toEqual([
       titleSave("ABC"),
       titleSave("ABCDEF"),
     ])
+    expect(releaseSaves).toHaveLength(2)
 
-    releaseSaves[1]?.()
+    releaseSaves[1]!()
     await flushPromises()
     expect(titleEditorEl(wrapper).innerText).toBe("ABCDEF")
   })

--- a/frontend/tests/notes/NoteTextContent.titleEdit.spec.ts
+++ b/frontend/tests/notes/NoteTextContent.titleEdit.spec.ts
@@ -4,6 +4,7 @@ import { type VueWrapper, flushPromises } from "@vue/test-utils"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { ComponentPublicInstance } from "vue"
 import { RESERVED_README_TITLE_MESSAGE } from "@/utils/reservedReadmeTitles"
+import { advanceNoteContentSaveDebounce } from "@tests/helpers/noteContentDebounceTestSupport"
 import {
   editTitle,
   editTitleThenBlur,
@@ -96,8 +97,7 @@ describe("NoteTextContent title edit", () => {
     const note = makeMe.aNote.title("Dummy Title").please()
     mountWith(note)
     await editTitle(wrapper, "ABC")
-    await vi.advanceTimersByTimeAsync(1000)
-    await flushPromises()
+    await advanceNoteContentSaveDebounce()
 
     expect(mockedUpdateTitleCall).toHaveBeenCalledWith({
       path: { note: note.id },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Note title (and other PathName) edits share `useDebouncedTextAutosave`. After a 1s pause a save can still be in flight while the user keeps typing. The earlier PATCH could finish last and overwrite the final title.

**Fix:** serialize persist so only one save runs at a time, skip superseded versions, and always send the latest title after the in-flight save finishes.

**Test:** `NoteTextContent.titleEdit.saveRace.spec.ts` holds the first `updateNoteTitle` and checks that a later blur does not send a second overlapping request; after the first save resolves, the last title is saved.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25dca4c6-ccfc-4ab8-998d-f468a2d208db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25dca4c6-ccfc-4ab8-998d-f468a2d208db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

