### PR TITLE
fix: mask repeated /spelling/ pronunciations in cloze stems

### DIFF
--- a/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
+++ b/backend/src/main/java/com/odde/doughnut/algorithms/ClozeReplacement.java
@@ -1,7 +1,9 @@
 package com.odde.doughnut.algorithms;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 record ClozeReplacement(
@@ -9,6 +11,11 @@ record ClozeReplacement(
     String fullMatchReplacement,
     String pronunciationReplacement,
     String fullMatchQualifierReplacement) {
+
+  private static final Pattern PRONUNCIATION =
+      Pattern.compile(
+          "/([^\\s/][^/\\n]*)/(?![a-zA-Z0-9_])",
+          Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
 
   private String maskAliasesAndQualifier(
       String pronunciationMasked, NoteTitle noteTitle, List<TitleFragment> extraAliases) {
@@ -19,12 +26,12 @@ record ClozeReplacement(
     var aliases =
         TitleFragment.mergeSortedLongestFirst(noteTitle.getRecallTitleFragments(), extraAliases);
     String step1 =
-        replaceAliasesWithInternalPlaceholder(
+        replaceFragmentsWithInternalPlaceholder(
             aliases,
             pronunciationMasked,
             (p, t) -> t.replaceLiteralWords(p, internalFullMatchReplacement));
     String step2 =
-        replaceAliasesWithInternalPlaceholder(
+        replaceFragmentsWithInternalPlaceholder(
             aliases, step1, (p, t) -> t.replaceSimilar(p, internalPartialMatchReplacement));
     String step3 =
         noteTitle
@@ -39,11 +46,11 @@ record ClozeReplacement(
         .replace(internalFullMatchReplacementForQualifier, fullMatchQualifierReplacement);
   }
 
-  private static String replaceAliasesWithInternalPlaceholder(
-      List<TitleFragment> aliases,
+  private static String replaceFragmentsWithInternalPlaceholder(
+      List<TitleFragment> fragments,
       String processed,
       BiFunction<String, TitleFragment, String> replacer) {
-    return aliases.stream().reduce(processed, replacer, (x, y) -> y);
+    return fragments.stream().reduce(processed, replacer, (x, y) -> y);
   }
 
   String maskPronunciationsAndTitles(
@@ -52,24 +59,35 @@ record ClozeReplacement(
       List<TitleFragment> extraAliases,
       boolean followsNonWhitespace) {
     final String internalPronunciationReplacement = "__p_r_o_n_u_n_c__";
-    final Pattern pattern =
-        Pattern.compile(
-            "/[^\\s/][^/\\n]*/(?![a-zA-Z0-9_])",
-            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS);
+    final String internalPronunciationSpellingReplacement = "__p_r_o_n_s_p_e_l__";
     // If this segment follows a non-whitespace character in the original HTML,
     // prepend a zero-width marker so suffix patterns can match at segment start
     String contentToProcess = originalContent1;
     if (followsNonWhitespace) {
       contentToProcess = HtmlOrMarkdown.NON_WHITESPACE_CONTEXT_MARKER + originalContent1;
     }
-    String pronunciationsReplaced =
-        pattern.matcher(contentToProcess).replaceAll(internalPronunciationReplacement);
+    Matcher matcher = PRONUNCIATION.matcher(contentToProcess);
+    StringBuffer pronunciationsReplaced = new StringBuffer();
+    List<TitleFragment> pronunciationSpellings = new ArrayList<>();
+    while (matcher.find()) {
+      pronunciationSpellings.add(TitleFragment.from(matcher.group(1)));
+      matcher.appendReplacement(
+          pronunciationsReplaced, Matcher.quoteReplacement(internalPronunciationReplacement));
+    }
+    matcher.appendTail(pronunciationsReplaced);
+    String spellingRepeatsMasked =
+        replaceFragmentsWithInternalPlaceholder(
+            TitleFragment.sortedLongestFirst(pronunciationSpellings),
+            pronunciationsReplaced.toString(),
+            (content, spelling) ->
+                spelling.replaceLiteralWords(content, internalPronunciationSpellingReplacement));
     return noteTitles1.stream()
         .reduce(
-            pronunciationsReplaced,
+            spellingRepeatsMasked,
             (content, noteTitle) -> maskAliasesAndQualifier(content, noteTitle, extraAliases),
             (s, s2) -> s)
         .replace(internalPronunciationReplacement, pronunciationReplacement)
+        .replace(internalPronunciationSpellingReplacement, fullMatchReplacement)
         .replace(HtmlOrMarkdown.NON_WHITESPACE_CONTEXT_MARKER, "");
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
+++ b/backend/src/test/java/com/odde/doughnut/algorithms/ClozeDescriptionTest.java
@@ -2,6 +2,7 @@ package com.odde.doughnut.algorithms;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -127,6 +128,15 @@ class ClozeDescriptionTest {
 
     assertThat(result, containsString("[...]"));
     assertThat(result, containsString("https://en.wikipedia.org/wiki/Enemy"));
+  }
+
+  @Test
+  void clozeShouldMaskPronunciationSpellingWhenItRepeatsInTheBody() {
+    String result =
+        new ClozedString(clozeReplacement, "a cat /kat/ also written kat")
+            .hide(new NoteTitle("cat"))
+            .maskedContentAsMarkdown();
+    assertThat(result, is("a [...] /.../ also written [...]"));
   }
 
   @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloze (recall) stems already hide `/spelling/` pronunciation markers as `/.../`. If that same spelling appeared again in the note body, it stayed visible and leaked the answer.

This change extracts the inner spelling from each `/spelling/` marker and masks later literal repeats with the usual `[...]` cloze placeholder.

Example: `a cat /kat/ also written kat` now becomes `a [...] /.../ also written [...]`.

## Test plan

- Added `ClozeDescriptionTest.clozeShouldMaskPronunciationSpellingWhenItRepeatsInTheBody`
- Ran `ClozeDescriptionTest` (all cases) — passing
- Ran the full backend unit test suite — passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93224c44-5a47-4506-bb08-f352cd35977f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93224c44-5a47-4506-bb08-f352cd35977f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

