### PR TITLE
Keep aliases and overlaps as note-only list property suggestions

### DIFF
--- a/frontend/src/utils/noteContentFrontmatter.ts
+++ b/frontend/src/utils/noteContentFrontmatter.ts
@@ -9,7 +9,6 @@ import {
 
 export {
   README_ONLY_PRESET_PROPERTY_KEYS,
-  RICH_MODE_PRESET_PROPERTY_KEYS,
   findPropertyRowIndexByExactKey,
   isExampleOfPropertyKey,
   isImagePropertyKey,
@@ -24,10 +23,14 @@ export {
   nextAvailablePropertyKeyForPreset,
   propertyKeyBaseAndSuffix,
   propertyKeyMatchesPresetFamily,
-  richModeKeyDropdownPresetKeys,
-  richModeKeyDropdownPresetKeysForPropertyRows,
   rowFillsReadmeOnlyPresetSlot,
 } from "@/utils/noteContentPropertyKeys"
+export {
+  NOTE_ONLY_PRESET_PROPERTY_KEYS,
+  RICH_MODE_PRESET_PROPERTY_KEYS,
+  richModeKeyDropdownPresetKeys,
+  richModeKeyDropdownPresetKeysForPropertyRows,
+} from "@/utils/noteContentPropertyKeyPresets"
 
 export {
   type PropertyRow,

--- a/frontend/src/utils/noteContentPropertyKeyPresets.ts
+++ b/frontend/src/utils/noteContentPropertyKeyPresets.ts
@@ -1,0 +1,55 @@
+import type { PropertyRow } from "@/utils/noteContentPropertyRows"
+import {
+  README_ONLY_PRESET_PROPERTY_KEYS,
+  nextAvailablePropertyKeyForPreset,
+} from "@/utils/noteContentPropertyKeys"
+
+/**
+ * Preset keys for ordinary notes only (not folder/notebook readme).
+ * Each is a singleton YAML list, so an occupied key is omitted rather than
+ * offered as `aliases 2` / `overlaps 2`.
+ */
+export const NOTE_ONLY_PRESET_PROPERTY_KEYS = ["aliases", "overlaps"] as const
+
+/** Preset property keys offered in rich-mode property name UI. */
+export const RICH_MODE_PRESET_PROPERTY_KEYS = [
+  "image",
+  "wikidata_id",
+  "url",
+  "example of",
+  "question_generation_instruction",
+] as const
+
+function isNoteOnlyPresetPropertyKey(key: string): boolean {
+  return (NOTE_ONLY_PRESET_PROPERTY_KEYS as readonly string[]).includes(key)
+}
+
+/** Keys offered in the rich-mode property key dropdown (insert and row key fields). */
+export function richModeKeyDropdownPresetKeys(
+  isReadmeContext: boolean
+): string[] {
+  if (isReadmeContext) {
+    return [
+      ...RICH_MODE_PRESET_PROPERTY_KEYS,
+      ...README_ONLY_PRESET_PROPERTY_KEYS,
+    ]
+  }
+  return [...NOTE_ONLY_PRESET_PROPERTY_KEYS, ...RICH_MODE_PRESET_PROPERTY_KEYS]
+}
+
+/**
+ * Preset keys for the rich-mode property key dropdown, each resolved to the next
+ * available name in its family (e.g. `url 2` when `url` already exists).
+ * Occupied note-only list keys are omitted instead of suffixed.
+ */
+export function richModeKeyDropdownPresetKeysForPropertyRows(
+  isReadmeContext: boolean,
+  rows: readonly PropertyRow[],
+  options?: { excludeRowIndex?: number }
+): string[] {
+  return richModeKeyDropdownPresetKeys(isReadmeContext).flatMap((preset) => {
+    const next = nextAvailablePropertyKeyForPreset(preset, rows, options)
+    if (isNoteOnlyPresetPropertyKey(preset) && next !== preset) return []
+    return [next]
+  })
+}

--- a/frontend/src/utils/noteContentPropertyKeys.ts
+++ b/frontend/src/utils/noteContentPropertyKeys.ts
@@ -1,16 +1,5 @@
 import type { PropertyRow } from "@/utils/noteContentPropertyRows"
 
-/** Preset property keys offered in rich-mode property name UI. */
-export const RICH_MODE_PRESET_PROPERTY_KEYS = [
-  "aliases",
-  "overlaps",
-  "image",
-  "wikidata_id",
-  "url",
-  "example of",
-  "question_generation_instruction",
-] as const
-
 /**
  * Predefined property keys shown only when editing a container readme
  * (notebook/folder readme editors, or a note whose title is a reserved readme name).
@@ -218,27 +207,4 @@ export function findPropertyRowIndexByExactKey(
     if (rows[i]!.key.trim() === trimmed) return i
   }
   return -1
-}
-
-/** Keys offered in the rich-mode property key dropdown (insert and row key fields). */
-export function richModeKeyDropdownPresetKeys(
-  isReadmeContext: boolean
-): string[] {
-  const keys: string[] = [...RICH_MODE_PRESET_PROPERTY_KEYS]
-  if (isReadmeContext) keys.push(...README_ONLY_PRESET_PROPERTY_KEYS)
-  return keys
-}
-
-/**
- * Preset keys for the rich-mode property key dropdown, each resolved to the next
- * available name in its family (e.g. `url 2` when `url` already exists).
- */
-export function richModeKeyDropdownPresetKeysForPropertyRows(
-  isReadmeContext: boolean,
-  rows: readonly PropertyRow[],
-  options?: { excludeRowIndex?: number }
-): string[] {
-  return richModeKeyDropdownPresetKeys(isReadmeContext).map((preset) =>
-    nextAvailablePropertyKeyForPreset(preset, rows, options)
-  )
 }

--- a/frontend/tests/utils/noteContentPropertyKeyPresets.spec.ts
+++ b/frontend/tests/utils/noteContentPropertyKeyPresets.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+import {
+  richModeKeyDropdownPresetKeys,
+  richModeKeyDropdownPresetKeysForPropertyRows,
+} from "@/utils/noteContentPropertyKeyPresets"
+import { propertyRowWithScalar } from "@/utils/noteContentPropertyRows"
+
+describe("richModeKeyDropdownPresetKeysForPropertyRows", () => {
+  it("matches full list when no rows use preset families", () => {
+    expect(richModeKeyDropdownPresetKeysForPropertyRows(false, [])).toEqual(
+      richModeKeyDropdownPresetKeys(false)
+    )
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("status", "ok"),
+      ])
+    ).toEqual(richModeKeyDropdownPresetKeys(false))
+  })
+
+  it("resolves occupied presets to the next suffixed key", () => {
+    const defaults = richModeKeyDropdownPresetKeys(false)
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("image", "/a.png"),
+      ])
+    ).toEqual(defaults.map((k) => (k === "image" ? "image 2" : k)))
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("wikidataId", "Q1"),
+      ])
+    ).toEqual(defaults.map((k) => (k === "wikidata_id" ? "wikidata_id 2" : k)))
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("url", "https://x"),
+      ])
+    ).toEqual(defaults.map((k) => (k === "url" ? "url 2" : k)))
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("example of", "[[A]]"),
+        propertyRowWithScalar("example of 2", "[[B]]"),
+      ])
+    ).toEqual(defaults.map((k) => (k === "example of" ? "example of 3" : k)))
+  })
+
+  it("omits occupied aliases and overlaps instead of suggesting a suffixed key", () => {
+    const defaults = richModeKeyDropdownPresetKeys(false)
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("aliases", "color"),
+      ])
+    ).toEqual(defaults.filter((k) => k !== "aliases"))
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("overlaps", "[[Other]]"),
+      ])
+    ).toEqual(defaults.filter((k) => k !== "overlaps"))
+  })
+
+  it("ignores rows with empty keys", () => {
+    expect(
+      richModeKeyDropdownPresetKeysForPropertyRows(false, [
+        propertyRowWithScalar("", "x"),
+        propertyRowWithScalar("  ", "y"),
+      ])
+    ).toEqual(richModeKeyDropdownPresetKeys(false))
+  })
+})
+
+describe("richModeKeyDropdownPresetKeys", () => {
+  it("returns the default rich-mode preset keys", () => {
+    expect(richModeKeyDropdownPresetKeys(false)).toEqual([
+      "aliases",
+      "overlaps",
+      "image",
+      "wikidata_id",
+      "url",
+      "example of",
+      "question_generation_instruction",
+    ])
+  })
+
+  it("omits aliases and overlaps and appends readme-only keys for folder and notebook readme", () => {
+    expect(richModeKeyDropdownPresetKeys(true)).toEqual([
+      "image",
+      "wikidata_id",
+      "url",
+      "example of",
+      "question_generation_instruction",
+      "title_pattern",
+    ])
+  })
+})

--- a/frontend/tests/utils/noteContentPropertyKeys.spec.ts
+++ b/frontend/tests/utils/noteContentPropertyKeys.spec.ts
@@ -8,8 +8,6 @@ import {
   nextAvailablePropertyKeyForBase,
   nextAvailablePropertyKeyForPreset,
   propertyKeyBaseAndSuffix,
-  richModeKeyDropdownPresetKeys,
-  richModeKeyDropdownPresetKeysForPropertyRows,
 } from "@/utils/noteContentPropertyKeys"
 
 describe("propertyKeyBaseAndSuffix", () => {
@@ -57,11 +55,6 @@ describe("nextAvailablePropertyKeyForPreset", () => {
 
   it("returns the next suffixed key when the base is taken", () => {
     expect(
-      nextAvailablePropertyKeyForPreset("aliases", [
-        propertyRowWithScalar("aliases", "color"),
-      ])
-    ).toBe("aliases 2")
-    expect(
       nextAvailablePropertyKeyForPreset("url", [
         propertyRowWithScalar("url", "https://a"),
       ])
@@ -87,74 +80,6 @@ describe("nextAvailablePropertyKeyForPreset", () => {
     expect(
       nextAvailablePropertyKeyForPreset("url", rows, { excludeRowIndex: 0 })
     ).toBe("url")
-  })
-})
-
-describe("richModeKeyDropdownPresetKeysForPropertyRows", () => {
-  it("matches full list when no rows use preset families", () => {
-    expect(richModeKeyDropdownPresetKeysForPropertyRows(false, [])).toEqual(
-      richModeKeyDropdownPresetKeys(false)
-    )
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("status", "ok"),
-      ])
-    ).toEqual(richModeKeyDropdownPresetKeys(false))
-  })
-
-  it("resolves occupied presets to the next suffixed key", () => {
-    const defaults = richModeKeyDropdownPresetKeys(false)
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("image", "/a.png"),
-      ])
-    ).toEqual(defaults.map((k) => (k === "image" ? "image 2" : k)))
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("wikidataId", "Q1"),
-      ])
-    ).toEqual(defaults.map((k) => (k === "wikidata_id" ? "wikidata_id 2" : k)))
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("url", "https://x"),
-      ])
-    ).toEqual(defaults.map((k) => (k === "url" ? "url 2" : k)))
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("example of", "[[A]]"),
-        propertyRowWithScalar("example of 2", "[[B]]"),
-      ])
-    ).toEqual(defaults.map((k) => (k === "example of" ? "example of 3" : k)))
-  })
-
-  it("ignores rows with empty keys", () => {
-    expect(
-      richModeKeyDropdownPresetKeysForPropertyRows(false, [
-        propertyRowWithScalar("", "x"),
-        propertyRowWithScalar("  ", "y"),
-      ])
-    ).toEqual(richModeKeyDropdownPresetKeys(false))
-  })
-})
-
-describe("richModeKeyDropdownPresetKeys", () => {
-  it("returns the default rich-mode preset keys", () => {
-    expect(richModeKeyDropdownPresetKeys(false)).toEqual([
-      "aliases",
-      "overlaps",
-      "image",
-      "wikidata_id",
-      "url",
-      "example of",
-      "question_generation_instruction",
-    ])
-  })
-
-  it("appends readme-only keys when isReadmeContext is true", () => {
-    expect(richModeKeyDropdownPresetKeys(true)).toEqual([
-      ...richModeKeyDropdownPresetKeys(false),
-      "title_pattern",
-    ])
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Aliases and overlaps are note properties, not folder or notebook readme properties. They are also singleton YAML lists, so a note should have at most one of each.

This change updates rich-mode property-key suggestions:

- Folder and notebook readme editors no longer offer `aliases` or `overlaps`.
- If a note already has `aliases` or `overlaps`, the dropdown omits that key instead of offering `aliases 2` / `overlaps 2`.
- Other presets still suffix when occupied (`url 2`, `image 2`, …).

## Tests

- Updated/added unit tests for `richModeKeyDropdownPresetKeys` and `richModeKeyDropdownPresetKeysForPropertyRows`.
- Related RichMarkdownEditor property-key / aliases / overlaps tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-059832cd-1ad5-472c-89a4-b46734669ea4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-059832cd-1ad5-472c-89a4-b46734669ea4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

