### PR TITLE
refactor(recall): cover and repair split-half reliability diagnostics

### DIFF
--- a/.planning/quick/001-morning-cognitive-index/PLAN.md
+++ b/.planning/quick/001-morning-cognitive-index/PLAN.md
@@ -1,15 +1,15 @@
 # Morning cognitive index from recall history
 
 **Status:** in progress — slices 1–14, 14.1–14.8, 15, 16, 17, 18, 19, 20,
-21.1–21.6 done. Repair pass **21.7 remaining (21.8 optional)** — **next:
-21.7**. Once that is done, the reliability endpoint
-(`GET /api/user/recall-split-half-reliability`) still needs **the developer
-to query it and decide against the ~0.6 gate before slice 22 starts** (see
-Jidoka checkpoints — this is a required stop, not an autonomous continuation
-point). Slice 17.1 (pace-expectation R/D correction, split from 17) is
-separately **blocked** pending a developer-specified formula, independent of
-21.x. `recall_stats.feature`'s pace scenario stays `@wip` — a second,
-unrelated E2E race condition was found (see Discoveries).
+21.1–21.7 done. Repair pass **21.8 optional remaining**. The reliability
+endpoint (`GET /api/user/recall-split-half-reliability`) still needs **the
+developer to query it and decide against the ~0.6 gate before slice 22
+starts** (see Jidoka checkpoints — this is a required stop, not an
+autonomous continuation point). Slice 17.1 (pace-expectation R/D correction,
+split from 17) is separately **blocked** pending a developer-specified
+formula, independent of 21.x. `recall_stats.feature`'s pace scenario stays
+`@wip` — a second, unrelated E2E race condition was found (see
+Discoveries).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Research memo:** https://claude.ai/code/artifact/9e13f954-fc5e-48e5-868f-f75d03f811c1
 
@@ -1029,32 +1029,17 @@ Aggregation tests unchanged (they remain the sparse/identity-fallback cases).
 
 - **Enables 21.7 only.**
 
-#### 21.7 The reliability diagnostic scores both halves of a day without duplicating expensive work — Behavior `[ ]`
+#### 21.7 The reliability diagnostic scores both halves of a day without duplicating expensive work — Structure `[x]`
 
-`RecallSplitHalfReliability.compute()` calls
-`RecallMorningHalfIndex.compute(..., Half.ODD)` and `...Half.EVEN)` as two
-fully independent calls per candidate day, across up to a 90-day window.
-Each call independently redoes the entire day-level setup from scratch — a
-whole-day `RecallPaceAggregator.compute` pass for `implausiblyFastRows`,
-rebuilding `dayQualifyingRowsInOrder`, and (most expensively)
-`RecallAccuracyAggregator`'s per-question-type 3PL guessing-floor fit (up to
-a 26-point grid search × up to 25 Newton-Raphson iterations each, over the
-trailing 180-day window) — none of which depends on which half is being
-scored (`implausiblyFastRows` is computed before any half-restriction; the
-calibration fit depends only on `allTimeQualifyingRows`/`today`/`zoneId`,
-never on which rows are "today's qualifying rows"). The single most
-expensive computation in the whole pipeline currently runs twice per day for
-no reason, on top of the up-to-90-day loop. `RecallStatsService`'s own
-documentation already says this exact class of problem — an endpoint whose
-cost silently scales with a user's full history — previously caused a
-production timeout; here it's redundant CPU-bound refitting rather than an
-N+1 query, but the risk and the fix's value are the same.
-
-Restructure so both halves of a day are scored from one shared day-level
-setup computed once (e.g. `RecallMorningHalfIndex` gains a method returning
-both halves' index values together), and `RecallSplitHalfReliability`'s loop
-calls it once per day instead of twice. Must not change any observable
-output — same numbers, just not computed twice.
+Done (plan heading said Behavior; implemented as Structure — same numbers).
+`RecallMorningHalfIndex.computeBothHalves` prepares one `DaySetup`
+(whole-day pace exclusions, qualifying-row order, per-question-type 3PL
+`RecallAccuracyAggregator.fit`) and `scoreHalf`s both sides.
+`RecallAccuracyAggregator` split into `fit` / `apply`; full-day `compute`
+still fit-then-apply. `RecallSplitHalfReliability` calls
+`computeBothHalves` once per candidate day. Characterization test:
+`scoringBothHalvesTogetherMatchesScoringEachHalfIndependently`. Per-half
+`compute(..., Half)` kept for existing tests.
 
 #### 21.8 (optional) Share the Newton-Raphson line-search scaffold between the two fitters — Structure `[ ]`
 

--- a/.planning/quick/001-morning-cognitive-index/PLAN.md
+++ b/.planning/quick/001-morning-cognitive-index/PLAN.md
@@ -1,12 +1,8 @@
 # Morning cognitive index from recall history
 
-**Status:** in progress — slices 1–14, 14.1–14.8, 15, 16, 17, 18, 19, 20 done.
-Slice 21 (split-half reliability) was split into 21.1–21.4 (pre-slice
-Jidoka: needed a composite formula the plan never specified, resolved with
-the developer — see "The index" section) — **21.1–21.4 all done.** A
-session-wide code review across slices 17–21.4 (developer-requested) found
-gaps addressed in a new repair pass, **21.5–21.7 (21.8 optional)** — **next:
-21.5**. Once those are done, the reliability endpoint
+**Status:** in progress — slices 1–14, 14.1–14.8, 15, 16, 17, 18, 19, 20,
+21.1–21.5 done. Repair pass **21.6–21.7 remaining (21.8 optional)** — **next:
+21.6**. Once those are done, the reliability endpoint
 (`GET /api/user/recall-split-half-reliability`) still needs **the developer
 to query it and decide against the ~0.6 gate before slice 22 starts** (see
 Jidoka checkpoints — this is a required stop, not an autonomous continuation
@@ -1005,29 +1001,21 @@ stopping after any of them leaves the already-shipped accuracy/index
 readouts more trustworthy than before, same as 14.1–14.8 did for the
 timer/pace channel.
 
-#### 21.5 The reliability endpoint's real-correlation path has regression coverage — Behavior `[ ]`
+#### 21.5 The reliability endpoint's real-correlation path has regression coverage — Behavior `[x]`
 
-`RecallSplitHalfReliability.compute()`'s path for >= `MIN_PAIRS_FOR_CORRELATION`
-(10) qualifying day-pairs — the one that actually produces the Pearson
-correlation and its Spearman-Brown correction the developer is about to read
-the ~0.6 gate off of — has no test exercising it end-to-end. Every test that
-calls `compute()` deliberately stays below the 10-pair threshold (asserting
-null correlations); the one test that looks like it covers the real-number
-path, `RecallSplitHalfReliabilityTest.spearmanBrownCorrectsTheRawCorrelationUpward`,
-is vacuous — it hardcodes `r = 0.5` and checks `(2*r)/(1+r)` against a
-literal, without calling `compute()` or any production method at all.
+Done: `RecallSplitHalfReliabilityTest.tenScorableMorningsYieldThePearsonOfTheirHalfIndexesAndTheSpearmanBrownCorrection`
+builds 10 scorable mornings, independently scores each day's odd/even halves
+via `RecallMorningHalfIndex.compute`, and asserts `compute()` returns that
+pair count, the same Pearson `r`, and Spearman-Brown `2r/(1+r)`. Vacuous
+`spearmanBrownCorrectsTheRawCorrelationUpward` (hardcoded `r = 0.5`, never
+called production) deleted. Production already implemented this path;
+no formula change.
 
-Add a test building >= 10 qualifying day-pairs (reuse
-`RecallStatsTestFixtures.warmedUpBaselines()`/`addWarmedUpBaselineDay` and
-`RecallMorningHalfIndexTest`'s "oddAndEvenHalvesAreScoredIndependently..."
-pattern for constructing scorable half-pairs) and assert `pairCount >= 10`,
-`rawCorrelation` non-null and matching an independently-computed expected
-Pearson value, and `spearmanBrownCorrelation` equal to `2r/(1+r)` for that
-real `r`. This is a regression-test-first exercise, not an
-assumed-passing addition: if the new test fails on first run, fix the
-underlying bug it reveals rather than adjusting the assertion to match
-whatever the code currently outputs. Once real coverage exists, delete or
-fold in the vacuous `spearmanBrownCorrectsTheRawCorrelationUpward` test.
+**Learning for remaining 21.x tests:** the two-value even/odd
+`warmedUpBaselines()` pace/lapse pattern majority-votes MAD to 0 when a
+later scored morning also sits in an earlier morning's trailing baseline
+window, which makes half-indexes null. Multi-day half-index fixtures must
+use `variedBaselinesThrough` (3-phase pace/lapse) plus `addScorableMorning`.
 
 #### 21.6 Accuracy documentation and tests reflect recalibration, not raw retrievability — Structure `[ ]`
 

--- a/.planning/quick/001-morning-cognitive-index/PLAN.md
+++ b/.planning/quick/001-morning-cognitive-index/PLAN.md
@@ -1,8 +1,8 @@
 # Morning cognitive index from recall history
 
 **Status:** in progress — slices 1–14, 14.1–14.8, 15, 16, 17, 18, 19, 20,
-21.1–21.5 done. Repair pass **21.6–21.7 remaining (21.8 optional)** — **next:
-21.6**. Once those are done, the reliability endpoint
+21.1–21.6 done. Repair pass **21.7 remaining (21.8 optional)** — **next:
+21.7**. Once that is done, the reliability endpoint
 (`GET /api/user/recall-split-half-reliability`) still needs **the developer
 to query it and decide against the ~0.6 gate before slice 22 starts** (see
 Jidoka checkpoints — this is a required stop, not an autonomous continuation
@@ -1017,29 +1017,17 @@ later scored morning also sits in an earlier morning's trailing baseline
 window, which makes half-indexes null. Multi-day half-index fixtures must
 use `variedBaselinesThrough` (3-phase pace/lapse) plus `addScorableMorning`.
 
-#### 21.6 Accuracy documentation and tests reflect recalibration, not raw retrievability — Structure `[ ]`
+#### 21.6 Accuracy documentation and tests reflect recalibration, not raw retrievability — Structure `[x]`
 
-`RecallStatsDTO.AccuracyStats`'s javadoc and
-`RecallStatsServiceAccuracyAggregationTest`'s class javadoc both still say
-the standardized residual compares against "raw FSRS retrievability" — true
-only through slice 17. Slices 19–20 layered personal recalibration
-(`RecallCalibrationFitter`) and a fitted 3PL guessing floor
-(`RecallGuessingFloorFitter`) on top; `RecallAccuracyAggregator`'s own class
-javadoc was kept accurate each time, but these two other comments were never
-revisited, since each slice's post-change-refactor pass only reviewed that
-slice's own diff. Update both to describe the recalibrated/guessing-floor-
-adjusted formula, cross-referencing `RecallAccuracyAggregator`, matching the
-already-accurate language in `RecallStatsServiceAccuracyCalibrationTest`'s
-and `RecallStatsServiceAccuracyGuessingFloorTest`'s class javadocs.
+Done: `RecallStatsDTO.AccuracyStats` and
+`RecallStatsServiceAccuracyAggregationTest` javadocs now describe the
+recalibrated 3PL `p̂` (identity fallback when trailing history is sparse),
+cross-referencing `RecallAccuracyAggregator`. Deleted redundant
+`todaysAccuracyUsesRawRetrievabilityWhenTrailingHistoryIsSparse`; kept
+`todaysAccuracyIsScoredAgainstTheRecalibratedProbabilityWhenTrailingHistoryIsAbundant`.
+Aggregation tests unchanged (they remain the sparse/identity-fallback cases).
 
-Bundle in one redundant-test cleanup found in the same area:
-`RecallStatsServiceAccuracyCalibrationTest.todaysAccuracyUsesRawRetrievabilityWhenTrailingHistoryIsSparse`
-re-covers exactly the same identity-fallback behavior
-`RecallStatsServiceAccuracyAggregationTest`'s six tests already establish;
-delete it and keep that file's other, genuinely distinct test.
-
-- **Enables 21.7 only** (shares the same files' context; sequenced so 21.7's
-  restructuring starts from accurate documentation).
+- **Enables 21.7 only.**
 
 #### 21.7 The reliability diagnostic scores both halves of a day without duplicating expensive work — Behavior `[ ]`
 

--- a/.planning/quick/001-morning-cognitive-index/PLAN.md
+++ b/.planning/quick/001-morning-cognitive-index/PLAN.md
@@ -1,15 +1,14 @@
 # Morning cognitive index from recall history
 
 **Status:** in progress — slices 1–14, 14.1–14.8, 15, 16, 17, 18, 19, 20,
-21.1–21.7 done. Repair pass **21.8 optional remaining**. The reliability
-endpoint (`GET /api/user/recall-split-half-reliability`) still needs **the
-developer to query it and decide against the ~0.6 gate before slice 22
-starts** (see Jidoka checkpoints — this is a required stop, not an
-autonomous continuation point). Slice 17.1 (pace-expectation R/D correction,
-split from 17) is separately **blocked** pending a developer-specified
-formula, independent of 21.x. `recall_stats.feature`'s pace scenario stays
-`@wip` — a second, unrelated E2E race condition was found (see
-Discoveries).
+21.1–21.8 done. The 21.x repair pass is complete. The reliability endpoint
+(`GET /api/user/recall-split-half-reliability`) still needs **the developer
+to query it and decide against the ~0.6 gate before slice 22 starts** (see
+Jidoka checkpoints — this is a required stop, not an autonomous continuation
+point). Slice 17.1 (pace-expectation R/D correction, split from 17) is
+separately **blocked** pending a developer-specified formula, independent of
+21.x. `recall_stats.feature`'s pace scenario stays `@wip` — a second,
+unrelated E2E race condition was found (see Discoveries).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Research memo:** https://claude.ai/code/artifact/9e13f954-fc5e-48e5-868f-f75d03f811c1
 
@@ -996,10 +995,9 @@ rescue a low number** — that would defeat the point of the gate.
 At the developer's request, a full session-wide code review across every
 slice landed this session (17–21.4: accuracy, recalibration, guessing floor,
 historical backfill, and split-half reliability) found the gaps below.
-Execute 21.5–21.7 before slice 22; 21.8 is optional. Each is stop-safe:
-stopping after any of them leaves the already-shipped accuracy/index
-readouts more trustworthy than before, same as 14.1–14.8 did for the
-timer/pace channel.
+21.5–21.8 are done. Each is stop-safe: stopping after any
+of them leaves the already-shipped accuracy/index readouts more trustworthy
+than before, same as 14.1–14.8 did for the timer/pace channel.
 
 #### 21.5 The reliability endpoint's real-correlation path has regression coverage — Behavior `[x]`
 
@@ -1041,26 +1039,18 @@ still fit-then-apply. `RecallSplitHalfReliability` calls
 `scoringBothHalvesTogetherMatchesScoringEachHalfIndependently`. Per-half
 `compute(..., Half)` kept for existing tests.
 
-#### 21.8 (optional) Share the Newton-Raphson line-search scaffold between the two fitters — Structure `[ ]`
+#### 21.8 (optional) Share the Newton-Raphson line-search scaffold between the two fitters — Structure `[x]`
 
-`RecallCalibrationFitter.newtonRaphson` and `RecallGuessingFloorFitter.fitConditional`
-duplicate an entire ~25-line backtracking-line-search/convergence/bailout
-scaffold (step-halving loop, NaN/Infinite/non-improving-step bailout,
-convergence check) almost line-for-line — they differ only in how the
-per-row gradient/Hessian/log-likelihood is computed inside that scaffold
-(canonical logistic score vs. BHHH approximation for the 3PL). Slice 20's
-post-change-refactor considered merging these and declined, reasoning that
-"the 2PL analytic-Hessian scoring and 3PL BHHH-approximation scoring are
-genuinely different math" — true of the scoring step, but the surrounding
-line-search skeleton really is identical. A shared helper taking a
-per-iteration score-computing function (gradient + curvature +
-log-likelihood) could remove the duplication without touching either fit's
-actual math.
+Done: extracted the duplicated iteration / 2×2 Newton step / 30-halving
+line search / NaN-Infinite-non-improving bailout / convergence check into
+`RecallNewtonRaphson.maximize` (dedicated class; clamp/logit/sigmoid stay in
+`RecallProbabilityMath`). Callers still own scoring math: 2PL analytic
+Fisher in `RecallCalibrationFitter.score`, 3PL BHHH in
+`RecallGuessingFloorFitter.score`. Bailout mapping unchanged (2PL →
+`CalibrationFit.IDENTITY`; 3PL grid skips a γ when `converged=false`;
+max-iter still counts as success). Numeric tests unchanged.
 
-**Marked optional/lower-priority, not a prerequisite for slice 22**: this
-duplication was already reviewed once and knowingly kept, and the codebase's
-own principle is to avoid premature abstraction. Worth doing if convenient;
-skip it without regret otherwise.
+Not a prerequisite for slice 22.
 
 #### 22. Recall Stats leads with the morning index — Behavior `[ ]`
 

--- a/backend/src/main/java/com/odde/donut/controllers/dto/RecallStatsDTO.java
+++ b/backend/src/main/java/com/odde/donut/controllers/dto/RecallStatsDTO.java
@@ -65,10 +65,13 @@ public class RecallStatsDTO {
 
   /**
    * Standardized Poisson-binomial residual comparing today's observed correctness against each
-   * answer's raw FSRS retrievability at the time it was answered: {@code A = Σ(y−p̂) / √Σp̂(1−p̂)}.
-   * Positive means recalling better than the model expected; negative means worse. {@code
+   * answer's recalibrated recall probability {@code p̂}: raw FSRS retrievability run through a
+   * per-learner, per-question-type 3PL fit with a fitted guessing floor, falling back to the
+   * identity mapping ({@code p̂} = raw retrievability) when trailing history is sparse. See {@link
+   * com.odde.donut.services.RecallAccuracyAggregator}. {@code A = Σ(y−p̂) / √Σp̂(1−p̂)}. Positive
+   * means recalling better than the (recalibrated) model expected; negative means worse. {@code
    * standardizedResidual} is {@code null} when the denominator is 0 (no qualifying rows, or every
-   * retrievability is 0 or 1).
+   * {@code p̂} is 0 or 1).
    */
   @Data
   @AllArgsConstructor

--- a/backend/src/main/java/com/odde/donut/services/RecallAccuracyAggregator.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallAccuracyAggregator.java
@@ -25,13 +25,16 @@ import java.util.Map;
  *
  * <p>Callers pass only rows that already qualify (answered today, counted as a review, not an
  * implausibly-fast mistap — see {@link RecallPaceAggregator}) for the numerator/denominator sum,
- * plus the all-time reviews (same exclusions applied) the calibration fit is refit from on every
- * call — there is no background job; refitting live from the already-fetched projection rows on
- * every stats request is this codebase's existing pattern for trailing-window statistics (see
- * {@code RecallPaceAggregator#consistencyZScore}'s 60-day baseline). This class applies the one
- * exclusion rule specific to the accuracy formula and the calibration fit alike: a row with no
- * persisted retrievability (e.g. a New tracker's first grade, per slice 16) is excluded — null
- * propagates, it is never treated as zero.
+ * plus the all-time reviews (same exclusions applied) the calibration fit is refit from. {@link
+ * #compute} fits then applies. Callers scoring more than one subset of the same day should {@link
+ * #fit} once and {@link #apply} each subset — the fit depends only on all-time qualifying rows,
+ * {@code today}, and {@code zoneId}, never on which of today's rows are being scored. There is no
+ * background job; refitting live from the already-fetched projection rows on every stats request is
+ * this codebase's existing pattern for trailing-window statistics (see {@code
+ * RecallPaceAggregator#consistencyZScore}'s 60-day baseline). This class applies the one exclusion
+ * rule specific to the accuracy formula and the calibration fit alike: a row with no persisted
+ * retrievability (e.g. a New tracker's first grade, per slice 16) is excluded — null propagates, it
+ * is never treated as zero.
  */
 final class RecallAccuracyAggregator {
   /** Trailing window the calibration fit is refit from on every request. */
@@ -44,9 +47,20 @@ final class RecallAccuracyAggregator {
       List<RecallAnswerRow> allTimeQualifyingRows,
       LocalDate today,
       ZoneId zoneId) {
-    Map<QuestionType, ThreePlFit> fitsByQuestionType =
-        fitPerQuestionType(trailingCalibrationRows(allTimeQualifyingRows, today, zoneId));
+    return apply(todaysQualifyingRows, fit(allTimeQualifyingRows, today, zoneId));
+  }
 
+  /**
+   * Per-question-type 3PL fits from the trailing calibration window strictly before {@code today}.
+   */
+  static Map<QuestionType, ThreePlFit> fit(
+      List<RecallAnswerRow> allTimeQualifyingRows, LocalDate today, ZoneId zoneId) {
+    return fitPerQuestionType(trailingCalibrationRows(allTimeQualifyingRows, today, zoneId));
+  }
+
+  /** Apply already-fitted 3PL curves to {@code todaysQualifyingRows}. Does not refit. */
+  static AccuracyStats apply(
+      List<RecallAnswerRow> todaysQualifyingRows, Map<QuestionType, ThreePlFit> fitsByQuestionType) {
     double sumResidual = 0;
     double sumVariance = 0;
     int sampleSize = 0;
@@ -55,8 +69,8 @@ final class RecallAccuracyAggregator {
       if (rawRetrievability == null) {
         continue;
       }
-      ThreePlFit fit = fitsByQuestionType.getOrDefault(r.questionType(), ThreePlFit.IDENTITY);
-      double p = fit.recalibrate(rawRetrievability);
+      ThreePlFit typeFit = fitsByQuestionType.getOrDefault(r.questionType(), ThreePlFit.IDENTITY);
+      double p = typeFit.recalibrate(rawRetrievability);
       double y = r.correct() ? 1 : 0;
       sumResidual += y - p;
       sumVariance += p * (1 - p);

--- a/backend/src/main/java/com/odde/donut/services/RecallCalibrationFitter.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallCalibrationFitter.java
@@ -28,9 +28,6 @@ final class RecallCalibrationFitter {
    */
   private static final int MIN_CALIBRATION_SAMPLES = 50;
 
-  private static final int MAX_ITERATIONS = 25;
-  private static final double CONVERGENCE_TOLERANCE = 1e-6;
-
   private RecallCalibrationFitter() {}
 
   record CalibrationFit(double alpha, double beta) {
@@ -80,76 +77,46 @@ final class RecallCalibrationFitter {
   }
 
   /**
-   * Newton-Raphson with backtracking line search. A full undamped Newton step can overshoot badly
-   * on the first few iterations here (the two-parameter fit is well-conditioned but the starting
-   * point is arbitrary), so each step is halved until the log-likelihood actually improves — the
-   * standard fix that restores Newton's guaranteed convergence for a concave objective like
-   * logistic log-likelihood. Starts at {@code alpha=0, beta=0} (the "retrievability carries no
-   * information" point), not {@code beta=1} (the identity mapping) — starting exactly at the
-   * no-slope point turned out to make the first step's direction unstable for this problem.
+   * Canonical 2PL Newton-Raphson via {@link RecallNewtonRaphson}. Starts at {@code alpha=0, beta=0}
+   * (the "retrievability carries no information" point), not {@code beta=1} (the identity mapping)
+   * — starting exactly at the no-slope point turned out to make the first step's direction unstable
+   * for this problem. Degenerate/NaN/non-improving steps fall back to {@link
+   * CalibrationFit#IDENTITY}; max-iter keeps the last parameters.
    */
   private static CalibrationFit newtonRaphson(double[] x, double[] y) {
-    double alpha = 0.0;
-    double beta = 0.0;
-    double logLikelihood = logLikelihood(alpha, beta, x, y);
-    for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
-      double gradAlpha = 0;
-      double gradBeta = 0;
-      double hAA = 0;
-      double hAB = 0;
-      double hBB = 0;
-      for (int i = 0; i < x.length; i++) {
-        double p = sigmoid(alpha + beta * x[i]);
-        double w = p * (1 - p);
-        double residual = y[i] - p;
-        gradAlpha += residual;
-        gradBeta += residual * x[i];
-        hAA += w;
-        hAB += w * x[i];
-        hBB += w * x[i] * x[i];
-      }
-      double determinant = hAA * hBB - hAB * hAB;
-      if (determinant < 1e-9) {
-        // Near-singular Fisher information (e.g. every row shares the same retrievability, so
-        // alpha and beta are not jointly identifiable) — bail out rather than blow up.
-        return CalibrationFit.IDENTITY;
-      }
-      double deltaAlpha = (hBB * gradAlpha - hAB * gradBeta) / determinant;
-      double deltaBeta = (hAA * gradBeta - hAB * gradAlpha) / determinant;
-      if (Double.isNaN(deltaAlpha) || Double.isNaN(deltaBeta)) {
-        return CalibrationFit.IDENTITY;
-      }
-      double step = 1.0;
-      double newAlpha = alpha;
-      double newBeta = beta;
-      double newLogLikelihood = Double.NEGATIVE_INFINITY;
-      for (int halving = 0; halving < 30; halving++) {
-        newAlpha = alpha + step * deltaAlpha;
-        newBeta = beta + step * deltaBeta;
-        newLogLikelihood = logLikelihood(newAlpha, newBeta, x, y);
-        if (newLogLikelihood >= logLikelihood) {
-          break;
-        }
-        step /= 2;
-      }
-      if (Double.isNaN(newAlpha)
-          || Double.isNaN(newBeta)
-          || Double.isInfinite(newAlpha)
-          || Double.isInfinite(newBeta)
-          || newLogLikelihood < logLikelihood) {
-        return CalibrationFit.IDENTITY;
-      }
-      boolean converged =
-          Math.abs(newAlpha - alpha) < CONVERGENCE_TOLERANCE
-              && Math.abs(newBeta - beta) < CONVERGENCE_TOLERANCE;
-      alpha = newAlpha;
-      beta = newBeta;
-      logLikelihood = newLogLikelihood;
-      if (converged) {
-        return new CalibrationFit(alpha, beta);
-      }
+    RecallNewtonRaphson.Fit fit =
+        RecallNewtonRaphson.maximize(
+            0.0,
+            0.0,
+            (alpha, beta) -> score(alpha, beta, x, y),
+            (alpha, beta) -> logLikelihood(alpha, beta, x, y));
+    return fit.converged() ? new CalibrationFit(fit.alpha(), fit.beta()) : CalibrationFit.IDENTITY;
+  }
+
+  /**
+   * Analytic Fisher-scoring gradient and Hessian for the canonical logistic: residual {@code y−p}
+   * and weight {@code p(1−p)}. Near-singular Fisher (e.g. every row shares the same retrievability,
+   * so alpha and beta are not jointly identifiable) is detected by the shared Newton step, which
+   * then bails out.
+   */
+  private static RecallNewtonRaphson.Score score(
+      double alpha, double beta, double[] x, double[] y) {
+    double gradAlpha = 0;
+    double gradBeta = 0;
+    double hAA = 0;
+    double hAB = 0;
+    double hBB = 0;
+    for (int i = 0; i < x.length; i++) {
+      double p = sigmoid(alpha + beta * x[i]);
+      double w = p * (1 - p);
+      double residual = y[i] - p;
+      gradAlpha += residual;
+      gradBeta += residual * x[i];
+      hAA += w;
+      hAB += w * x[i];
+      hBB += w * x[i] * x[i];
     }
-    return new CalibrationFit(alpha, beta);
+    return new RecallNewtonRaphson.Score(gradAlpha, gradBeta, hAA, hAB, hBB);
   }
 
   /** Numerically stable Bernoulli log-likelihood under the current alpha/beta. */

--- a/backend/src/main/java/com/odde/donut/services/RecallGuessingFloorFitter.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallGuessingFloorFitter.java
@@ -32,8 +32,6 @@ final class RecallGuessingFloorFitter {
   private static final double GAMMA_MIN = 0.0;
   private static final double GAMMA_MAX = 0.5;
   private static final double GAMMA_STEP = 0.02;
-  private static final int MAX_ITERATIONS = 25;
-  private static final double CONVERGENCE_TOLERANCE = 1e-6;
 
   private RecallGuessingFloorFitter() {}
 
@@ -49,10 +47,6 @@ final class RecallGuessingFloorFitter {
       return gamma + (1 - gamma) * s;
     }
   }
-
-  /** One (alpha, beta) candidate at a fixed gamma, and the log-likelihood it converged to. */
-  private record ConditionalFit(
-      double alpha, double beta, double logLikelihood, boolean converged) {}
 
   /**
    * Fits the 3PL model for one question type's trailing qualifying rows. Callers pass only rows
@@ -101,7 +95,12 @@ final class RecallGuessingFloorFitter {
     int steps = (int) Math.round((GAMMA_MAX - GAMMA_MIN) / GAMMA_STEP);
     for (int i = 0; i <= steps; i++) {
       double gamma = Math.min(GAMMA_MAX, GAMMA_MIN + i * GAMMA_STEP);
-      ConditionalFit fit = fitConditional(x, y, gamma, warmAlpha, warmBeta);
+      RecallNewtonRaphson.Fit fit =
+          RecallNewtonRaphson.maximize(
+              warmAlpha,
+              warmBeta,
+              (alpha, beta) -> score(alpha, beta, gamma, x, y),
+              (alpha, beta) -> logLikelihood(alpha, beta, gamma, x, y));
       if (!fit.converged()) {
         continue;
       }
@@ -121,79 +120,34 @@ final class RecallGuessingFloorFitter {
   }
 
   /**
-   * Newton-Raphson maximizing the 3PL log-likelihood for a <em>fixed</em> gamma, with backtracking
-   * line search — mirrors {@code RecallCalibrationFitter#newtonRaphson}'s structure and convergence
-   * tolerance. Uses the outer-product-of-gradients (BHHH) approximation of the Hessian rather than
-   * the analytic second derivative through gamma's non-canonical link: simpler and safer to get the
-   * sign right, at the cost of possibly more iterations. Validated against a finite-difference
-   * gradient check in {@code RecallGuessingFloorFitterTest}.
+   * Outer-product-of-gradients (BHHH) curvature for a <em>fixed</em> gamma, rather than the analytic
+   * second derivative through gamma's non-canonical link: simpler and safer to get the sign right,
+   * at the cost of possibly more iterations. Validated against a finite-difference gradient check in
+   * {@code RecallGuessingFloorFitterTest}.
    *
    * <p>Per-row score {@code u_i = ((y_i − p_i) / (p_i·(1−p_i))) · dp_i/dz_i}, where {@code
    * dp_i/dz_i = (1−γ)·σ(z_i)·(1−σ(z_i))}; gradient {@code g = Σ u_i·[1, x_i]}; BHHH curvature
    * {@code M = Σ u_i²·[1,x_i][1,x_i]ᵀ ≈ -H}, so the Newton step solves {@code M·Δ = g}.
    */
-  private static ConditionalFit fitConditional(
-      double[] x, double[] y, double gamma, double alphaInit, double betaInit) {
-    double alpha = alphaInit;
-    double beta = betaInit;
-    double logLikelihood = logLikelihood(alpha, beta, gamma, x, y);
-    for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
-      double gradAlpha = 0;
-      double gradBeta = 0;
-      double hAA = 0;
-      double hAB = 0;
-      double hBB = 0;
-      for (int i = 0; i < x.length; i++) {
-        double s = sigmoid(alpha + beta * x[i]);
-        double p = clamp(gamma + (1 - gamma) * s);
-        double dpdz = (1 - gamma) * s * (1 - s);
-        double u = ((y[i] - p) / (p * (1 - p))) * dpdz;
-        gradAlpha += u;
-        gradBeta += u * x[i];
-        hAA += u * u;
-        hAB += u * u * x[i];
-        hBB += u * u * x[i] * x[i];
-      }
-      double determinant = hAA * hBB - hAB * hAB;
-      if (determinant < 1e-9) {
-        return new ConditionalFit(alpha, beta, logLikelihood, false);
-      }
-      double deltaAlpha = (hBB * gradAlpha - hAB * gradBeta) / determinant;
-      double deltaBeta = (hAA * gradBeta - hAB * gradAlpha) / determinant;
-      if (Double.isNaN(deltaAlpha) || Double.isNaN(deltaBeta)) {
-        return new ConditionalFit(alpha, beta, logLikelihood, false);
-      }
-      double step = 1.0;
-      double newAlpha = alpha;
-      double newBeta = beta;
-      double newLogLikelihood = Double.NEGATIVE_INFINITY;
-      for (int halving = 0; halving < 30; halving++) {
-        newAlpha = alpha + step * deltaAlpha;
-        newBeta = beta + step * deltaBeta;
-        newLogLikelihood = logLikelihood(newAlpha, newBeta, gamma, x, y);
-        if (newLogLikelihood >= logLikelihood) {
-          break;
-        }
-        step /= 2;
-      }
-      if (Double.isNaN(newAlpha)
-          || Double.isNaN(newBeta)
-          || Double.isInfinite(newAlpha)
-          || Double.isInfinite(newBeta)
-          || newLogLikelihood < logLikelihood) {
-        return new ConditionalFit(alpha, beta, logLikelihood, false);
-      }
-      boolean converged =
-          Math.abs(newAlpha - alpha) < CONVERGENCE_TOLERANCE
-              && Math.abs(newBeta - beta) < CONVERGENCE_TOLERANCE;
-      alpha = newAlpha;
-      beta = newBeta;
-      logLikelihood = newLogLikelihood;
-      if (converged) {
-        return new ConditionalFit(alpha, beta, logLikelihood, true);
-      }
+  private static RecallNewtonRaphson.Score score(
+      double alpha, double beta, double gamma, double[] x, double[] y) {
+    double gradAlpha = 0;
+    double gradBeta = 0;
+    double hAA = 0;
+    double hAB = 0;
+    double hBB = 0;
+    for (int i = 0; i < x.length; i++) {
+      double s = sigmoid(alpha + beta * x[i]);
+      double p = clamp(gamma + (1 - gamma) * s);
+      double dpdz = (1 - gamma) * s * (1 - s);
+      double u = ((y[i] - p) / (p * (1 - p))) * dpdz;
+      gradAlpha += u;
+      gradBeta += u * x[i];
+      hAA += u * u;
+      hAB += u * u * x[i];
+      hBB += u * u * x[i] * x[i];
     }
-    return new ConditionalFit(alpha, beta, logLikelihood, true);
+    return new RecallNewtonRaphson.Score(gradAlpha, gradBeta, hAA, hAB, hBB);
   }
 
   /** Numerically stable Bernoulli log-likelihood under the current alpha/beta/gamma. */

--- a/backend/src/main/java/com/odde/donut/services/RecallMorningHalfIndex.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallMorningHalfIndex.java
@@ -2,6 +2,8 @@ package com.odde.donut.services;
 
 import com.odde.donut.controllers.dto.RecallStatsDTO.AccuracyStats;
 import com.odde.donut.controllers.dto.RecallStatsDTO.PaceStats;
+import com.odde.donut.entities.QuestionType;
+import com.odde.donut.services.RecallGuessingFloorFitter.ThreePlFit;
 import com.odde.donut.services.RecallPaceAggregator.PaceResult;
 import com.odde.donut.utils.TimestampOperations;
 import java.time.LocalDate;
@@ -10,26 +12,32 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * Scores one half (odd- or even-indexed attempts, 1-indexed by within-day chronological order) of a
- * single historical day D's recall attempts through the same accuracy/pace/lapse/consistency
- * machinery already used to score a whole day (slices 17-20, 21.1) — producing one composite index
- * value (slice 21.2's formula) for that half. Enables slice 21.4's split-half reliability check.
+ * Scores odd- or even-indexed halves (1-indexed by within-day chronological order) of a single
+ * historical day D's recall attempts through the same accuracy/pace/lapse/consistency machinery
+ * already used to score a whole day (slices 17-20, 21.1) — producing one composite index value
+ * (slice 21.2's formula) per half. Enables slice 21.4's split-half reliability check.
  *
  * <p>Trailing-window calibration/baselines are never recomputed per half: they are derived from
  * history strictly before D (the accuracy calibration's trailing-180-day window excludes today by
  * construction, and the pace/lapse/consistency baseline window already ends {@code
  * BASELINE_WINDOW_END_DAYS_AGO} days before D regardless of which of D's own rows are being scored)
  * — restricting to a half only changes which of D's own rows feed the numerator, never what they
- * are compared against.
+ * are compared against. {@link #computeBothHalves} therefore prepares that shared day-level setup
+ * once (whole-day pace exclusions, qualifying-row order, and the per-question-type 3PL fit) and
+ * applies it to each half.
  */
 final class RecallMorningHalfIndex {
   enum Half {
     ODD,
     EVEN
   }
+
+  /** Index values for both halves of one day. Either side may be {@code null}. */
+  record HalfIndexes(Double odd, Double even) {}
 
   private RecallMorningHalfIndex() {}
 
@@ -40,20 +48,49 @@ final class RecallMorningHalfIndex {
    */
   static Double compute(
       List<RecallAnswerRow> allTimeReviews, LocalDate day, ZoneId zoneId, Half half) {
+    return scoreHalf(prepareDay(allTimeReviews, day, zoneId), half);
+  }
+
+  /**
+   * Scores both halves from one shared day-level setup. Either value may be {@code null} under the
+   * same conditions as {@link #compute(List, LocalDate, ZoneId, Half)}.
+   */
+  static HalfIndexes computeBothHalves(
+      List<RecallAnswerRow> allTimeReviews, LocalDate day, ZoneId zoneId) {
+    DaySetup setup = prepareDay(allTimeReviews, day, zoneId);
+    return new HalfIndexes(scoreHalf(setup, Half.ODD), scoreHalf(setup, Half.EVEN));
+  }
+
+  private record DaySetup(
+      List<RecallAnswerRow> allTimeReviews,
+      LocalDate day,
+      ZoneId zoneId,
+      List<RecallAnswerRow> dayQualifyingRowsInOrder,
+      Map<QuestionType, ThreePlFit> accuracyFits) {}
+
+  private static DaySetup prepareDay(
+      List<RecallAnswerRow> allTimeReviews, LocalDate day, ZoneId zoneId) {
     PaceResult wholeDayPaceResult = RecallPaceAggregator.compute(allTimeReviews, day, zoneId);
     Set<RecallAnswerRow> implausiblyFastRows = wholeDayPaceResult.implausiblyFastRows();
-
     List<RecallAnswerRow> dayQualifyingRowsInOrder =
         dayQualifyingRowsInOrder(allTimeReviews, day, zoneId, implausiblyFastRows);
-    Set<RecallAnswerRow> halfRows = selectHalf(dayQualifyingRowsInOrder, half);
-
     List<RecallAnswerRow> allTimeQualifyingRows =
         allTimeReviews.stream().filter(r -> !implausiblyFastRows.contains(r)).toList();
-    List<RecallAnswerRow> halfQualifyingRows =
-        dayQualifyingRowsInOrder.stream().filter(halfRows::contains).toList();
+    return new DaySetup(
+        allTimeReviews,
+        day,
+        zoneId,
+        dayQualifyingRowsInOrder,
+        RecallAccuracyAggregator.fit(allTimeQualifyingRows, day, zoneId));
+  }
+
+  private static Double scoreHalf(DaySetup setup, Half half) {
+    List<RecallAnswerRow> halfQualifyingRows = selectHalf(setup.dayQualifyingRowsInOrder(), half);
+    Set<RecallAnswerRow> halfRows = Collections.newSetFromMap(new IdentityHashMap<>());
+    halfRows.addAll(halfQualifyingRows);
 
     AccuracyStats accuracy =
-        RecallAccuracyAggregator.compute(halfQualifyingRows, allTimeQualifyingRows, day, zoneId);
+        RecallAccuracyAggregator.apply(halfQualifyingRows, setup.accuracyFits());
     if (accuracy.getStandardizedResidual() == null) {
       return null;
     }
@@ -62,7 +99,8 @@ final class RecallMorningHalfIndex {
     // "worse than usual" convention, per 21.2's deferred note.
     double zA = -accuracy.getStandardizedResidual();
 
-    PaceResult halfPaceResult = RecallPaceAggregator.compute(allTimeReviews, day, zoneId, halfRows);
+    PaceResult halfPaceResult =
+        RecallPaceAggregator.compute(setup.allTimeReviews(), setup.day(), setup.zoneId(), halfRows);
     PaceStats stats = halfPaceResult.stats();
     if (stats.getPctVsUsual() == null || stats.getConsistencyZScore() == null) {
       return null;
@@ -111,13 +149,13 @@ final class RecallMorningHalfIndex {
 
   /**
    * 1-indexed by within-day chronological order: odd positions (1st, 3rd, ...) in one half, even
-   * positions (2nd, 4th, ...) in the other. Identity-based, matching {@code implausiblyFastRows}'
-   * existing precedent (slice 10) of tracking specific row objects rather than relying on {@link
-   * RecallAnswerRow}'s structural equality.
+   * positions (2nd, 4th, ...) in the other. Returns the selected row objects themselves so callers
+   * can identity-match them (matching {@code implausiblyFastRows}' existing precedent of tracking
+   * specific row objects rather than relying on {@link RecallAnswerRow}'s structural equality).
    */
-  private static Set<RecallAnswerRow> selectHalf(
+  private static List<RecallAnswerRow> selectHalf(
       List<RecallAnswerRow> dayQualifyingRowsInOrder, Half half) {
-    Set<RecallAnswerRow> selected = Collections.newSetFromMap(new IdentityHashMap<>());
+    List<RecallAnswerRow> selected = new ArrayList<>();
     for (int i = 0; i < dayQualifyingRowsInOrder.size(); i++) {
       boolean isOddPosition = (i + 1) % 2 == 1;
       if ((half == Half.ODD) == isOddPosition) {

--- a/backend/src/main/java/com/odde/donut/services/RecallNewtonRaphson.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallNewtonRaphson.java
@@ -1,0 +1,91 @@
+package com.odde.donut.services;
+
+/**
+ * Shared Newton-Raphson scaffold for the two-parameter (α, β) logistic fits used by {@link
+ * RecallCalibrationFitter} (analytic Fisher Hessian) and {@link RecallGuessingFloorFitter} (BHHH
+ * approximation). Owns only the iteration loop, 2×2 Newton step, backtracking line search, and
+ * bailout/convergence checks — callers supply the per-iteration gradient, curvature, and
+ * log-likelihood, which is where the 2PL and 3PL scoring math actually differs.
+ *
+ * <p>A full undamped Newton step can overshoot on early iterations, so each step is halved until
+ * the log-likelihood actually improves. {@code converged=false} means the curvature was degenerate,
+ * a step was NaN/Infinite, or line search found no improving step; {@code converged=true} means the
+ * parameter change fell under {@link #CONVERGENCE_TOLERANCE} or {@link #MAX_ITERATIONS} was reached
+ * (callers treat max-iter as success and keep the last parameters).
+ */
+final class RecallNewtonRaphson {
+  private static final int MAX_ITERATIONS = 25;
+  private static final double CONVERGENCE_TOLERANCE = 1e-6;
+  private static final int MAX_LINE_SEARCH_HALVINGS = 30;
+  private static final double SINGULARITY_THRESHOLD = 1e-9;
+
+  private RecallNewtonRaphson() {}
+
+  /**
+   * Per-iteration gradient of the log-likelihood and the 2×2 curvature used for the Newton step
+   * (analytic Fisher information for 2PL; BHHH outer-product approximation for 3PL). Treated as a
+   * positive-definite approximation of {@code -H}; the step solves {@code curvature · Δ =
+   * gradient}.
+   */
+  record Score(double gradAlpha, double gradBeta, double hAA, double hAB, double hBB) {}
+
+  record Fit(double alpha, double beta, double logLikelihood, boolean converged) {}
+
+  @FunctionalInterface
+  interface ScoreFn {
+    Score score(double alpha, double beta);
+  }
+
+  @FunctionalInterface
+  interface LogLikelihoodFn {
+    double logLikelihood(double alpha, double beta);
+  }
+
+  static Fit maximize(double alpha, double beta, ScoreFn scoreFn, LogLikelihoodFn logLikelihoodFn) {
+    double logLikelihood = logLikelihoodFn.logLikelihood(alpha, beta);
+    for (int iter = 0; iter < MAX_ITERATIONS; iter++) {
+      Score score = scoreFn.score(alpha, beta);
+      double determinant = score.hAA() * score.hBB() - score.hAB() * score.hAB();
+      if (determinant < SINGULARITY_THRESHOLD) {
+        return new Fit(alpha, beta, logLikelihood, false);
+      }
+      double deltaAlpha =
+          (score.hBB() * score.gradAlpha() - score.hAB() * score.gradBeta()) / determinant;
+      double deltaBeta =
+          (score.hAA() * score.gradBeta() - score.hAB() * score.gradAlpha()) / determinant;
+      if (Double.isNaN(deltaAlpha) || Double.isNaN(deltaBeta)) {
+        return new Fit(alpha, beta, logLikelihood, false);
+      }
+      double step = 1.0;
+      double newAlpha = alpha;
+      double newBeta = beta;
+      double newLogLikelihood = Double.NEGATIVE_INFINITY;
+      for (int halving = 0; halving < MAX_LINE_SEARCH_HALVINGS; halving++) {
+        newAlpha = alpha + step * deltaAlpha;
+        newBeta = beta + step * deltaBeta;
+        newLogLikelihood = logLikelihoodFn.logLikelihood(newAlpha, newBeta);
+        if (newLogLikelihood >= logLikelihood) {
+          break;
+        }
+        step /= 2;
+      }
+      if (Double.isNaN(newAlpha)
+          || Double.isNaN(newBeta)
+          || Double.isInfinite(newAlpha)
+          || Double.isInfinite(newBeta)
+          || newLogLikelihood < logLikelihood) {
+        return new Fit(alpha, beta, logLikelihood, false);
+      }
+      boolean converged =
+          Math.abs(newAlpha - alpha) < CONVERGENCE_TOLERANCE
+              && Math.abs(newBeta - beta) < CONVERGENCE_TOLERANCE;
+      alpha = newAlpha;
+      beta = newBeta;
+      logLikelihood = newLogLikelihood;
+      if (converged) {
+        return new Fit(alpha, beta, logLikelihood, true);
+      }
+    }
+    return new Fit(alpha, beta, logLikelihood, true);
+  }
+}

--- a/backend/src/main/java/com/odde/donut/services/RecallSplitHalfReliability.java
+++ b/backend/src/main/java/com/odde/donut/services/RecallSplitHalfReliability.java
@@ -1,6 +1,6 @@
 package com.odde.donut.services;
 
-import com.odde.donut.services.RecallMorningHalfIndex.Half;
+import com.odde.donut.services.RecallMorningHalfIndex.HalfIndexes;
 import com.odde.donut.utils.TimestampOperations;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -12,9 +12,9 @@ import java.util.Map;
 /**
  * Internal diagnostic (slice 21.4) for the morning cognitive index's split-half reliability: across
  * a trailing window of historical mornings, scores each qualifying day's odd- and even-indexed
- * attempts independently ({@link RecallMorningHalfIndex}, slice 21.3) and reports how well the two
- * halves agree. This is the reliability gate the plan's "The index" section requires before slices
- * 22-25 (the user-facing composite) can ship — see the Jidoka checkpoint before slice 22.
+ * attempts ({@link RecallMorningHalfIndex#computeBothHalves}) and reports how well the two halves
+ * agree. This is the reliability gate the plan's "The index" section requires before slices 22-25
+ * (the user-facing composite) can ship — see the Jidoka checkpoint before slice 22.
  *
  * <p>Not wired into {@link com.odde.donut.controllers.dto.RecallStatsDTO} or any user-facing page.
  */
@@ -31,9 +31,9 @@ final class RecallSplitHalfReliability {
    * Mirrors {@code RecallPaceAggregator.consistencyZScore}'s own minimum of >= 2 residuals for a
    * half to produce a non-null consistency z-score: 4 total rows is the fewest that can put >= 2 in
    * each of two non-empty halves. This is a coarse, cheap pre-filter only — the real gate is still
-   * "did {@link RecallMorningHalfIndex#compute} return non-null for both halves" (a day can pass
-   * this row-count filter and still be excluded, e.g. if some rows lack a warmed-up per-item
-   * baseline).
+   * "did {@link RecallMorningHalfIndex#computeBothHalves} return non-null for both halves" (a day
+   * can pass this row-count filter and still be excluded, e.g. if some rows lack a warmed-up
+   * per-item baseline).
    */
   private static final int MIN_QUALIFYING_ROWS_PER_DAY = 4;
 
@@ -62,10 +62,9 @@ final class RecallSplitHalfReliability {
   static Result compute(List<RecallAnswerRow> allTimeReviews, LocalDate today, ZoneId zoneId) {
     List<double[]> pairs = new ArrayList<>();
     for (LocalDate day : candidateDays(allTimeReviews, today, zoneId)) {
-      Double odd = RecallMorningHalfIndex.compute(allTimeReviews, day, zoneId, Half.ODD);
-      Double even = RecallMorningHalfIndex.compute(allTimeReviews, day, zoneId, Half.EVEN);
-      if (odd != null && even != null) {
-        pairs.add(new double[] {odd, even});
+      HalfIndexes halves = RecallMorningHalfIndex.computeBothHalves(allTimeReviews, day, zoneId);
+      if (halves.odd() != null && halves.even() != null) {
+        pairs.add(new double[] {halves.odd(), halves.even()});
       }
     }
     if (pairs.size() < MIN_PAIRS_FOR_CORRELATION) {
@@ -81,7 +80,8 @@ final class RecallSplitHalfReliability {
    * #MIN_QUALIFYING_ROWS_PER_DAY} rows, in ascending order. A coarse pre-filter over raw row counts
    * (not accounting for implausibly-fast rows or per-item baseline warm-up) purely so {@link
    * #compute} doesn't run the full half-index pipeline against every historical day; the real
-   * qualification is {@link RecallMorningHalfIndex#compute} returning non-null for both halves.
+   * qualification is {@link RecallMorningHalfIndex#computeBothHalves} returning non-null for both
+   * halves.
    */
   private static List<LocalDate> candidateDays(
       List<RecallAnswerRow> allTimeReviews, LocalDate today, ZoneId zoneId) {

--- a/backend/src/test/java/com/odde/donut/services/RecallMorningHalfIndexTest.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallMorningHalfIndexTest.java
@@ -63,4 +63,19 @@ class RecallMorningHalfIndexTest {
     // zA_even) = 2.5 * 2*sqrt(2) = 5*sqrt(2).
     assertThat(oddIndex - evenIndex, closeTo(5 * Math.sqrt(2), 0.001));
   }
+
+  @Test
+  void scoringBothHalvesTogetherMatchesScoringEachHalfIndependently() {
+    List<RecallAnswerRow> rows = RecallStatsTestFixtures.warmedUpBaselines();
+    RecallStatsTestFixtures.addScorableMorning(
+        rows, TODAY, 9001, new boolean[] {true, false, true, false});
+
+    RecallMorningHalfIndex.HalfIndexes both =
+        RecallMorningHalfIndex.computeBothHalves(rows, TODAY_DATE, UTC);
+    Double odd = RecallMorningHalfIndex.compute(rows, TODAY_DATE, UTC, Half.ODD);
+    Double even = RecallMorningHalfIndex.compute(rows, TODAY_DATE, UTC, Half.EVEN);
+
+    assertThat(both.odd(), closeTo(odd, 0.0001));
+    assertThat(both.even(), closeTo(even, 0.0001));
+  }
 }

--- a/backend/src/test/java/com/odde/donut/services/RecallMorningHalfIndexTest.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallMorningHalfIndexTest.java
@@ -47,15 +47,11 @@ class RecallMorningHalfIndexTest {
   @Test
   void oddAndEvenHalvesAreScoredIndependentlyAndReflectTheirOwnOutcomes() {
     List<RecallAnswerRow> rows = RecallStatsTestFixtures.warmedUpBaselines();
-    int[] items = {9001, 9002, 9003, 9004};
-    boolean[] correctByPosition = {true, false, true, false}; // odd = correct, even = incorrect
-    for (int i = 0; i < items.length; i++) {
-      rows.add(answered(utc(0, 8), BASELINE_MS, true, null, items[i]));
-      // Answered exactly at its own established baseline -> zero pace residual, so pace/lapse/
-      // consistency come out identical between the two halves; only accuracy (zA) differs, by
-      // construction, isolating the sign-flip/wiring this slice is responsible for.
-      rows.add(answered(utc(TODAY, 8 + i), BASELINE_MS, correctByPosition[i], null, items[i], 0.5));
-    }
+    // Answered exactly at each item's established baseline -> zero pace residual, so pace/lapse/
+    // consistency come out identical between the two halves; only accuracy (zA) differs, by
+    // construction, isolating the sign-flip/wiring this class is responsible for.
+    RecallStatsTestFixtures.addScorableMorning(
+        rows, TODAY, 9001, new boolean[] {true, false, true, false});
 
     Double oddIndex = RecallMorningHalfIndex.compute(rows, TODAY_DATE, UTC, Half.ODD);
     Double evenIndex = RecallMorningHalfIndex.compute(rows, TODAY_DATE, UTC, Half.EVEN);

--- a/backend/src/test/java/com/odde/donut/services/RecallSplitHalfReliabilityTest.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallSplitHalfReliabilityTest.java
@@ -1,14 +1,16 @@
 package com.odde.donut.services;
 
-import static com.odde.donut.services.RecallStatsTestFixtures.answered;
-import static com.odde.donut.services.RecallStatsTestFixtures.utc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.odde.donut.services.RecallMorningHalfIndex.Half;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -16,15 +18,14 @@ import org.junit.jupiter.api.Test;
  * Covers slice 21.4: the split-half reliability diagnostic that gates slices 22-25 (see "The index"
  * section of the plan). {@link RecallMorningHalfIndex} itself is exercised by {@link
  * RecallMorningHalfIndexTest} (sharing its warmed-up baseline fixture via {@link
- * RecallStatsTestFixtures}); these tests cover the new orchestration (enumerating candidate
- * mornings, collecting only both-halves-non-null pairs, the minimum-pairs-for-correlation gate) and
- * the pure Pearson/Spearman-Brown math, including the Jidoka-flagged zero-variance edge case.
+ * RecallStatsTestFixtures}); these tests cover the orchestration (enumerating candidate mornings,
+ * collecting only both-halves-non-null pairs, the minimum-pairs-for-correlation gate) and the
+ * Pearson/Spearman-Brown path that actually produces a coefficient once enough pairs exist.
  */
 class RecallSplitHalfReliabilityTest {
   private static final ZoneId UTC = ZoneId.of("UTC");
   private static final int TODAY = RecallStatsTestFixtures.WARMED_UP_BASELINE_TODAY;
   private static final LocalDate TODAY_DATE = RecallStatsTestFixtures.WARMED_UP_BASELINE_TODAY_DATE;
-  private static final int BASELINE_MS = RecallStatsTestFixtures.WARMED_UP_BASELINE_MS;
 
   @Test
   void noHistoryYieldsNoPairsAndNullCorrelations() {
@@ -37,15 +38,10 @@ class RecallSplitHalfReliabilityTest {
 
   @Test
   void aSingleQualifyingMorningIsCountedButFallsBelowTheMinimumPairsForCorrelation() {
-    // Mirrors RecallMorningHalfIndexTest's "oddAndEvenHalvesAreScoredIndependently..." fixture:
-    // one morning with 4 established items split 2/2 across the halves, both halves non-null.
+    // One morning with 4 established items split 2/2 across the halves, both halves non-null.
     List<RecallAnswerRow> rows = RecallStatsTestFixtures.warmedUpBaselines();
-    int[] items = {9001, 9002, 9003, 9004};
-    boolean[] correctByPosition = {true, false, true, false};
-    for (int i = 0; i < items.length; i++) {
-      rows.add(answered(utc(0, 8), BASELINE_MS, true, null, items[i]));
-      rows.add(answered(utc(TODAY, 8 + i), BASELINE_MS, correctByPosition[i], null, items[i], 0.5));
-    }
+    RecallStatsTestFixtures.addScorableMorning(
+        rows, TODAY, 9001, new boolean[] {true, false, true, false});
 
     RecallSplitHalfReliability.Result result =
         RecallSplitHalfReliability.compute(rows, TODAY_DATE, UTC);
@@ -55,6 +51,45 @@ class RecallSplitHalfReliabilityTest {
     assertThat(result.pairCount(), equalTo(1));
     assertThat(result.rawCorrelation(), nullValue());
     assertThat(result.spearmanBrownCorrelation(), nullValue());
+  }
+
+  @Test
+  void tenScorableMorningsYieldThePearsonOfTheirHalfIndexesAndTheSpearmanBrownCorrection() {
+    // Varied per-day pace/lapse (not the two-value even/odd pattern) so later mornings that fall
+    // in an earlier morning's trailing window cannot collapse baseline MAD to 0.
+    List<RecallAnswerRow> rows = RecallStatsTestFixtures.variedBaselinesThrough(TODAY - 20);
+    // Vary odd/even outcomes so neither half-index series is constant (Pearson undefined).
+    for (int d = 0; d < 10; d++) {
+      boolean oddCorrect = d % 2 == 0;
+      boolean evenCorrect = d % 3 != 0;
+      RecallStatsTestFixtures.addScorableMorning(
+          rows,
+          TODAY - 9 + d,
+          9100 + d * 4,
+          new boolean[] {oddCorrect, evenCorrect, oddCorrect, evenCorrect});
+    }
+
+    List<double[]> expectedPairs = new ArrayList<>();
+    for (int d = 0; d < 10; d++) {
+      int dayNumber = TODAY - 9 + d;
+      LocalDate day = TODAY_DATE.minusDays(9 - d);
+      Double odd = RecallMorningHalfIndex.compute(rows, day, UTC, Half.ODD);
+      Double even = RecallMorningHalfIndex.compute(rows, day, UTC, Half.EVEN);
+      assertThat("odd half-index for day " + dayNumber, odd, notNullValue());
+      assertThat("even half-index for day " + dayNumber, even, notNullValue());
+      expectedPairs.add(new double[] {odd, even});
+    }
+    Double expectedR = RecallSplitHalfReliability.pearson(expectedPairs);
+    assertThat(expectedR, notNullValue());
+
+    RecallSplitHalfReliability.Result result =
+        RecallSplitHalfReliability.compute(rows, TODAY_DATE, UTC);
+
+    assertThat(result.pairCount(), greaterThanOrEqualTo(10));
+    assertThat(result.pairCount(), equalTo(expectedPairs.size()));
+    assertThat(result.rawCorrelation(), closeTo(expectedR, 0.0001));
+    assertThat(
+        result.spearmanBrownCorrelation(), closeTo((2 * expectedR) / (1 + expectedR), 0.0001));
   }
 
   @Test
@@ -69,12 +104,5 @@ class RecallSplitHalfReliabilityTest {
     // never varies across the sample.
     List<double[]> pairs = List.of(new double[] {5, 1}, new double[] {5, 2}, new double[] {5, 3});
     assertThat(RecallSplitHalfReliability.pearson(pairs), nullValue());
-  }
-
-  @Test
-  void spearmanBrownCorrectsTheRawCorrelationUpward() {
-    double r = 0.5;
-    double correctedR = (2 * r) / (1 + r);
-    assertThat(correctedR, closeTo(0.6667, 0.0001));
   }
 }

--- a/backend/src/test/java/com/odde/donut/services/RecallStatsServiceAccuracyAggregationTest.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallStatsServiceAccuracyAggregationTest.java
@@ -11,8 +11,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the accuracy tile's standardized Poisson-binomial residual {@code A = Σ(y−p̂) /
- * √Σp̂(1−p̂)} on raw FSRS retrievability. Split out to keep {@link RecallStatsServiceTest} under
- * the 250-line limit, matching the pace/lapse/consistency test-file precedent.
+ * √Σp̂(1−p̂)} against the recalibrated recall probability {@code p̂} (see {@link
+ * RecallAccuracyAggregator}). These cases sit below the calibration sample threshold, so the
+ * identity fallback applies and {@code p̂} equals raw FSRS retrievability. Split out to keep {@link
+ * RecallStatsServiceTest} under the 250-line limit, matching the pace/lapse/consistency test-file
+ * precedent.
  */
 class RecallStatsServiceAccuracyAggregationTest {
   @Test

--- a/backend/src/test/java/com/odde/donut/services/RecallStatsServiceAccuracyCalibrationTest.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallStatsServiceAccuracyCalibrationTest.java
@@ -43,22 +43,4 @@ class RecallStatsServiceAccuracyCalibrationTest {
     // = 1.0, not the raw-retrievability value of (1-0.9)/sqrt(0.09) = 0.333.
     assertThat(accuracy.getStandardizedResidual(), closeTo(1.0, 0.05));
   }
-
-  @Test
-  void todaysAccuracyUsesRawRetrievabilityWhenTrailingHistoryIsSparse() {
-    Timestamp now = utc(11, 12); // today = 1989-01-11
-    // Only a handful of trailing rows — far below the minimum calibration sample size, so the
-    // fit falls back to the identity mapping and today's accuracy is scored on raw
-    // retrievability, exactly as before this slice.
-    List<RecallAnswerRow> rows =
-        List.of(
-            answered(utc(9, 9), 5000, false, null, 1, 0.9),
-            answered(utc(9, 10), 5000, true, null, 2, 0.9),
-            answered(utc(11, 10), 5000, true, null, 3, 0.9));
-    RecallStatsDTO dto = aggregate(rows, now);
-    RecallStatsDTO.AccuracyStats accuracy = dto.getAccuracy();
-    assertThat(accuracy.getSampleSize(), equalTo(1));
-    // (1 - 0.9) / sqrt(0.9 * 0.1) = 0.1 / 0.3 = 0.333
-    assertThat(accuracy.getStandardizedResidual(), closeTo(0.333, 0.001));
-  }
 }

--- a/backend/src/test/java/com/odde/donut/services/RecallStatsTestFixtures.java
+++ b/backend/src/test/java/com/odde/donut/services/RecallStatsTestFixtures.java
@@ -38,19 +38,76 @@ final class RecallStatsTestFixtures {
    * One trailing baseline day: two items, each with a pre-existing baseline from day 0, answered
    * again on {@code day} so that day contributes exactly two residuals (needed for the consistency
    * spread baseline's own {@code >= 2 residuals/day} qualification) with a non-degenerate pace and
-   * lapse spread across days. Shared by {@code RecallMorningHalfIndexTest} and {@code
-   * RecallSplitHalfReliabilityTest}.
+   * lapse spread across days (two-value even/odd pattern).
    */
-  static void addWarmedUpBaselineDay(List<RecallAnswerRow> rows, int day, int itemIdBase) {
+  private static void addWarmedUpBaselineDay(List<RecallAnswerRow> rows, int day, int itemIdBase) {
+    boolean evenDay = (day - WARMED_UP_BASELINE_WINDOW_START) % 2 == 0;
+    int onTaskMsA = evenDay ? 4500 : 6000; // gives every baseline day a non-zero pace spread
+    int onTaskMsB = evenDay ? 15000 : WARMED_UP_BASELINE_MS; // itemB lapses on half the days
+    addWarmedUpBaselineDay(rows, day, itemIdBase, onTaskMsA, onTaskMsB);
+  }
+
+  private static void addWarmedUpBaselineDay(
+      List<RecallAnswerRow> rows, int day, int itemIdBase, int onTaskMsA, int onTaskMsB) {
     int itemA = itemIdBase;
     int itemB = itemIdBase + 1;
     rows.add(answered(utc(0, 6), WARMED_UP_BASELINE_MS, true, null, itemA));
     rows.add(answered(utc(0, 7), WARMED_UP_BASELINE_MS, true, null, itemB));
-    boolean evenDay = (day - WARMED_UP_BASELINE_WINDOW_START) % 2 == 0;
-    int onTaskMsA = evenDay ? 4500 : 6000; // gives every baseline day a non-zero pace spread
-    int onTaskMsB = evenDay ? 15000 : WARMED_UP_BASELINE_MS; // itemB lapses on half the days
     rows.add(answered(utc(day, 10), onTaskMsA, true, null, itemA));
     rows.add(answered(utc(day, 11), onTaskMsB, true, null, itemB));
+  }
+
+  /**
+   * Trailing baseline days whose per-day pace and lapse values take more than two distinct values,
+   * so later scored mornings that also fall in the window cannot collapse MAD to 0 the way the
+   * two-value even/odd pattern of {@link #addWarmedUpBaselineDay(List, int, int)} does.
+   */
+  static List<RecallAnswerRow> variedBaselinesThrough(int lastDayInclusive) {
+    List<RecallAnswerRow> rows = new ArrayList<>();
+    int itemId = 2000;
+    for (int day = WARMED_UP_BASELINE_WINDOW_START; day <= lastDayInclusive; day++) {
+      // Three lapse-count phases (0/1/2) and non-identical on-task times so pace and consistency
+      // spreads also take more than two values — a two-value series has MAD 0 whenever one value
+      // is a strict majority.
+      int phase = day % 3;
+      int onTaskMsA;
+      int onTaskMsB;
+      if (phase == 0) {
+        onTaskMsA = 4000 + (day % 11) * 300;
+        onTaskMsB = 5500 + (day % 7) * 200;
+      } else if (phase == 1) {
+        onTaskMsA = 15000;
+        onTaskMsB = 6000;
+      } else {
+        onTaskMsA = 15000;
+        onTaskMsB = 20000;
+      }
+      addWarmedUpBaselineDay(rows, day, itemId, onTaskMsA, onTaskMsB);
+      itemId += 2;
+    }
+    return rows;
+  }
+
+  /**
+   * One morning of established items scored at their own baseline time, split across odd/even
+   * positions by {@code correctByPosition}. Both halves are scorable when the array has length 4
+   * (2/2) and a warmed-up trailing day-baseline is present. Shared by
+   * {@code RecallMorningHalfIndexTest} and {@code RecallSplitHalfReliabilityTest}.
+   */
+  static void addScorableMorning(
+      List<RecallAnswerRow> rows, int day, int itemIdBase, boolean[] correctByPosition) {
+    for (int i = 0; i < correctByPosition.length; i++) {
+      int itemId = itemIdBase + i;
+      rows.add(answered(utc(0, 8), WARMED_UP_BASELINE_MS, true, null, itemId));
+      rows.add(
+          answered(
+              utc(day, 8 + i),
+              WARMED_UP_BASELINE_MS,
+              correctByPosition[i],
+              null,
+              itemId,
+              0.5));
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Repair pass on the morning cognitive index reliability work (plan quick 001, **21.5–21.8**). Does **not** start slice 22 — that still waits on querying `GET /api/user/recall-split-half-reliability` against the ~0.6 gate.

## Done

- **21.5:** End-to-end coverage of `RecallSplitHalfReliability.compute()` for ≥10 qualifying day-pairs. Asserts pair count, independently computed Pearson `r`, and Spearman-Brown `2r/(1+r)`. Removes the vacuous hardcoded `r = 0.5` test. Production formula unchanged. Multi-day fixtures use `variedBaselinesThrough` so baseline MAD does not collapse to 0.
- **21.6:** `AccuracyStats` and aggregation-test javadocs describe the recalibrated 3PL `p̂` (identity fallback when trailing history is sparse). Deleted the sparse-history calibration test that duplicated aggregation tests.
- **21.7:** Score both halves of a day from one shared setup (`computeBothHalves`): whole-day pace exclusions, qualifying-row order, and a single per-question-type 3PL fit. `RecallAccuracyAggregator` split into `fit` / `apply`. Numbers unchanged.
- **21.8 (optional, done):** Shared Newton-Raphson line-search scaffold in `RecallNewtonRaphson`. 2PL Fisher scoring and 3PL BHHH scoring stay in their fitters.

## Not in this PR

- Slice 22–25 (user-facing composite) — Jidoka: developer must read the reliability endpoint first.
- Slice 17.1 (pace R/D correction) — still blocked on a formula.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1964941-a56e-4ef5-a195-6029fc7dfda2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1964941-a56e-4ef5-a195-6029fc7dfda2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

