### PR TITLE
Tutor descriptive feedback in Learning Session reports

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -10,7 +10,7 @@ Healthy mainline for learning and knowledge work. Approved [ADR 0002](../docs/ad
 
 ## Current State
 
-**Shipped v1.3 (2026-08-08):** Commissioned learning session — assimilate as commissioned, potential sessions on recall progress bar, Request markdown ([commissioned learning session protocol](../docs/commissioned-learning-session-protocol.md)), record Report with ADR 0003 scheduling (`e2e_test/features/learning_session/commissioned_learning_session.feature`). Request is ephemeral (`GET /api/learning-sessions/request` from due trackers). Recall list shows potential sessions.
+**Shipped v1.3 (2026-08-08):** Commissioned learning session — assimilate as commissioned, potential sessions on recall progress bar, Request markdown ([commissioned learning session protocol](../docs/commissioned-learning-session-protocol.md)), record Report with ADR 0003 scheduling (`e2e_test/features/learning_session/commissioned_learning_session.feature`). Request is ephemeral (`GET /api/learning-sessions/request` from due trackers). Recall list shows potential sessions. Tutor Feedback is a Grade and descriptive text; the next Request carries the last two dated Feedbacks per Session Item.
 
 **Shipped v1.2 (2026-08-06):** Accidental-match resolve dialog UX; distinct `overlaps` frontmatter; reviewed note stays primary.
 
@@ -38,6 +38,7 @@ Portable content direction is ADR 0002 (git-native notebooks). Catalog ZIP downl
 - ✓ Potential learning sessions by notebook on recall (POT-01, POT-02) — v1.3
 - ✓ Commission Learning Session + Request markdown (COM-01–03) — v1.3
 - ✓ Record Report → Grade schedule + feedback log (REC-01–05) — v1.3
+- ✓ Descriptive Feedback on tutor RecallLog, recall history, and last two in the Request
 
 ### Active
 
@@ -52,7 +53,8 @@ Portable content direction is ADR 0002 (git-native notebooks). Catalog ZIP downl
 - Stacked matched `NoteShow` bodies on accidental-match result — replaced by dialog
 - Content peek in resolve dialog — identity only
 - Forced resolve / try-again or SRS reclaim after dialog overlap declare — locked anti-features
-- Descriptive Feedback, smart request generator, in-app Tutor, machine transport — v2 / later
+- Smart request generator, in-app Tutor, machine transport — later
+- Feedback recommendations of what to study next — later
 - Commissioned trackers for properties in UI — domain allows; UI deferred (TRK-04)
 - Commissioned assimilation (first intake via Tutor only) — TRK-05 deferred
 
@@ -85,4 +87,4 @@ Accepted ADRs under `docs/adrs/`. Planning history for completed milestones is n
 This document evolves at phase transitions and milestone boundaries.
 
 ---
-*Last updated: 2026-08-21*
+*Last updated: 2026-08-22*

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,121 +1,13 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** in progress (slices 1–5 done)
+**Status:** complete
 
-## Goal
+Shipped in product docs and code. Canonical record:
 
-A Tutor returns a Grade **and** free-text feedback per Session Item. Doughnut
-records the text with the Feedback, the learner reviews it in the memory
-tracker's recall history, and the next Learning Session Request carries the last
-two dated Feedbacks per Session Item.
+- [Commissioned learning session protocol](../../../docs/commissioned-learning-session-protocol.md)
+- ADR 0001 **Feedback** gloss (Grade and descriptive text)
 
-## Agreed Report format
-
-Preferred block; item split by `###` heading, first structured line is `Grade: N`,
-everything after (until the next `###` or the close tag) is descriptive text.
-
-```markdown
-# Learning Session Report
-
-<session_item_feedback>
-### Hola
-Grade: 4
-Pronunciation was clear; still mixes ser/estar under pressure.
-
-### Gracias
-Grade: 1
-Needed several reminders on the soft g.
-</session_item_feedback>
-```
-
-Legacy shapes stay accepted for grade-only reports: `<session_item_grades>`,
-`<session_item_scores>`, and bare `Title: N` lines.
-
-## Key design decisions
-
-| Decision | Choice | Why |
-|---|---|---|
-| Item structure | `###` heading + `Grade: N` + prose | Matches Request `<session_items>`; nested `<session_item>` tags are the part LLM paste breaks |
-| Block tag | `<session_item_feedback>` preferred; grades/scores blocks legacy | Outer name states Feedback (Grade + text), not just grades |
-| Persistence | descriptive text on the same tutor `RecallLog` (`answer_id` null) | One Feedback = one history entry (ADR 0001); "last two" is one query |
-| Grade required | Item block without a valid `Grade:` line is rejected and reported | A grade-less `RecallLog` means CONFUSION; text-only Feedback has no clean representation |
-| Recording semantics | Unchanged from ADR 0003 — partial recording, append-only, per-notebook | No new failure mode |
-| Learner review | recall history on the memory tracker page | Feedback history already lives there |
-
-## Open forks (Jidoka before the slice that needs them)
-
-1. **Tutoring status line** — keep today's `N previous sessions, last on DATE`
-   and add up to two dated Feedback entries beneath (recommended), or replace it.
-   Needed by slice 6.
-2. **Prose size** — no cap on stored or echoed text initially (recommended);
-   revisit if Requests bloat against the related-notes budget. Needed by slice 6.
-
-Fork 3 (legacy grades block) is closed: keep `<session_item_grades>` as a
-supported grade-only shape (recorded in the protocol).
-
-## Slices
-
-### 1. Protocol decision recorded — Docs
-
-Status: done
-
-Protocol (`docs/commissioned-learning-session-protocol.md`) now documents
-preferred `<session_item_feedback>` (`###` + `Grade: N` + prose), Grade-required,
-storage on the tutor RecallLog, and Request last-two dated Feedbacks. Legacy
-grade-only shapes remain accepted. ADR 0001 **Feedback** gloss: Grade and
-descriptive text; recommendations remain later. No new ADR.
-
-Learning: the commissioned-learning ADR was already removed (glossary in ADR
-0001; protocol in the normal doc). There was no Out of scope section to edit.
-
-### 2. Report `<session_item_feedback>` records Grades — Behavior
-
-Status: done
-
-Preferred `<session_item_feedback>` records Grades (prose ignored). Legacy
-grade-only shapes unchanged. Parser dispatch: feedback block wins when present;
-`SessionItemFeedbackBlockParser` owns `###` + `Grade: N` grammar.
-
-Learning: E2E scenario added beside the existing grades-block scenario; parser
-tests live in `LearningSessionReportFeedbackBlockParsingTest`.
-
-### 3. Tutor feedback column — Structure
-
-Status: done
-
-`V300000301__add_tutor_feedback_to_recall_log.sql` adds nullable `tutor_feedback`
-TEXT. `RecallLog.tutorFeedback` is on the JSON wire. ERD regenerated with no
-diagram delta (exporter draws PK/UK/FK only). API client regenerated.
-
-Exists only for slice 4.
-
-### 4. Descriptive feedback recorded and reviewable — Behavior
-
-Status: done
-
-Parser carries prose on `ParsedReportEntry.descriptiveText`; recording writes it
-on the tutor RecallLog. Recall history shows it
-(`data-testid="recall-log-tutor-feedback"`) when present.
-
-Learning: blank prose stays null; `ParsedReportEntry` compact constructor is the
-blank-to-null seam. E2E extends the existing feedback-report scenario.
-
-### 5. Request asks for descriptive feedback — Behavior
-
-Status: done
-
-`<how_to_report>` prefers `<session_item_feedback>` (`###`, `Grade: N`, prose).
-E2E step now asserts a grade **and** descriptive-text instruction.
-
-### 6. Request carries the last two Feedbacks with dates — Behavior
-
-- Repository query: last two tutor RecallLogs per tracker (recordedAt, grade,
-  text).
-- Render per Session Item alongside the tutoring status (fork 1).
-- E2E: two recorded sessions → open the request → both dated Feedbacks appear
-  for that Session Item.
-
-## Notes
-
-- Migration versions must exceed `300000300` (`db-migration.mdc`).
-- No product artifact carries plan or slice numbers.
+A Tutor Report prefers `<session_item_feedback>` (`###` heading, `Grade: N`, prose).
+Doughnut records the text on the tutor RecallLog; the learner reviews it in recall
+history; the next Request carries the last two dated Feedbacks per Session Item.
+Legacy grade-only Report shapes remain accepted.

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,6 +1,6 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** in progress (slices 1–2 done)
+**Status:** in progress (slices 1–3 done)
 
 ## Goal
 
@@ -81,13 +81,13 @@ tests live in `LearningSessionReportFeedbackBlockParsingTest`.
 
 ### 3. Tutor feedback column — Structure
 
-- Migration `V300000301__add_tutor_feedback_to_recall_log.sql` — `tutor_feedback`
-  TEXT NULL on `recall_log`.
-- `RecallLog` field + JSON property; regenerate `docs/database-erd.md`
-  (`database-erd` skill) and the frontend API client (`generate-api-client`).
+Status: done
 
-Verify: no observable change; backend + frontend suites stay green. Exists only
-for slice 4.
+`V300000301__add_tutor_feedback_to_recall_log.sql` adds nullable `tutor_feedback`
+TEXT. `RecallLog.tutorFeedback` is on the JSON wire. ERD regenerated with no
+diagram delta (exporter draws PK/UK/FK only). API client regenerated.
+
+Exists only for slice 4.
 
 ### 4. Descriptive feedback recorded and reviewable — Behavior
 

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,6 +1,6 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** in progress (slices 1–4 done)
+**Status:** in progress (slices 1–5 done)
 
 ## Goal
 
@@ -102,11 +102,10 @@ blank-to-null seam. E2E extends the existing feedback-report scenario.
 
 ### 5. Request asks for descriptive feedback — Behavior
 
-`<how_to_report>` describes the new format and the worked example includes prose,
-so Tutors actually produce what slice 4 can store.
+Status: done
 
-- E2E: extend the existing "instruct the tutor to report one grade per session
-  item" assertion to cover the descriptive-feedback instruction.
+`<how_to_report>` prefers `<session_item_feedback>` (`###`, `Grade: N`, prose).
+E2E step now asserts a grade **and** descriptive-text instruction.
 
 ### 6. Request carries the last two Feedbacks with dates — Behavior
 

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,6 +1,6 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** planned (not started)
+**Status:** in progress (slice 1 done)
 
 ## Goal
 
@@ -37,10 +37,10 @@ Legacy shapes stay accepted for grade-only reports: `<session_item_grades>`,
 |---|---|---|
 | Item structure | `###` heading + `Grade: N` + prose | Matches Request `<session_items>`; nested `<session_item>` tags are the part LLM paste breaks |
 | Block tag | `<session_item_feedback>` preferred; grades/scores blocks legacy | Outer name states Feedback (Grade + text), not just grades |
-| Persistence | `tutor_feedback` text on the same tutor `RecallLog` row (`answer_id` null) | One Feedback = one history entry (ADR 0001); "last two" is one query |
+| Persistence | descriptive text on the same tutor `RecallLog` (`answer_id` null) | One Feedback = one history entry (ADR 0001); "last two" is one query |
 | Grade required | Item block without a valid `Grade:` line is rejected and reported | A grade-less `RecallLog` means CONFUSION; text-only Feedback has no clean representation |
 | Recording semantics | Unchanged from ADR 0003 — partial recording, append-only, per-notebook | No new failure mode |
-| Learner review | `RecallHistory` on the memory tracker page | Feedback history already lives there |
+| Learner review | recall history on the memory tracker page | Feedback history already lives there |
 
 ## Open forks (Jidoka before the slice that needs them)
 
@@ -49,26 +49,24 @@ Legacy shapes stay accepted for grade-only reports: `<session_item_grades>`,
    Needed by slice 6.
 2. **Prose size** — no cap on stored or echoed text initially (recommended);
    revisit if Requests bloat against the related-notes budget. Needed by slice 6.
-3. **Legacy grades block** — keep `<session_item_grades>` as a supported
-   grade-only shape rather than deprecating it (recommended). Needed by slice 1.
+
+Fork 3 (legacy grades block) is closed: keep `<session_item_grades>` as a
+supported grade-only shape (recorded in the protocol).
 
 ## Slices
 
 ### 1. Protocol decision recorded — Docs
 
-The [commissioned learning session protocol](../../../docs/commissioned-learning-session-protocol.md)
-currently lists descriptive feedback as out of scope; that line is the
-blocker for every slice below.
+Status: done
 
-- Move descriptive Feedback out of **Out of scope** (recommendations, Tutor
-  identity, machine transport stay out).
-- Add the `<session_item_feedback>` Report shape, per-item `Grade: N` + prose,
-  Grade-required rule, storage as text on the tutor RecallLog, and the Request
-  carrying the last two dated Feedbacks.
-- ADR 0001 **Feedback** gloss: descriptive feedback is recorded now;
-  recommendations remain later.
+Protocol (`docs/commissioned-learning-session-protocol.md`) now documents
+preferred `<session_item_feedback>` (`###` + `Grade: N` + prose), Grade-required,
+storage on the tutor RecallLog, and Request last-two dated Feedbacks. Legacy
+grade-only shapes remain accepted. ADR 0001 **Feedback** gloss: Grade and
+descriptive text; recommendations remain later. No new ADR.
 
-Verify: protocol doc and ADR 0001 Feedback gloss only; no new ADR.
+Learning: the commissioned-learning ADR was already removed (glossary in ADR
+0001; protocol in the normal doc). There was no Out of scope section to edit.
 
 ### 2. Report `<session_item_feedback>` records Grades — Behavior
 
@@ -121,7 +119,5 @@ so Tutors actually produce what slice 4 can store.
 
 ## Notes
 
-- The working tree still holds the deleted `quick/001-.../PLAN.md`; commit that
-  housekeeping separately from this plan.
 - Migration versions must exceed `300000300` (`db-migration.mdc`).
 - No product artifact carries plan or slice numbers.

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,6 +1,6 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** in progress (slices 1–3 done)
+**Status:** in progress (slices 1–4 done)
 
 ## Goal
 
@@ -91,12 +91,14 @@ Exists only for slice 4.
 
 ### 4. Descriptive feedback recorded and reviewable — Behavior
 
-- Parse result carries the text; `LearningSessionService` writes it on the tutor
-  RecallLog it already creates.
-- `RecallHistory.vue` renders it (`data-testid="recall-log-tutor-feedback"`).
-- E2E: record a report with prose → visit the commissioned memory tracker →
-  see the tutor's text.
-- Frontend unit test: text rendered when present, absent when not.
+Status: done
+
+Parser carries prose on `ParsedReportEntry.descriptiveText`; recording writes it
+on the tutor RecallLog. Recall history shows it
+(`data-testid="recall-log-tutor-feedback"`) when present.
+
+Learning: blank prose stays null; `ParsedReportEntry` compact constructor is the
+blank-to-null seam. E2E extends the existing feedback-report scenario.
 
 ### 5. Request asks for descriptive feedback — Behavior
 

--- a/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
+++ b/.planning/quick/002-tutor-descriptive-feedback/PLAN.md
@@ -1,6 +1,6 @@
 # Tutor descriptive feedback in Learning Session protocol
 
-**Status:** in progress (slice 1 done)
+**Status:** in progress (slices 1–2 done)
 
 ## Goal
 
@@ -70,17 +70,14 @@ Learning: the commissioned-learning ADR was already removed (glossary in ADR
 
 ### 2. Report `<session_item_feedback>` records Grades — Behavior
 
-Parser prefers the new block: `###` title, `Grade: N`, prose tolerated and
-ignored for now. Legacy blocks behave exactly as today.
+Status: done
 
-- E2E (`commissioned_learning_session.feature`): record a report in the new
-  format → Feedback shown, both trackers scheduled.
-- Unit (`LearningSessionReportParser` boundary): item without `Grade:` rejected;
-  grade outside 1–4 rejected; unknown title rejected; duplicate title rejected;
-  new block wins over a legacy block present in the same document.
+Preferred `<session_item_feedback>` records Grades (prose ignored). Legacy
+grade-only shapes unchanged. Parser dispatch: feedback block wins when present;
+`SessionItemFeedbackBlockParser` owns `###` + `Grade: N` grammar.
 
-Stop-safe alone: Tutors can use the richer shape; prose is ignored, nothing lost
-that Doughnut promised to keep.
+Learning: E2E scenario added beside the existing grades-block scenario; parser
+tests live in `LearningSessionReportFeedbackBlockParsingTest`.
 
 ### 3. Tutor feedback column — Structure
 

--- a/backend/src/main/java/com/odde/doughnut/controllers/MemoryTrackerController.java
+++ b/backend/src/main/java/com/odde/doughnut/controllers/MemoryTrackerController.java
@@ -120,7 +120,7 @@ class MemoryTrackerController {
           HttpStatus.BAD_REQUEST, "Just review accepts only GOOD or AGAIN");
     }
     memoryTrackerService.markAsRecalled(
-        testabilitySettings.getCurrentUTCTimestamp(), grade, memoryTracker, null);
+        testabilitySettings.getCurrentUTCTimestamp(), grade, memoryTracker, null, null);
     return memoryTracker;
   }
 

--- a/backend/src/main/java/com/odde/doughnut/entities/RecallLog.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/RecallLog.java
@@ -22,6 +22,7 @@ import lombok.Setter;
   "recordedAt",
   "elapsedHours",
   "productOutcome",
+  "tutorFeedback",
   "memoryTrackerId",
   "answerId"
 })
@@ -64,6 +65,11 @@ public class RecallLog extends EntityIdentifiedByIdOnly {
   @Getter
   @Setter
   private Answer answer;
+
+  @Column(name = "tutor_feedback", columnDefinition = "TEXT")
+  @Getter
+  @Setter
+  private String tutorFeedback;
 
   @JsonIgnore
   public boolean isConfusion() {

--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/RecallLogRepository.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/RecallLogRepository.java
@@ -14,15 +14,14 @@ public interface RecallLogRepository extends CrudRepository<RecallLog, Integer> 
 
   @Query(
       """
-      SELECT new com.odde.doughnut.entities.repositories.TutorLogSummary(
-        COUNT(rl), MAX(rl.recordedAt))
+      SELECT rl
       FROM RecallLog rl
       WHERE rl.memoryTracker.id = :memoryTrackerId
         AND rl.answer IS NULL
         AND rl.grade IS NOT NULL
+      ORDER BY rl.recordedAt DESC, rl.id DESC
       """)
-  TutorLogSummary summarizeTutorLogsByMemoryTrackerId(
-      @Param("memoryTrackerId") Integer memoryTrackerId);
+  List<RecallLog> findTutorLogsByMemoryTrackerId(@Param("memoryTrackerId") Integer memoryTrackerId);
 
   @Query(
       """

--- a/backend/src/main/java/com/odde/doughnut/entities/repositories/TutorLogSummary.java
+++ b/backend/src/main/java/com/odde/doughnut/entities/repositories/TutorLogSummary.java
@@ -1,5 +1,0 @@
-package com.odde.doughnut.entities.repositories;
-
-import java.sql.Timestamp;
-
-public record TutorLogSummary(long logCount, Timestamp lastRecordedAt) {}

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParseCollector.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParseCollector.java
@@ -33,7 +33,7 @@ final class LearningSessionReportParseCollector {
     return true;
   }
 
-  void acceptEntry(String displayLine, String title, int gradeValue) {
+  void acceptEntry(String displayLine, String title, int gradeValue, String descriptiveText) {
     if (ambiguousTitles.contains(title)) {
       reject(displayLine, "Ambiguous note title in notebook.");
       return;
@@ -46,7 +46,7 @@ final class LearningSessionReportParseCollector {
       reject(displayLine, "Duplicate note title in report.");
       return;
     }
-    entries.add(new ParsedReportEntry(title, Grade.fromValue(gradeValue)));
+    entries.add(new ParsedReportEntry(title, Grade.fromValue(gradeValue), descriptiveText));
   }
 
   ParseResult result() {

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParseCollector.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParseCollector.java
@@ -1,0 +1,55 @@
+package com.odde.doughnut.services;
+
+import com.odde.doughnut.entities.Grade;
+import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
+import com.odde.doughnut.services.LearningSessionReportParser.ParsedReportEntry;
+import com.odde.doughnut.services.LearningSessionReportParser.RejectedReportEntry;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class LearningSessionReportParseCollector {
+  private final List<ParsedReportEntry> entries = new ArrayList<>();
+  private final List<RejectedReportEntry> rejected = new ArrayList<>();
+  private final Set<String> seenTitles = new HashSet<>();
+  private final Set<String> notebookTitles;
+  private final Set<String> ambiguousTitles;
+
+  LearningSessionReportParseCollector(Set<String> notebookTitles, Set<String> ambiguousTitles) {
+    this.notebookTitles = notebookTitles;
+    this.ambiguousTitles = ambiguousTitles;
+  }
+
+  void reject(String displayLine, String reason) {
+    rejected.add(new RejectedReportEntry(displayLine, reason));
+  }
+
+  boolean rejectIfGradeOutOfRange(String displayLine, int gradeValue) {
+    if (gradeValue >= 1 && gradeValue <= 4) {
+      return false;
+    }
+    reject(displayLine, "Grade must be 1, 2, 3, or 4.");
+    return true;
+  }
+
+  void acceptEntry(String displayLine, String title, int gradeValue) {
+    if (ambiguousTitles.contains(title)) {
+      reject(displayLine, "Ambiguous note title in notebook.");
+      return;
+    }
+    if (!notebookTitles.contains(title)) {
+      reject(displayLine, "Note title not found in notebook.");
+      return;
+    }
+    if (!seenTitles.add(title)) {
+      reject(displayLine, "Duplicate note title in report.");
+      return;
+    }
+    entries.add(new ParsedReportEntry(title, Grade.fromValue(gradeValue)));
+  }
+
+  ParseResult result() {
+    return new ParseResult(entries, rejected);
+  }
+}

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParser.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParser.java
@@ -1,7 +1,6 @@
 package com.odde.doughnut.services;
 
 import com.odde.doughnut.entities.Grade;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -11,6 +10,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class LearningSessionReportParser {
+
+  public static final String SESSION_ITEM_FEEDBACK_OPEN_TAG = "<session_item_feedback>";
+  public static final String SESSION_ITEM_FEEDBACK_CLOSE_TAG = "</session_item_feedback>";
 
   public static final String SESSION_ITEM_GRADES_OPEN_TAG = "<session_item_grades>";
   public static final String SESSION_ITEM_GRADES_CLOSE_TAG = "</session_item_grades>";
@@ -31,15 +33,25 @@ public class LearningSessionReportParser {
 
   public ParseResult parse(
       String reportMarkdown, Set<String> notebookTitles, Set<String> ambiguousTitles) {
-    List<ParsedReportEntry> entries = new ArrayList<>();
-    List<RejectedReportEntry> rejected = new ArrayList<>();
-    Set<String> seenTitles = new HashSet<>();
-
     if (reportMarkdown == null || reportMarkdown.isBlank()) {
-      return new ParseResult(entries, rejected);
+      return new ParseResult(List.of(), List.of());
     }
 
-    for (String rawLine : extractGradeContent(reportMarkdown).split("\\R")) {
+    String feedbackBlock =
+        extractTaggedBlock(
+            reportMarkdown, SESSION_ITEM_FEEDBACK_OPEN_TAG, SESSION_ITEM_FEEDBACK_CLOSE_TAG);
+    if (feedbackBlock != null) {
+      return SessionItemFeedbackBlockParser.parse(feedbackBlock, notebookTitles, ambiguousTitles);
+    }
+    return parseGradeLines(extractGradeContent(reportMarkdown), notebookTitles, ambiguousTitles);
+  }
+
+  private ParseResult parseGradeLines(
+      String gradeContent, Set<String> notebookTitles, Set<String> ambiguousTitles) {
+    LearningSessionReportParseCollector collector =
+        new LearningSessionReportParseCollector(notebookTitles, ambiguousTitles);
+
+    for (String rawLine : gradeContent.split("\\R")) {
       String line = rawLine.trim();
       if (line.isEmpty()) {
         continue;
@@ -50,36 +62,19 @@ public class LearningSessionReportParser {
 
       Matcher matcher = GRADE_LINE.matcher(line);
       if (!matcher.matches()) {
-        rejected.add(new RejectedReportEntry(line, "Could not parse note title and grade."));
+        collector.reject(line, "Could not parse note title and grade.");
         continue;
       }
 
       String title = matcher.group(1).trim();
       int gradeValue = Integer.parseInt(matcher.group(2));
-      if (gradeValue < 1 || gradeValue > 4) {
-        rejected.add(new RejectedReportEntry(line, "Grade must be 1, 2, 3, or 4."));
+      if (collector.rejectIfGradeOutOfRange(line, gradeValue)) {
         continue;
       }
-
-      if (ambiguousTitles.contains(title)) {
-        rejected.add(new RejectedReportEntry(line, "Ambiguous note title in notebook."));
-        continue;
-      }
-
-      if (!notebookTitles.contains(title)) {
-        rejected.add(new RejectedReportEntry(line, "Note title not found in notebook."));
-        continue;
-      }
-
-      if (!seenTitles.add(title)) {
-        rejected.add(new RejectedReportEntry(line, "Duplicate note title in report."));
-        continue;
-      }
-
-      entries.add(new ParsedReportEntry(title, Grade.fromValue(gradeValue)));
+      collector.acceptEntry(line, title, gradeValue);
     }
 
-    return new ParseResult(entries, rejected);
+    return collector.result();
   }
 
   private String extractGradeContent(String reportMarkdown) {

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParser.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionReportParser.java
@@ -25,7 +25,12 @@ public class LearningSessionReportParser {
 
   private static final Pattern GRADE_LINE = Pattern.compile("^(.+?):\\s*(\\d+)(?:\\s.*)?$");
 
-  public record ParsedReportEntry(String noteTitle, Grade grade) {}
+  public record ParsedReportEntry(String noteTitle, Grade grade, String descriptiveText) {
+    public ParsedReportEntry {
+      descriptiveText =
+          descriptiveText == null || descriptiveText.isBlank() ? null : descriptiveText.strip();
+    }
+  }
 
   public record RejectedReportEntry(String line, String reason) {}
 
@@ -71,7 +76,7 @@ public class LearningSessionReportParser {
       if (collector.rejectIfGradeOutOfRange(line, gradeValue)) {
         continue;
       }
-      collector.acceptEntry(line, title, gradeValue);
+      collector.acceptEntry(line, title, gradeValue, null);
     }
 
     return collector.result();

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionRequestMarkdownBuilder.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionRequestMarkdownBuilder.java
@@ -100,32 +100,47 @@ public class LearningSessionRequestMarkdownBuilder {
   private void appendHowToReport(StringBuilder sb, List<MemoryTracker> trackers) {
     sb.append("<how_to_report>\n");
     sb.append("Teach the session items above, then return a Learning Session Report giving one\n");
-    sb.append("Grade from 1 to 4 per item:\n\n");
+    sb.append("Grade from 1 to 4 and descriptive text per item:\n\n");
     sb.append("- 4 — mastered the session item with full fluency\n");
     sb.append("- 3 — mastered the session item with fluency\n");
     sb.append(
         "- 2 — mastered the session item but not fluent, or needed a reminder then showed mastery\n");
     sb.append(
         "- 1 — needed several reminders, or could not reach the session item even with help\n\n");
+    sb.append("Preferred report format: one `###` heading per item, then `Grade: N`, then\n");
+    sb.append("descriptive text until the next heading or the close tag.\n\n");
     sb.append("Example of how to provide feedback:\n\n");
     sb.append("# Learning Session Report\n\n");
-    sb.append(LearningSessionReportParser.SESSION_ITEM_GRADES_OPEN_TAG).append("\n");
-    appendExampleReportGrades(sb, trackers);
-    sb.append("\n").append(LearningSessionReportParser.SESSION_ITEM_GRADES_CLOSE_TAG);
+    sb.append(LearningSessionReportParser.SESSION_ITEM_FEEDBACK_OPEN_TAG).append("\n");
+    appendExampleReportFeedback(sb, trackers);
+    sb.append("\n").append(LearningSessionReportParser.SESSION_ITEM_FEEDBACK_CLOSE_TAG);
     sb.append(
         "\n\nOnly grade session items that were actually taught in this session. Do not list\n");
     sb.append("items that were not taught in the session.\n");
     sb.append("</how_to_report>\n");
   }
 
-  private void appendExampleReportGrades(StringBuilder sb, List<MemoryTracker> trackers) {
+  private void appendExampleReportFeedback(StringBuilder sb, List<MemoryTracker> trackers) {
     if (trackers.isEmpty()) {
       return;
     }
-    sb.append(trackers.getFirst().getNote().getTitle()).append(": 4");
+    appendExampleFeedbackItem(
+        sb,
+        trackers.getFirst().getNote().getTitle(),
+        4,
+        "Pronunciation was clear; still mixes ser/estar under pressure.");
     if (trackers.size() > 1) {
-      sb.append("\n").append(trackers.get(1).getNote().getTitle()).append(": 1");
+      sb.append("\n\n");
+      appendExampleFeedbackItem(
+          sb, trackers.get(1).getNote().getTitle(), 1, "Needed several reminders on the soft g.");
     }
+  }
+
+  private void appendExampleFeedbackItem(
+      StringBuilder sb, String title, int grade, String descriptiveText) {
+    sb.append("### ").append(title).append("\n");
+    sb.append("Grade: ").append(grade).append("\n");
+    sb.append(descriptiveText);
   }
 
   private void appendSessionItem(

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionRequestMarkdownBuilder.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionRequestMarkdownBuilder.java
@@ -4,14 +4,15 @@ import com.odde.doughnut.algorithms.FrontmatterQuestionGenerationInstruction;
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Note;
 import com.odde.doughnut.entities.Notebook;
+import com.odde.doughnut.entities.RecallLog;
 import com.odde.doughnut.entities.User;
 import com.odde.doughnut.entities.repositories.RecallLogRepository;
-import com.odde.doughnut.entities.repositories.TutorLogSummary;
 import com.odde.doughnut.services.focusContext.FocusContextMarkdownRenderer;
 import com.odde.doughnut.services.focusContext.FocusContextResult;
 import com.odde.doughnut.services.focusContext.FocusContextRetrievalService;
 import com.odde.doughnut.services.focusContext.MergedRelatedNotes;
 import com.odde.doughnut.services.focusContext.RetrievalConfig;
+import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -153,25 +154,46 @@ public class LearningSessionRequestMarkdownBuilder {
     Note note = tracker.getNote();
 
     sb.append("### ").append(note.getTitle()).append("\n");
-    sb.append("- Tutoring status: ")
-        .append(tutoringStatusLine(tracker.getId(), zoneId))
-        .append("\n");
+    List<RecallLog> tutorLogs = recallLogRepository.findTutorLogsByMemoryTrackerId(tracker.getId());
+    sb.append("- Tutoring status: ").append(tutoringStatusLine(tutorLogs, zoneId)).append("\n");
+    appendRecentFeedbacks(sb, tutorLogs, zoneId);
     FocusContextResult focusContextResult =
         focusContextRetrievalService.retrieve(note, viewer, config);
     sb.append(focusContextMarkdownRenderer.renderFocusNote(focusContextResult.getFocusNote()));
     mergedRelatedNotes.addAll(focusContextResult.getRelatedNotes());
   }
 
-  private String tutoringStatusLine(Integer memoryTrackerId, ZoneId zoneId) {
-    TutorLogSummary summary =
-        recallLogRepository.summarizeTutorLogsByMemoryTrackerId(memoryTrackerId);
-    if (summary.logCount() == 0) {
+  private void appendRecentFeedbacks(StringBuilder sb, List<RecallLog> tutorLogs, ZoneId zoneId) {
+    for (RecallLog log : tutorLogs.stream().limit(2).toList().reversed()) {
+      appendDatedFeedback(sb, log, zoneId);
+    }
+  }
+
+  private void appendDatedFeedback(StringBuilder sb, RecallLog log, ZoneId zoneId) {
+    sb.append("- ")
+        .append(isoDate(log.getRecordedAt(), zoneId))
+        .append(" — Grade: ")
+        .append(log.getGrade().getValue())
+        .append("\n");
+    String descriptiveText = log.getTutorFeedback();
+    if (descriptiveText != null && !descriptiveText.isBlank()) {
+      sb.append("  ").append(descriptiveText).append("\n");
+    }
+  }
+
+  private String tutoringStatusLine(List<RecallLog> tutorLogs, ZoneId zoneId) {
+    if (tutorLogs.isEmpty()) {
       return "not yet tutored";
     }
+    String sessionWord = tutorLogs.size() == 1 ? "session" : "sessions";
+    return tutorLogs.size()
+        + " previous "
+        + sessionWord
+        + ", last on "
+        + isoDate(tutorLogs.getFirst().getRecordedAt(), zoneId);
+  }
 
-    String lastDate =
-        summary.lastRecordedAt().toInstant().atZone(zoneId).toLocalDate().format(ISO_DATE);
-    String sessionWord = summary.logCount() == 1 ? "session" : "sessions";
-    return summary.logCount() + " previous " + sessionWord + ", last on " + lastDate;
+  private static String isoDate(Timestamp recordedAt, ZoneId zoneId) {
+    return recordedAt.toInstant().atZone(zoneId).toLocalDate().format(ISO_DATE);
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/LearningSessionService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/LearningSessionService.java
@@ -93,7 +93,8 @@ public class LearningSessionService {
 
     for (MatchedReportEntry matched : matchedEntries) {
       Grade grade = matched.entry().grade();
-      memoryTrackerService.markAsRecalled(now, grade, matched.tracker(), null);
+      memoryTrackerService.markAsRecalled(
+          now, grade, matched.tracker(), null, matched.entry().descriptiveText());
 
       RecordedLearningSessionItem recorded = new RecordedLearningSessionItem();
       recorded.setNoteTitle(matched.entry().noteTitle());

--- a/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
+++ b/backend/src/main/java/com/odde/doughnut/services/MemoryTrackerService.java
@@ -80,13 +80,18 @@ public class MemoryTrackerService {
         currentUTCTimestamp,
         Grade.fromCorrect(Boolean.TRUE.equals(correct)),
         memoryTracker,
-        answer);
+        answer,
+        null);
   }
 
   public boolean markAsRecalled(
-      Timestamp currentUTCTimestamp, Grade grade, MemoryTracker memoryTracker, Answer answer) {
+      Timestamp currentUTCTimestamp,
+      Grade grade,
+      MemoryTracker memoryTracker,
+      Answer answer,
+      String tutorFeedback) {
     Objects.requireNonNull(grade, "grade");
-    persistRecallLog(memoryTracker, currentUTCTimestamp, grade, answer);
+    persistRecallLog(memoryTracker, currentUTCTimestamp, grade, answer, tutorFeedback);
     memoryTracker.applyGrade(currentUTCTimestamp, grade);
     entityPersister.save(memoryTracker);
 
@@ -98,13 +103,18 @@ public class MemoryTrackerService {
 
   /** Persist a graded recall log, or CONFUSION when {@code grade} is null. */
   void persistRecallLog(
-      MemoryTracker memoryTracker, Timestamp recordedAt, Grade grade, Answer answer) {
+      MemoryTracker memoryTracker,
+      Timestamp recordedAt,
+      Grade grade,
+      Answer answer,
+      String tutorFeedback) {
     RecallLog recallLog = new RecallLog();
     recallLog.setMemoryTracker(memoryTracker);
     recallLog.setRecordedAt(recordedAt);
     recallLog.setElapsedHours((int) memoryTracker.elapsedHoursUntil(recordedAt));
     recallLog.setGrade(grade);
     recallLog.setAnswer(answer);
+    recallLog.setTutorFeedback(tutorFeedback);
     entityPersister.save(recallLog);
     memoryTracker.addRecallLog(recallLog);
     if (answer != null) {

--- a/backend/src/main/java/com/odde/doughnut/services/SessionItemFeedbackBlockParser.java
+++ b/backend/src/main/java/com/odde/doughnut/services/SessionItemFeedbackBlockParser.java
@@ -1,0 +1,66 @@
+package com.odde.doughnut.services;
+
+import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class SessionItemFeedbackBlockParser {
+  private static final Pattern HEADING = Pattern.compile("^###\\s+(.+)$");
+  private static final Pattern GRADE = Pattern.compile("^Grade:\\s*(\\d+)(?:\\s.*)?$");
+
+  private SessionItemFeedbackBlockParser() {}
+
+  static ParseResult parse(String block, Set<String> notebookTitles, Set<String> ambiguousTitles) {
+    LearningSessionReportParseCollector collector =
+        new LearningSessionReportParseCollector(notebookTitles, ambiguousTitles);
+    String currentTitle = null;
+    StringBuilder body = new StringBuilder();
+    for (String rawLine : block.split("\\R")) {
+      Matcher heading = HEADING.matcher(rawLine.trim());
+      if (heading.matches()) {
+        acceptItem(currentTitle, body.toString(), collector);
+        currentTitle = heading.group(1).trim();
+        body.setLength(0);
+        continue;
+      }
+      if (currentTitle != null) {
+        if (!body.isEmpty()) {
+          body.append('\n');
+        }
+        body.append(rawLine);
+      }
+    }
+    acceptItem(currentTitle, body.toString(), collector);
+    return collector.result();
+  }
+
+  private static void acceptItem(
+      String title, String body, LearningSessionReportParseCollector collector) {
+    if (title == null || title.isEmpty()) {
+      return;
+    }
+    String headingLine = "### " + title;
+    String gradeLine = firstNonBlankLine(body);
+    Matcher gradeMatcher = GRADE.matcher(gradeLine);
+    if (!gradeMatcher.matches()) {
+      collector.reject(headingLine, "Grade is required.");
+      return;
+    }
+    int gradeValue = Integer.parseInt(gradeMatcher.group(1));
+    if (collector.rejectIfGradeOutOfRange(gradeLine, gradeValue)) {
+      return;
+    }
+    collector.acceptEntry(headingLine, title, gradeValue);
+  }
+
+  private static String firstNonBlankLine(String body) {
+    for (String line : body.split("\\R")) {
+      String trimmed = line.trim();
+      if (!trimmed.isEmpty()) {
+        return trimmed;
+      }
+    }
+    return "";
+  }
+}

--- a/backend/src/main/java/com/odde/doughnut/services/SessionItemFeedbackBlockParser.java
+++ b/backend/src/main/java/com/odde/doughnut/services/SessionItemFeedbackBlockParser.java
@@ -1,6 +1,7 @@
 package com.odde.doughnut.services;
 
 import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -51,16 +52,30 @@ final class SessionItemFeedbackBlockParser {
     if (collector.rejectIfGradeOutOfRange(gradeLine, gradeValue)) {
       return;
     }
-    collector.acceptEntry(headingLine, title, gradeValue);
+    collector.acceptEntry(headingLine, title, gradeValue, descriptiveTextAfterGrade(body));
+  }
+
+  private static String descriptiveTextAfterGrade(String body) {
+    String[] lines = body.split("\\R", -1);
+    int gradeLineIndex = firstNonBlankLineIndex(lines);
+    if (gradeLineIndex < 0 || gradeLineIndex + 1 >= lines.length) {
+      return null;
+    }
+    return String.join("\n", Arrays.copyOfRange(lines, gradeLineIndex + 1, lines.length));
   }
 
   private static String firstNonBlankLine(String body) {
-    for (String line : body.split("\\R")) {
-      String trimmed = line.trim();
-      if (!trimmed.isEmpty()) {
-        return trimmed;
+    String[] lines = body.split("\\R");
+    int index = firstNonBlankLineIndex(lines);
+    return index < 0 ? "" : lines[index].trim();
+  }
+
+  private static int firstNonBlankLineIndex(String[] lines) {
+    for (int i = 0; i < lines.length; i++) {
+      if (!lines[i].trim().isEmpty()) {
+        return i;
       }
     }
-    return "";
+    return -1;
   }
 }

--- a/backend/src/main/java/com/odde/doughnut/services/SpellingRecallGrading.java
+++ b/backend/src/main/java/com/odde/doughnut/services/SpellingRecallGrading.java
@@ -65,6 +65,7 @@ final class SpellingRecallGrading {
         currentUTCTimestamp,
         Grade.fromCorrect(Boolean.TRUE.equals(answer.getCorrect())),
         memoryTracker,
+        null,
         null);
     return recallPrompt;
   }
@@ -114,7 +115,7 @@ final class SpellingRecallGrading {
                   target -> {
                     memoryTrackerService.applyConfusionAdjustment(target, currentUTCTimestamp);
                     memoryTrackerService.persistRecallLog(
-                        target, currentUTCTimestamp, null, gradedAnswer);
+                        target, currentUTCTimestamp, null, gradedAnswer, null);
                   });
         }
       }
@@ -125,7 +126,8 @@ final class SpellingRecallGrading {
         currentUTCTimestamp,
         Grade.fromCorrect(Boolean.TRUE.equals(correct)),
         memoryTracker,
-        persistedAnswer);
+        persistedAnswer,
+        null);
     return new MemoryTrackerService.SpellingAnswerResult(recallPrompt, matches);
   }
 

--- a/backend/src/main/resources/db/migration/V300000301__add_tutor_feedback_to_recall_log.sql
+++ b/backend/src/main/resources/db/migration/V300000301__add_tutor_feedback_to_recall_log.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `recall_log`
+  ADD COLUMN `tutor_feedback` TEXT NULL;

--- a/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionControllerTestBase.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionControllerTestBase.java
@@ -32,6 +32,20 @@ abstract class LearningSessionControllerTestBase extends ControllerTestBase {
     return "# Learning Session Report\n\n%s: %d\n".formatted(title, grade);
   }
 
+  protected static String sessionItemFeedbackReport(
+      String title, int grade, String descriptiveText) {
+    return """
+        # Learning Session Report
+
+        <session_item_feedback>
+        ### %s
+        Grade: %d
+        %s
+        </session_item_feedback>
+        """
+        .formatted(title, grade, descriptiveText);
+  }
+
   protected static String legacyScoresTaggedReport(String lines) {
     return LearningSessionReportParser.SESSION_ITEM_SCORES_OPEN_TAG
         + "\n"

--- a/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRecordTutorFeedbackRecallLogTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRecordTutorFeedbackRecallLogTests.java
@@ -36,6 +36,38 @@ class LearningSessionRecordTutorFeedbackRecallLogTests extends LearningSessionCo
   }
 
   @Test
+  void recordingWritesTutorFeedbackOnRecallLog() throws UnexpectedNoAccessRightException {
+    Timestamp dayTwo = makeMe.aTimestamp().of(1, 9).please();
+    testabilitySettings.timeTravelTo(dayTwo);
+
+    SpanishNotebookFixture fixture = spanishNotebookFixture(dayTwo);
+    controller.record(
+        recordRequest(
+            fixture.notebook(),
+            sessionItemFeedbackReport(
+                "Hola", 4, "Pronunciation was clear; still mixes ser/estar under pressure.")),
+        "Asia/Shanghai");
+
+    RecallLog log = memoryTrackerController.getRecallLogs(fixture.holaTracker()).get(0);
+    assertThat(
+        log.getTutorFeedback(),
+        is("Pronunciation was clear; still mixes ser/estar under pressure."));
+  }
+
+  @Test
+  void legacyGradeOnlyReportLeavesTutorFeedbackNull() throws UnexpectedNoAccessRightException {
+    Timestamp dayTwo = makeMe.aTimestamp().of(1, 9).please();
+    testabilitySettings.timeTravelTo(dayTwo);
+
+    SpanishNotebookFixture fixture = spanishNotebookFixture(dayTwo);
+    controller.record(
+        recordRequest(fixture.notebook(), learningSessionReport("Hola", 4)), "Asia/Shanghai");
+
+    RecallLog log = memoryTrackerController.getRecallLogs(fixture.holaTracker()).get(0);
+    assertThat(log.getTutorFeedback(), nullValue());
+  }
+
+  @Test
   void unmatchedTitleWritesNoRecallLog() throws UnexpectedNoAccessRightException {
     Timestamp dayTwo = makeMe.aTimestamp().of(1, 9).please();
     testabilitySettings.timeTravelTo(dayTwo);

--- a/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRequestTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRequestTests.java
@@ -135,7 +135,8 @@ class LearningSessionRequestTests extends LearningSessionControllerTestBase {
   @Test
   void requestMarkdownReflectsPriorRecordedFeedbackPerTracker()
       throws UnexpectedNoAccessRightException {
-    Timestamp priorSessionAt = makeMe.aTimestamp().of(5, 10).fromShanghai().please();
+    Timestamp firstSessionAt = makeMe.aTimestamp().of(5, 10).fromShanghai().please();
+    Timestamp secondSessionAt = makeMe.aTimestamp().of(7, 10).fromShanghai().please();
     Timestamp dayTwo = makeMe.aTimestamp().of(1, 9).fromShanghai().please();
     testabilitySettings.timeTravelTo(dayTwo);
 
@@ -143,17 +144,44 @@ class LearningSessionRequestTests extends LearningSessionControllerTestBase {
     makeMe
         .aRecallLogFor(fixture.holaTracker())
         .grade(Grade.GOOD)
-        .recordedAt(priorSessionAt)
+        .tutorFeedback("Pronunciation was clear")
+        .recordedAt(firstSessionAt)
+        .please();
+    makeMe
+        .aRecallLogFor(fixture.holaTracker())
+        .grade(Grade.EASY)
+        .tutorFeedback("Fluent greeting")
+        .recordedAt(secondSessionAt)
         .please();
 
     LearningSessionRequestResponse response =
         controller.request(fixture.notebook().getId(), "Asia/Shanghai");
 
     String markdown = response.getRequestMarkdown();
-    assertThat(markdown, containsString("### Hola"));
-    assertThat(markdown, containsString("1 previous session, last on 1989-01-06"));
-    assertThat(markdown, containsString("### Gracias"));
-    assertThat(markdown, containsString("- Tutoring status: not yet tutored"));
+    String holaItem = sessionItem(markdown, "Hola");
+    String graciasItem = sessionItem(markdown, "Gracias");
+    assertThat(
+        holaItem,
+        containsString(
+            """
+            - Tutoring status: 2 previous sessions, last on 1989-01-08
+            - 1989-01-06 — Grade: 3
+              Pronunciation was clear
+            - 1989-01-08 — Grade: 4
+              Fluent greeting
+            """));
+    assertThat(graciasItem, containsString("- Tutoring status: not yet tutored"));
+    assertThat(graciasItem, not(containsString("Grade:")));
+  }
+
+  private static String sessionItem(String markdown, String title) {
+    int itemsStart = markdown.indexOf("<session_items>");
+    int itemsEnd = markdown.indexOf("</session_items>");
+    String sessionItems = markdown.substring(itemsStart, itemsEnd);
+    String heading = "### " + title;
+    int start = sessionItems.indexOf(heading);
+    int next = sessionItems.indexOf("### ", start + heading.length());
+    return next < 0 ? sessionItems.substring(start) : sessionItems.substring(start, next);
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRequestTests.java
+++ b/backend/src/test/java/com/odde/doughnut/controllers/LearningSessionRequestTests.java
@@ -9,7 +9,6 @@ import com.odde.doughnut.entities.Grade;
 import com.odde.doughnut.entities.MemoryTracker;
 import com.odde.doughnut.entities.Notebook;
 import com.odde.doughnut.exceptions.UnexpectedNoAccessRightException;
-import com.odde.doughnut.services.LearningSessionReportParser;
 import com.odde.doughnut.services.focusContext.FocusContextConstants;
 import java.sql.Timestamp;
 import org.junit.jupiter.api.Test;
@@ -61,15 +60,7 @@ class LearningSessionRequestTests extends LearningSessionControllerTestBase {
         markdown,
         containsString(
             "Teach the session items above, then return a Learning Session Report giving one"));
-    assertThat(markdown, containsString("Grade from 1 to 4 per item"));
     assertThat(markdown, containsString("Example of how to provide feedback:"));
-    assertThat(
-        markdown,
-        containsString(
-            "# Learning Session Report\n\n"
-                + LearningSessionReportParser.SESSION_ITEM_GRADES_OPEN_TAG
-                + "\nHola: 4\nGracias: 1\n"
-                + LearningSessionReportParser.SESSION_ITEM_GRADES_CLOSE_TAG));
     assertThat(
         markdown,
         containsString(
@@ -88,6 +79,34 @@ class LearningSessionRequestTests extends LearningSessionControllerTestBase {
         containsString(
             "- 1 — needed several reminders, or could not reach the session item even with help"));
     assertThat(recallLogRepository.count(), equalTo(logsBefore));
+  }
+
+  @Test
+  void requestMarkdownInstructsDescriptiveFeedback() throws UnexpectedNoAccessRightException {
+    Timestamp dayTwo = makeMe.aTimestamp().of(1, 9).please();
+    testabilitySettings.timeTravelTo(dayTwo);
+
+    Notebook notebook = spanishNotebook(dayTwo);
+
+    String markdown = controller.request(notebook.getId(), "Asia/Shanghai").getRequestMarkdown();
+
+    assertThat(markdown, containsString("Grade from 1 to 4 and descriptive text per item"));
+    assertThat(
+        markdown,
+        containsString(
+            """
+            # Learning Session Report
+
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+            Pronunciation was clear; still mixes ser/estar under pressure.
+
+            ### Gracias
+            Grade: 1
+            Needed several reminders on the soft g.
+            </session_item_feedback>
+            """));
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportFeedbackBlockParsingTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportFeedbackBlockParsingTest.java
@@ -1,0 +1,164 @@
+package com.odde.doughnut.services;
+
+import static com.odde.doughnut.services.LearningSessionReportParseAssertions.assertRejected;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.odde.doughnut.entities.Grade;
+import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LearningSessionReportFeedbackBlockParsingTest {
+
+  private static final Set<String> SPANISH_TITLES = Set.of("Hola", "Gracias");
+
+  private LearningSessionReportParser parser;
+
+  @BeforeEach
+  void setup() {
+    parser = new LearningSessionReportParser();
+  }
+
+  @Test
+  void parsesHeadingAndGradeIgnoringProse() {
+    ParseResult result =
+        parser.parse(
+            """
+            # Learning Session Report
+
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+            Pronunciation was clear; still mixes ser/estar under pressure.
+
+            ### Gracias
+            Grade: 1
+            Needed several reminders on the soft g.
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.rejected(), empty());
+    assertThat(result.entries(), hasSize(2));
+    assertEquals("Hola", result.entries().get(0).noteTitle());
+    assertEquals(Grade.EASY, result.entries().get(0).grade());
+    assertEquals("Gracias", result.entries().get(1).noteTitle());
+    assertEquals(Grade.AGAIN, result.entries().get(1).grade());
+  }
+
+  @Test
+  void rejectsItemWithoutGrade() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### Hola
+            Pronunciation was clear.
+
+            ### Gracias
+            Grade: 1
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.entries(), hasSize(1));
+    assertEquals("Gracias", result.entries().get(0).noteTitle());
+    assertThat(result.rejected(), hasSize(1));
+    assertRejected(result.rejected().get(0), "### Hola", "Grade is required");
+  }
+
+  @Test
+  void rejectsGradeOutsideOneToFour() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### Hola
+            Grade: 5
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.entries(), empty());
+    assertThat(result.rejected(), hasSize(1));
+    assertRejected(result.rejected().get(0), "Grade: 5", "Grade must be 1, 2, 3, or 4.");
+  }
+
+  @Test
+  void rejectsUnknownTitle() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### UnknownNote
+            Grade: 3
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.entries(), empty());
+    assertThat(result.rejected(), hasSize(1));
+    assertRejected(result.rejected().get(0), "### UnknownNote", "Note title not found in notebook");
+  }
+
+  @Test
+  void rejectsDuplicateTitle() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+
+            ### Hola
+            Grade: 3
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.entries(), hasSize(1));
+    assertEquals("Hola", result.entries().get(0).noteTitle());
+    assertEquals(Grade.EASY, result.entries().get(0).grade());
+    assertThat(result.rejected(), hasSize(1));
+    assertRejected(result.rejected().get(0), "### Hola", "Duplicate note title");
+  }
+
+  @Test
+  void prefersFeedbackBlockOverLegacyGradesBlock() {
+    ParseResult result =
+        parser.parse(
+            """
+            # Learning Session Report
+
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+            ### Gracias
+            Grade: 1
+            </session_item_feedback>
+
+            <session_item_grades>
+            Hola: 1
+            Gracias: 4
+            </session_item_grades>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertThat(result.rejected(), empty());
+    assertThat(result.entries(), hasSize(2));
+    assertEquals("Hola", result.entries().get(0).noteTitle());
+    assertEquals(Grade.EASY, result.entries().get(0).grade());
+    assertEquals("Gracias", result.entries().get(1).noteTitle());
+    assertEquals(Grade.AGAIN, result.entries().get(1).grade());
+  }
+}

--- a/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportFeedbackBlockParsingTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportFeedbackBlockParsingTest.java
@@ -24,7 +24,7 @@ class LearningSessionReportFeedbackBlockParsingTest {
   }
 
   @Test
-  void parsesHeadingAndGradeIgnoringProse() {
+  void parsesHeadingAndGrade() {
     ParseResult result =
         parser.parse(
             """
@@ -47,8 +47,46 @@ class LearningSessionReportFeedbackBlockParsingTest {
     assertThat(result.entries(), hasSize(2));
     assertEquals("Hola", result.entries().get(0).noteTitle());
     assertEquals(Grade.EASY, result.entries().get(0).grade());
+    assertEquals(
+        "Pronunciation was clear; still mixes ser/estar under pressure.",
+        result.entries().get(0).descriptiveText());
     assertEquals("Gracias", result.entries().get(1).noteTitle());
     assertEquals(Grade.AGAIN, result.entries().get(1).grade());
+    assertEquals(
+        "Needed several reminders on the soft g.", result.entries().get(1).descriptiveText());
+  }
+
+  @Test
+  void gradeOnlyFeedbackItemLeavesDescriptiveTextNull() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertEquals(null, result.entries().get(0).descriptiveText());
+  }
+
+  @Test
+  void blankProseLeavesDescriptiveTextNull() {
+    ParseResult result =
+        parser.parse(
+            """
+            <session_item_feedback>
+            ### Hola
+            Grade: 4
+
+            </session_item_feedback>
+            """,
+            SPANISH_TITLES,
+            Set.of());
+
+    assertEquals(null, result.entries().get(0).descriptiveText());
   }
 
   @Test

--- a/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportParseAssertions.java
+++ b/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportParseAssertions.java
@@ -1,0 +1,17 @@
+package com.odde.doughnut.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.odde.doughnut.services.LearningSessionReportParser.RejectedReportEntry;
+
+final class LearningSessionReportParseAssertions {
+  private LearningSessionReportParseAssertions() {}
+
+  static void assertRejected(RejectedReportEntry rejected, String line, String reasonFragment) {
+    assertEquals(line, rejected.line());
+    assertTrue(
+        rejected.reason().contains(reasonFragment),
+        () -> "expected reason containing '" + reasonFragment + "' but was: " + rejected.reason());
+  }
+}

--- a/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportParserTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportParserTest.java
@@ -1,5 +1,6 @@
 package com.odde.doughnut.services;
 
+import static com.odde.doughnut.services.LearningSessionReportParseAssertions.assertRejected;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
@@ -7,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.odde.doughnut.entities.Grade;
 import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
-import com.odde.doughnut.services.LearningSessionReportParser.RejectedReportEntry;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -109,12 +109,5 @@ class LearningSessionReportParserTest {
 
     assertThat(result.rejected(), empty());
     assertThat(result.entries(), hasSize(2));
-  }
-
-  private void assertRejected(RejectedReportEntry rejected, String line, String reasonFragment) {
-    assertEquals(line, rejected.line());
-    org.junit.jupiter.api.Assertions.assertTrue(
-        rejected.reason().contains(reasonFragment),
-        () -> "expected reason containing '" + reasonFragment + "' but was: " + rejected.reason());
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportTagBlockParsingTest.java
+++ b/backend/src/test/java/com/odde/doughnut/services/LearningSessionReportTagBlockParsingTest.java
@@ -1,5 +1,6 @@
 package com.odde.doughnut.services;
 
+import static com.odde.doughnut.services.LearningSessionReportParseAssertions.assertRejected;
 import static com.odde.doughnut.services.LearningSessionReportParser.SESSION_ITEM_GRADES_CLOSE_TAG;
 import static com.odde.doughnut.services.LearningSessionReportParser.SESSION_ITEM_GRADES_OPEN_TAG;
 import static com.odde.doughnut.services.LearningSessionReportParser.SESSION_ITEM_SCORES_CLOSE_TAG;
@@ -11,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.odde.doughnut.entities.Grade;
 import com.odde.doughnut.services.LearningSessionReportParser.ParseResult;
-import com.odde.doughnut.services.LearningSessionReportParser.RejectedReportEntry;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -157,12 +157,5 @@ class LearningSessionReportTagBlockParsingTest {
     return Stream.of(
         Arguments.of(SESSION_ITEM_GRADES_OPEN_TAG, SESSION_ITEM_GRADES_CLOSE_TAG),
         Arguments.of(SESSION_ITEM_SCORES_OPEN_TAG, SESSION_ITEM_SCORES_CLOSE_TAG));
-  }
-
-  private void assertRejected(RejectedReportEntry rejected, String line, String reasonFragment) {
-    assertEquals(line, rejected.line());
-    org.junit.jupiter.api.Assertions.assertTrue(
-        rejected.reason().contains(reasonFragment),
-        () -> "expected reason containing '" + reasonFragment + "' but was: " + rejected.reason());
   }
 }

--- a/backend/src/test/java/com/odde/doughnut/testability/builders/RecallLogBuilder.java
+++ b/backend/src/test/java/com/odde/doughnut/testability/builders/RecallLogBuilder.java
@@ -48,6 +48,11 @@ public class RecallLogBuilder extends EntityBuilder<RecallLog> {
     return this;
   }
 
+  public RecallLogBuilder tutorFeedback(String tutorFeedback) {
+    entity.setTutorFeedback(tutorFeedback);
+    return this;
+  }
+
   @Override
   protected void beforeCreate(boolean needPersist) {
     if (entity.getMemoryTracker() == null) {

--- a/docs/adrs/0001-ubiquitous-language.md
+++ b/docs/adrs/0001-ubiquitous-language.md
@@ -199,7 +199,8 @@ commission from Doughnut:
   Feedback per Session Item
 - **Session Item** — One memory tracker within a Learning Session, and
   the Feedback recorded for it
-- **Feedback** — A Tutor's evaluation of a Session Item (a **Grade**)
+- **Feedback** — A Tutor's evaluation of a Session Item: a **Grade** and
+  descriptive text. Recommendations of what to study next are not Feedback.
 
 Request/Report documents:
 [commissioned learning session protocol](../commissioned-learning-session-protocol.md).

--- a/docs/commissioned-learning-session-protocol.md
+++ b/docs/commissioned-learning-session-protocol.md
@@ -15,8 +15,8 @@ by note title within the notebook.
 ## Learning Session Request
 
 The Request names the notebook, the Session Items to teach, tutoring status per
-item, the notes to teach from, related notes for context, and how to report
-(with the rubric inline).
+item, the last two dated Feedbacks per Session Item, the notes to teach from,
+related notes for context, and how to report (with the rubric inline).
 
 Document structure, in order:
 
@@ -25,12 +25,17 @@ Document structure, in order:
    instruction, and to wait for the learner before starting
 3. `<session_item_titles>` — the Session Item titles in this session
 4. `<session_items>` — one `### {title}` section per Session Item, with tutoring
-   status and a `<focus_note>` for that item
+   status, the last two dated Feedbacks for that Session Item, and a
+   `<focus_note>` for that item
 5. `<related_notes>` — notes related to the Session Items, for tutor context;
    Session Items themselves are not repeated here
-6. `<how_to_report>` — the Grade 1–4 rubric and a worked Report example
+6. `<how_to_report>` — the Grade 1–4 rubric, the `<session_item_feedback>`
+   Report shape, and a worked Report example
 
 Focus notes and related notes use **Focus Context** (ADR 0001).
+
+Each of the last two dated Feedbacks carries its date, Grade, and descriptive
+text. A Session Item with no prior Feedback has none to include.
 
 The rubric in `<how_to_report>` is:
 
@@ -40,7 +45,8 @@ The rubric in `<how_to_report>` is:
 - 1 — needed several reminders, or could not reach the session item even with help
 
 Those four values are Grade (ADR 0001) and FSRS `G` (ADR 0003). The Tutor grades
-only Session Items actually taught in this session.
+only Session Items actually taught in this session, and includes descriptive
+text per those items.
 
 ```markdown
 # Learning Session Request
@@ -71,16 +77,42 @@ Wait for the learner's instruction before starting the learning session.
 
 <how_to_report>
 Teach the session items above, then return a Learning Session Report giving one
-Grade from 1 to 4 per item.
+Grade from 1 to 4 and descriptive text per item.
 …
 </how_to_report>
 ```
 
 ## Learning Session Report
 
-The Tutor returns one Grade per taught Session Item inside
-`<session_item_grades>`. Line form is `{title}: {1–4}`. Prose and markdown
-outside the block are not Feedback.
+The preferred Report carries Feedback inside `<session_item_feedback>`. Each
+Session Item is a `### {title}` heading, then a first structured line
+`Grade: {1–4}`, then descriptive text until the next `###` heading or the close
+tag. Prose and markdown outside the block are not Feedback.
+
+```markdown
+# Learning Session Report
+
+<session_item_feedback>
+### Hola
+Grade: 4
+Pronunciation was clear; still mixes ser/estar under pressure.
+
+### Gracias
+Grade: 1
+Needed several reminders on the soft g.
+</session_item_feedback>
+```
+
+A Session Item block without a valid `Grade:` line is rejected and reported. A
+RecallLog without a Grade is Confusion (ADR 0003); text-only Feedback has no
+representation.
+
+When `<session_item_feedback>` is present, it is the Feedback. Grade-only
+Reports remain accepted in these legacy shapes:
+
+- `<session_item_grades>` — `{title}: {1–4}` lines
+- `<session_item_scores>` — the same line form (legacy tag spelling)
+- untagged `{title}: {1–4}` lines in the document
 
 ```markdown
 # Learning Session Report
@@ -98,3 +130,9 @@ Gracias: 1
 Entries match Session Items by note title within the notebook. Duplicate titles
 in one notebook are unmatched. A title that no longer exists in the notebook is
 unmatched.
+
+## Recording Feedback
+
+Recording follows ADR 0003. Each recorded Feedback is one tutor RecallLog
+without an Answer. Descriptive text is stored on that same RecallLog. The
+learner reviews Feedback in recall history on the memory tracker page.

--- a/e2e_test/features/learning_session/commissioned_learning_session.feature
+++ b/e2e_test/features/learning_session/commissioned_learning_session.feature
@@ -92,6 +92,23 @@ Feature: Commissioned learning session
     When I visit the commissioned memory tracker for "Hola"
     Then I should see the tutor's feedback "Pronunciation was clear; still mixes ser/estar under pressure."
 
+  Scenario: Request carries the last two dated Feedbacks per Session Item
+    Given the notes "Hola, Gracias" are assimilated as commissioned on day 1
+    And I have recorded a learning session for notebook "Spanish conversation" on day 2, 9 hour with feedback:
+      | Note    | Grade | Text                                |
+      | Hola    | 3     | Pronunciation was clear             |
+      | Gracias | 1     | Needed several reminders on the soft g |
+    And I have recorded a learning session for notebook "Spanish conversation" on day 4, 16 hour with feedback:
+      | Note    | Grade | Text             |
+      | Hola    | 4     | Fluent greeting  |
+      | Gracias | 1     | Still needed help |
+    And It's day 25, 8 hour
+    When I open the learning session request for notebook "Spanish conversation"
+    Then the learning session request should include dated Feedbacks for "Hola":
+      | Grade | Text                    |
+      | 3     | Pronunciation was clear |
+      | 4     | Fluent greeting         |
+
   Scenario Outline: First tutor grade on a new tracker sets Stability and Difficulty
     Given the notes "Hola, Gracias" are assimilated as commissioned on day 1
     And I have recorded a learning session for notebook "Spanish conversation" on day 2 with grades:

--- a/e2e_test/features/learning_session/commissioned_learning_session.feature
+++ b/e2e_test/features/learning_session/commissioned_learning_session.feature
@@ -89,6 +89,8 @@ Feature: Commissioned learning session
     And the commissioned memory tracker for "Gracias" should have recall count 1
     And the commissioned memory tracker for "Hola" should have tutor feedback grade 4
     And I should see 0 potential learning session for notebook "Spanish conversation"
+    When I visit the commissioned memory tracker for "Hola"
+    Then I should see the tutor's feedback "Pronunciation was clear; still mixes ser/estar under pressure."
 
   Scenario Outline: First tutor grade on a new tracker sets Stability and Difficulty
     Given the notes "Hola, Gracias" are assimilated as commissioned on day 1

--- a/e2e_test/features/learning_session/commissioned_learning_session.feature
+++ b/e2e_test/features/learning_session/commissioned_learning_session.feature
@@ -66,6 +66,30 @@ Feature: Commissioned learning session
     And the commissioned memory tracker for "Hola" should have tutor feedback grade 4
     And I should see 0 potential learning session for notebook "Spanish conversation"
 
+  Scenario: Recording a session item feedback report writes Feedback and schedules each tracker
+    Given the notes "Hola, Gracias" are assimilated as commissioned on day 1
+    And It's day 2, 9 hour
+    When I open the learning session request for notebook "Spanish conversation"
+    And I record the learning session report:
+      """
+      # Learning Session Report
+
+      <session_item_feedback>
+      ### Hola
+      Grade: 4
+      Pronunciation was clear; still mixes ser/estar under pressure.
+
+      ### Gracias
+      Grade: 1
+      Needed several reminders on the soft g.
+      </session_item_feedback>
+      """
+    Then the recorded Feedback for notebook "Spanish conversation" should be shown
+    And the commissioned memory tracker for "Hola" should have recall count 1
+    And the commissioned memory tracker for "Gracias" should have recall count 1
+    And the commissioned memory tracker for "Hola" should have tutor feedback grade 4
+    And I should see 0 potential learning session for notebook "Spanish conversation"
+
   Scenario Outline: First tutor grade on a new tracker sets Stability and Difficulty
     Given the notes "Hola, Gracias" are assimilated as commissioned on day 1
     And I have recorded a learning session for notebook "Spanish conversation" on day 2 with grades:

--- a/e2e_test/features/learning_session/commissioned_learning_session.feature
+++ b/e2e_test/features/learning_session/commissioned_learning_session.feature
@@ -33,7 +33,7 @@ Feature: Commissioned learning session
     And the learning session request should include the tutoring status of "Hola"
     And the learning session request should include focus note with note body "Hello"
     And the learning session request should include related notes with note body "Greetings"
-    And the learning session request should instruct the tutor to report one grade per session item
+    And the learning session request should instruct the tutor to report a grade and descriptive text per session item
     And I should see 1 potential learning session for notebook "Spanish conversation"
 
   Scenario: Notes from different notebooks are commissioned as separate learning sessions

--- a/e2e_test/start/pageObjects/memoryTrackerPage.ts
+++ b/e2e_test/start/pageObjects/memoryTrackerPage.ts
@@ -210,6 +210,17 @@ const assumeMemoryTrackerPage = () => {
       )
       return assumeMemoryTrackerPage()
     },
+    expectTutorFeedback(feedback: string) {
+      expectMemoryTrackerPage()
+      cy.get('[data-testid="recall-log-tutor-feedback"]').should(($el) => {
+        const actual = $el.text().trim()
+        expect(
+          actual,
+          `Expected tutor feedback to be ${feedback}, but found ${actual}`
+        ).to.equal(feedback)
+      })
+      return assumeMemoryTrackerPage()
+    },
   }
 }
 

--- a/e2e_test/start/pageObjects/recallLearningSessionMethods.ts
+++ b/e2e_test/start/pageObjects/recallLearningSessionMethods.ts
@@ -101,11 +101,20 @@ export const recallLearningSessionMethods = () => ({
     })
     return this
   },
-  expectLearningSessionRequestIncludesRubric() {
+  expectLearningSessionRequestInstructsDescriptiveFeedback() {
     this.learningSessionRequestText().should((text) => {
-      expect(text).to.contain('Grade from 1 to 4 per item')
-      expect(text).to.contain('<session_item_grades>')
-      expect(text).to.contain('Hola: 4')
+      expect(
+        text,
+        'how_to_report should ask for Grade plus descriptive text'
+      ).to.contain('Grade from 1 to 4 and descriptive text per item')
+      expect(
+        text,
+        'how_to_report should prefer the session_item_feedback block'
+      ).to.contain('<session_item_feedback>')
+      expect(
+        text,
+        'how_to_report example should include a Grade: line'
+      ).to.contain('Grade: 4')
     })
     return this
   },

--- a/e2e_test/start/pageObjects/recallLearningSessionMethods.ts
+++ b/e2e_test/start/pageObjects/recallLearningSessionMethods.ts
@@ -11,6 +11,24 @@ function doughnutNoteBodiesIn(markdown: string): string[] {
   )
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function sessionItemSection(markdown: string, noteTitle: string) {
+  const sessionItems = markdown.match(
+    /<session_items>[\s\S]*?<\/session_items>/
+  )?.[0]
+  expect(sessionItems, 'session_items block').to.exist
+  const heading = `### ${noteTitle}`
+  const headingAt = sessionItems!.indexOf(heading)
+  expect(headingAt, `Session Item heading ${noteTitle}`).to.be.greaterThan(-1)
+  const nextHeading = sessionItems!.indexOf('### ', headingAt + heading.length)
+  return nextHeading === -1
+    ? sessionItems!.slice(headingAt)
+    : sessionItems!.slice(headingAt, nextHeading)
+}
+
 function closeLearningSessionDetailIfOpen() {
   cy.get('body').then(($body) => {
     if (
@@ -115,6 +133,33 @@ export const recallLearningSessionMethods = () => ({
         text,
         'how_to_report example should include a Grade: line'
       ).to.contain('Grade: 4')
+    })
+    return this
+  },
+  expectLearningSessionRequestIncludesDatedFeedbacks(
+    noteTitle: string,
+    feedbacks: Array<{ Grade?: string; Text?: string }>
+  ) {
+    this.learningSessionRequestText().should((text) => {
+      const item = sessionItemSection(text, noteTitle)
+      expect(
+        item,
+        `tutoring status for ${noteTitle} should remain beside dated Feedbacks`
+      ).to.match(
+        /Tutoring status: \d+ previous sessions?, last on \d{4}-\d{2}-\d{2}/
+      )
+      let remaining = item
+      for (const row of feedbacks) {
+        const pattern = new RegExp(
+          `- \\d{4}-\\d{2}-\\d{2} — Grade: ${row.Grade}\\n  ${escapeRegExp(row.Text ?? '')}`
+        )
+        const match = remaining.match(pattern)
+        expect(
+          match,
+          `dated Feedback Grade ${row.Grade} with text ${JSON.stringify(row.Text)} for ${noteTitle}. Actual Session Item:\n${item}`
+        ).to.exist
+        remaining = remaining.slice((match!.index ?? 0) + match![0].length)
+      }
     })
     return this
   },

--- a/e2e_test/step_definitions/learning_session.ts
+++ b/e2e_test/step_definitions/learning_session.ts
@@ -9,6 +9,28 @@ import start from '../start'
 
 const SESSION_ITEM_GRADES_OPEN_TAG = '<session_item_grades>'
 const SESSION_ITEM_GRADES_CLOSE_TAG = '</session_item_grades>'
+const SESSION_ITEM_FEEDBACK_OPEN_TAG = '<session_item_feedback>'
+const SESSION_ITEM_FEEDBACK_CLOSE_TAG = '</session_item_feedback>'
+
+function recordLearningSessionForNotebook(
+  notebookTitle: string,
+  reportMarkdown: string
+) {
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  start
+    .testability()
+    .getNotebookIdByName(notebookTitle)
+    .then((notebookId) =>
+      cy.wrap(
+        LearningSessionController.record({
+          body: { notebookId, reportMarkdown },
+          query: { timezone },
+        }),
+        { log: false }
+      )
+    )
+  start.recall().visitRecallPage()
+}
 
 Given(
   'I have recorded a learning session for notebook {string} on day {int} with grades:',
@@ -16,20 +38,20 @@ Given(
     start.testability().timeTravelTo(day, 9)
     const lines = dataTable.hashes().map((row) => `${row.Note}: ${row.Grade}`)
     const reportMarkdown = `# Learning Session Report\n\n${SESSION_ITEM_GRADES_OPEN_TAG}\n${lines.join('\n')}\n${SESSION_ITEM_GRADES_CLOSE_TAG}\n`
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    start
-      .testability()
-      .getNotebookIdByName(notebookTitle)
-      .then((notebookId) =>
-        cy.wrap(
-          LearningSessionController.record({
-            body: { notebookId, reportMarkdown },
-            query: { timezone },
-          }),
-          { log: false }
-        )
-      )
-    start.recall().visitRecallPage()
+    recordLearningSessionForNotebook(notebookTitle, reportMarkdown)
+  }
+)
+
+Given(
+  'I have recorded a learning session for notebook {string} on day {int}, {int} hour with feedback:',
+  (notebookTitle: string, day: number, hour: number, dataTable: DataTable) => {
+    start.testability().timeTravelTo(day, hour)
+    const items = dataTable
+      .hashes()
+      .map((row) => `### ${row.Note}\nGrade: ${row.Grade}\n${row.Text}`)
+      .join('\n\n')
+    const reportMarkdown = `# Learning Session Report\n\n${SESSION_ITEM_FEEDBACK_OPEN_TAG}\n${items}\n${SESSION_ITEM_FEEDBACK_CLOSE_TAG}\n`
+    recordLearningSessionForNotebook(notebookTitle, reportMarkdown)
   }
 )
 
@@ -126,5 +148,18 @@ Then(
       .recall()
       .assumeRecallPage()
       .expectLearningSessionRequestInstructsDescriptiveFeedback()
+  }
+)
+
+Then(
+  'the learning session request should include dated Feedbacks for {string}:',
+  (noteTitle: string, dataTable: DataTable) => {
+    start
+      .recall()
+      .assumeRecallPage()
+      .expectLearningSessionRequestIncludesDatedFeedbacks(
+        noteTitle,
+        dataTable.hashes()
+      )
   }
 )

--- a/e2e_test/step_definitions/learning_session.ts
+++ b/e2e_test/step_definitions/learning_session.ts
@@ -120,11 +120,11 @@ Then(
 )
 
 Then(
-  'the learning session request should instruct the tutor to report one grade per session item',
+  'the learning session request should instruct the tutor to report a grade and descriptive text per session item',
   () => {
     start
       .recall()
       .assumeRecallPage()
-      .expectLearningSessionRequestIncludesRubric()
+      .expectLearningSessionRequestInstructsDescriptiveFeedback()
   }
 )

--- a/e2e_test/step_definitions/recall_memory_tracker.ts
+++ b/e2e_test/step_definitions/recall_memory_tracker.ts
@@ -25,6 +25,10 @@ Then('I should see an AGAIN RecallLog', () => {
   assumeMemoryTrackerPage().expectAgainRecallLog()
 })
 
+Then("I should see the tutor's feedback {string}", (feedback: string) => {
+  assumeMemoryTrackerPage().expectTutorFeedback(feedback)
+})
+
 Then('I should see Stability {int}', (stability: number) => {
   assumeMemoryTrackerPage().expectStability(stability)
 })

--- a/frontend/src/components/recall/RecallHistory.vue
+++ b/frontend/src/components/recall/RecallHistory.vue
@@ -57,6 +57,13 @@ const historyItemKey = (item: RecallHistoryItem, index: number) => {
           <span>Recorded: {{ new Date(item.recallLog.recordedAt).toLocaleString() }}</span>
           <span>Elapsed hours: {{ item.recallLog.elapsedHours }}</span>
         </div>
+        <p
+          v-if="item.recallLog?.tutorFeedback"
+          data-testid="recall-log-tutor-feedback"
+          class="text-sm mb-2 whitespace-pre-wrap"
+        >
+          {{ item.recallLog.tutorFeedback }}
+        </p>
         <template v-if="item.recallPrompt">
           <div class="text-sm text-base-content/70 mb-2 flex gap-2 flex-wrap">
             <span v-if="item.recallPrompt.questionGeneratedTime">

--- a/frontend/tests/pages/MemoryTrackerPageView.history.spec.ts
+++ b/frontend/tests/pages/MemoryTrackerPageView.history.spec.ts
@@ -49,6 +49,32 @@ describe("MemoryTrackerPageView recall history", () => {
     expect(outcomes.map((el) => el.text())).toContain("AGAIN")
   })
 
+  it("shows tutor feedback when the recall log has descriptive text", async () => {
+    const wrapper = await mountMemoryTrackerPageViewReady({
+      recallHistory: historyFromLogs([
+        makeMe.aRecallLog
+          .tutorFeedback(
+            "Pronunciation was clear; still mixes ser/estar under pressure."
+          )
+          .please(),
+      ]),
+    })
+
+    expect(
+      wrapper.find('[data-testid="recall-log-tutor-feedback"]').text()
+    ).toBe("Pronunciation was clear; still mixes ser/estar under pressure.")
+  })
+
+  it("does not show tutor feedback when the recall log has none", async () => {
+    const wrapper = await mountMemoryTrackerPageViewReady({
+      recallHistory: historyFromLogs([makeMe.aRecallLog.please()]),
+    })
+
+    expect(
+      wrapper.find('[data-testid="recall-log-tutor-feedback"]').exists()
+    ).toBe(false)
+  })
+
   it("shows a paired recall log and question in the same card", async () => {
     const wrapper = await mountMemoryTrackerPageViewReady({
       recallHistory: [

--- a/open_api_docs.yaml
+++ b/open_api_docs.yaml
@@ -5345,6 +5345,8 @@ components:
           - GOOD
           - EASY
           - CONFUSION
+        tutorFeedback:
+          type: string
         memoryTrackerId:
           type: integer
           format: int32

--- a/packages/doughnut-test-fixtures/src/RecallLogBuilder.ts
+++ b/packages/doughnut-test-fixtures/src/RecallLogBuilder.ts
@@ -33,6 +33,11 @@ class RecallLogBuilder extends Builder<RecallLog> {
     return this
   }
 
+  tutorFeedback(tutorFeedback: string): RecallLogBuilder {
+    this.data.tutorFeedback = tutorFeedback
+    return this
+  }
+
   do(): RecallLog {
     return this.data
   }

--- a/packages/generated/doughnut-backend-api/types.gen.ts
+++ b/packages/generated/doughnut-backend-api/types.gen.ts
@@ -1092,6 +1092,7 @@ export type RecallLog = {
     recordedAt: string;
     elapsedHours: number;
     productOutcome: 'AGAIN' | 'HARD' | 'GOOD' | 'EASY' | 'CONFUSION';
+    tutorFeedback?: string;
     memoryTrackerId: number;
     answerId?: number;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A Tutor’s Learning Session Report can include descriptive text with each Grade. Doughnut records that text with the Feedback, the learner reviews it in recall history, and the next Request carries the last two dated Feedbacks per Session Item.

## What landed

- **Protocol:** preferred `<session_item_feedback>` Report (`###` heading, `Grade: N`, then prose). Legacy grade-only shapes stay accepted. ADR 0001 Feedback gloss: Grade and descriptive text; recommendations of what to study next remain later.
- **Parser:** recording a `<session_item_feedback>` report writes Grades; the feedback block wins over a legacy grades block in the same document.
- **Schema:** nullable `tutor_feedback` on `recall_log`.
- **Persist and review:** prose is stored on the tutor RecallLog and shown in recall history (`data-testid="recall-log-tutor-feedback"`).
- **Request instruction:** `<how_to_report>` prefers the new format with a worked prose example.
- **Request history:** each Session Item keeps the tutoring status line and lists up to two dated Feedbacks (date, Grade, text) beneath it. No cap on prose.

Canonical docs: [commissioned learning session protocol](docs/commissioned-learning-session-protocol.md), [ADR 0001](docs/adrs/0001-ubiquitous-language.md), [ADR 0003](docs/adrs/0003-spaced-repetition-scheduling-policy-accepted.md).

The commissioned-learning ADR was already removed before this work; glossary lives in ADR 0001 and the protocol doc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-724c5056-16eb-4445-a8c8-f95f316e02b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-724c5056-16eb-4445-a8c8-f95f316e02b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

