### PR TITLE
Compile wiki/path-Markdown anchor hrefs to note-show

### DIFF
--- a/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
+++ b/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
@@ -1,6 +1,6 @@
 # Compiled href for wiki / path-Markdown anchors
 
-**Status:** in progress (slice 1 done).
+**Status:** in progress (slices 1–2 done).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Depends on:** Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) wiki-destination clause (compiled `href`; concept path is not a Vue location). ADR wording for this policy is already in that draft — this plan is the product change.
 
@@ -10,7 +10,7 @@ Live path-Markdown anchors use the same compiled note-show `href` as live `[[wik
 
 ## Inspection
 
-Live `[[wiki]]` and live **body** path Markdown compile `href` via `noteShowHref`. Property-field path Markdown still uses the concept path as `href`. Unresolved wiki uses `#`; unresolved path Markdown still keeps the concept path. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings. Quill left-click `preventDefault`s; user-visible hole is middle-click / copy-link / open-in-new-tab, plus leftover click that misses `data-note-id`.
+Live `[[wiki]]` and live path Markdown (body and property field) compile `href` via `noteShowHref`. Unresolved wiki uses `#`; unresolved path Markdown still keeps the concept path. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings. Quill left-click `preventDefault`s; user-visible hole is middle-click / copy-link / open-in-new-tab, plus leftover click that misses `data-note-id`.
 
 `WikiLinkToken.vue` already uses named `noteShowLocation` / `href="#"`. Backend token parse is unchanged.
 
@@ -41,15 +41,13 @@ Verify with `CURSOR_DEV=true nix develop -c pnpm frontend:test` on the specs nam
 
 **Learning:** leftover in-session live tags with a concept-path `href` needed an extra replace (shared `livePathMarkdownAttrs`). Slice 3 still must match `href="#"` after unresolved wrapping.
 
-### 2. Live path-Markdown in a property field has a note-show href — Behavior `[ ]`
+### 2. Live path-Markdown in a property field has a note-show href — Behavior `[x]`
 
 **Pre:** A YAML property scalar (e.g. relationship `source`) is resolved path Markdown.
 **Trigger:** Render the property value field.
-**Post:** Live anchor `href` is `noteShowHref(id)`. Serialize still `[Moon](/Moon.md)` (or the authored token). No wiki brackets on path Markdown.
+**Post:** Live anchor `href` is `noteShowHref(id)`. Serialize still `[Moon](/Moon.md)`. No wiki brackets on path Markdown.
 
-Tests: `propertyValueField.spec.ts` live `/Moon.md` → `noteShowHref(42)` (round-trip markdown unchanged); `RichMarkdownEditor.propertyWikiLinks.spec.ts` relationship source live `href`.
-
-Production: `propertyValuePlainToDisplayHtml` path-Markdown live branch uses `noteShowHref(noteId)` instead of `target`. Unresolved in this function still uses the concept-path `href` until slice 3.
+**Done:** `propertyValuePlainToDisplayHtml` live path-Markdown uses `noteShowHref(noteId)`; unresolved still uses concept-path `href` until slice 3.
 
 ### 3. Unresolved path-Markdown href is `#` — Behavior `[ ]`
 

--- a/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
+++ b/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
@@ -1,76 +1,8 @@
 # Compiled href for wiki / path-Markdown anchors
 
-**Status:** in progress (slices 1–3 done).
+**Status:** complete.
 **Type:** ad-hoc plan (`.planning/quick/`)
-**Depends on:** Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) wiki-destination clause (compiled `href`; concept path is not a Vue location). ADR wording for this policy is already in that draft — this plan is the product change.
 
-## Goal
+Live path-Markdown anchors use `noteShowHref(id)`; unresolved use `href="#"`. Stored tokens stay ADR 0004 path Markdown (`data-wiki-title`). Leftover `#` and concept-path hrefs are not routed.
 
-Live path-Markdown anchors use the same compiled note-show `href` as live `[[wiki]]`. Unresolved path-Markdown uses `href="#"`. Stored tokens stay ADR 0004 path Markdown. Stop after any slice.
-
-## Inspection
-
-Live `[[wiki]]` and live path Markdown (body and property field) compile `href` via `noteShowHref`. Unresolved wiki and unresolved path Markdown use `href="#"`. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings, so a leftover concept-path or `#` can still be fed to the router. Quill left-click `preventDefault`s; remaining hole is leftover click that misses `data-note-id`.
-
-`WikiLinkToken.vue` already uses named `noteShowLocation` / `href="#"`. Backend token parse is unchanged.
-
-`path_markdown_link.feature` live outline asserts `expectNoteShowHref` via `the wiki link … should open`.
-
-## Design decisions
-
-- **No 0004 change.** Authored `[label](/folder/File.md)` stays. Serialize keeps using `data-wiki-title` (`wikiAnchorToMarkdownToken`), never the compiled `href`.
-- **One compiled `href` language in the DOM.** Live: `noteShowHref(id)`. Unresolved (dead / pending): `#`. Concept path only on `data-wiki-title` and in markdown.
-- **Do not classify by SPA-route denylist.** `hrefLooksLikeConceptNotePath` stays a token/inbound classifier (not note-show), not a `routeMetadata` mirror.
-- **Incoming HTML still has concept-path `href`s** from marked (`<a href="/Folder/Title.md">label</a>`) and from in-session Quill written before this change. `upgradePathMarkdownAnchors` must still match those inputs, then emit compiled `href`. After unresolved uses `#`, dead→live must also match `href="#"`.
-- **Surfaces in order:** note body (common), then property-field / relationship source (same rule, narrower precondition), then unresolved `href`, then click leftover.
-- **Not 011.** `.planning/quick/011-named-spa-route-honesty-follow-up/` is test-router / E2E visit honesty. Do not fold this in.
-
-## Slices
-
-Status legend: `[ ]` planned · `[~]` in progress · `[x]` done
-
-Verify with `CURSOR_DEV=true nix develop -c pnpm frontend:test` on the specs named in the slice. Slice 1 also runs `path_markdown_link.feature` (`cypress run --spec`). No full E2E suite.
-
-### 1. Live path-Markdown in note body has a note-show href — Behavior `[x]`
-
-**Pre:** Note body contains a resolved path-Markdown link (wikiTitles hit).
-**Trigger:** View the note as rich content.
-**Post:** The live anchor’s `href` is `noteShowHref(id)`. Stored markdown is still the path-Markdown token. Following the link still opens the target note.
-
-**Done:** `upgradePathMarkdownAnchors` emits `noteShowHref(w.noteId)` and still matches marked concept-path `<a href>` plus leftover live/dead tags whose `href` is the concept path. Serialize still uses `data-wiki-title`.
-
-**Learning:** leftover in-session live tags with a concept-path `href` needed an extra replace (shared `livePathMarkdownAttrs`).
-
-### 2. Live path-Markdown in a property field has a note-show href — Behavior `[x]`
-
-**Pre:** A YAML property scalar (e.g. relationship `source`) is resolved path Markdown.
-**Trigger:** Render the property value field.
-**Post:** Live anchor `href` is `noteShowHref(id)`. Serialize still `[Moon](/Moon.md)`. No wiki brackets on path Markdown.
-
-**Done:** `propertyValuePlainToDisplayHtml` live path-Markdown uses `noteShowHref(noteId)`.
-
-### 3. Unresolved path-Markdown href is `#` — Behavior `[x]`
-
-**Pre:** Path Markdown in body or property field does not resolve (dead or pending).
-**Trigger:** Render rich content / property field.
-**Post:** Unresolved anchor `href` is `#`. `data-wiki-title` is still the concept path. Serialize still path Markdown.
-
-**Done:** `markUnresolvedWikiLinks` and property-field unresolved path Markdown emit `href="#"`. `upgradePathMarkdownAnchors` upgrades leftover concept-path and `href="#"` dead/pending tags to live `noteShowHref`.
-
-### 4. Concept-path and `#` hrefs are not routed — Behavior `[ ]`
-
-**Pre:** A rich-content anchor is not a dead/pending wiki handler hit and not a live `data-note-id` wiki link.
-**Trigger:** Click (the existing capture `preventDefault` + `handleRichContentAnchorClick`).
-**Post:** `href="#"` and concept-path `href`s do not call `navigateInApp`. `http(s)` still opens a tab. Live wiki with `data-note-id` still uses `noteShowLocation`.
-
-Test: `wikiLinkMarkup.spec.ts` — extend `handleRichContentAnchorClick` (concept path / `#` must not navigate; keep the existing path-Markdown + `data-note-id` case). Production: leftover branch in `handleRichContentAnchorClick` skips `#` and `hrefLooksLikeConceptNotePath`. Do not push a raw concept path. Optional: leftover note-show path strings become `noteShowLocation` instead of `navigateInApp(href)` if that stays a small change in this slice; if not, leave string push for real note-show hrefs only.
-
-## Out of scope
-
-- Requiring `.md` on path-Markdown (0004 tightening)
-- Changing compact `/n:id` or SPA prefixes
-- Teaching `hrefLooksLikeConceptNotePath` a `routeMetadata` denylist
-- ADR 0004; accepting ADR 0005 (human)
-- Plan 011 named-route honesty follow-up / E2E visit paths
-- `WikiLinkToken.vue` (already named `:to` / `href="#"`)
-- Backend `WikiLinkMarkdown` token parse
+Product: `replaceWikiLinksInHtml.ts`, `propertyValueField.ts`, `handleRichContentAnchorClick` in `wikiLinkMarkup.ts`. Policy text: Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) wiki-destination clause (not accepted by this plan).

--- a/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
+++ b/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
@@ -1,6 +1,6 @@
 # Compiled href for wiki / path-Markdown anchors
 
-**Status:** in progress (slices 1–2 done).
+**Status:** in progress (slices 1–3 done).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Depends on:** Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) wiki-destination clause (compiled `href`; concept path is not a Vue location). ADR wording for this policy is already in that draft — this plan is the product change.
 
@@ -10,7 +10,7 @@ Live path-Markdown anchors use the same compiled note-show `href` as live `[[wik
 
 ## Inspection
 
-Live `[[wiki]]` and live path Markdown (body and property field) compile `href` via `noteShowHref`. Unresolved wiki uses `#`; unresolved path Markdown still keeps the concept path. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings. Quill left-click `preventDefault`s; user-visible hole is middle-click / copy-link / open-in-new-tab, plus leftover click that misses `data-note-id`.
+Live `[[wiki]]` and live path Markdown (body and property field) compile `href` via `noteShowHref`. Unresolved wiki and unresolved path Markdown use `href="#"`. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings, so a leftover concept-path or `#` can still be fed to the router. Quill left-click `preventDefault`s; remaining hole is leftover click that misses `data-note-id`.
 
 `WikiLinkToken.vue` already uses named `noteShowLocation` / `href="#"`. Backend token parse is unchanged.
 
@@ -39,7 +39,7 @@ Verify with `CURSOR_DEV=true nix develop -c pnpm frontend:test` on the specs nam
 
 **Done:** `upgradePathMarkdownAnchors` emits `noteShowHref(w.noteId)` and still matches marked concept-path `<a href>` plus leftover live/dead tags whose `href` is the concept path. Serialize still uses `data-wiki-title`.
 
-**Learning:** leftover in-session live tags with a concept-path `href` needed an extra replace (shared `livePathMarkdownAttrs`). Slice 3 still must match `href="#"` after unresolved wrapping.
+**Learning:** leftover in-session live tags with a concept-path `href` needed an extra replace (shared `livePathMarkdownAttrs`).
 
 ### 2. Live path-Markdown in a property field has a note-show href — Behavior `[x]`
 
@@ -47,17 +47,15 @@ Verify with `CURSOR_DEV=true nix develop -c pnpm frontend:test` on the specs nam
 **Trigger:** Render the property value field.
 **Post:** Live anchor `href` is `noteShowHref(id)`. Serialize still `[Moon](/Moon.md)`. No wiki brackets on path Markdown.
 
-**Done:** `propertyValuePlainToDisplayHtml` live path-Markdown uses `noteShowHref(noteId)`; unresolved still uses concept-path `href` until slice 3.
+**Done:** `propertyValuePlainToDisplayHtml` live path-Markdown uses `noteShowHref(noteId)`.
 
-### 3. Unresolved path-Markdown href is `#` — Behavior `[ ]`
+### 3. Unresolved path-Markdown href is `#` — Behavior `[x]`
 
 **Pre:** Path Markdown in body or property field does not resolve (dead or pending).
 **Trigger:** Render rich content / property field.
-**Post:** Unresolved anchor `href` is `#` (same as unresolved `[[wiki]]`). `data-wiki-title` is still the concept path. Serialize still path Markdown. Dead click still opens the dead-wiki flow, not a route.
+**Post:** Unresolved anchor `href` is `#`. `data-wiki-title` is still the concept path. Serialize still path Markdown.
 
-Tests: `NoteTextContent.wikiLinks.spec.ts` unresolved path Markdown (add `href="#"`); `propertyValueField.spec.ts` unresolved `href="/Moon.md"` → `href="#"` (keep `not.toContain("/n")` for unresolved); `replaceWikiLinksInHtml` / `quillHtmlToMarkdown` unresolved path Markdown round-trip after wrap. Dead→live still upgrades when wikiTitles arrive (`upgradePathMarkdownAnchors` must match dead/pending tags with `href="#"` as well as leftover concept-path `href`s).
-
-Production: `markUnresolvedWikiLinks` and property-field unresolved path Markdown pass `href: "#"`.
+**Done:** `markUnresolvedWikiLinks` and property-field unresolved path Markdown emit `href="#"`. `upgradePathMarkdownAnchors` upgrades leftover concept-path and `href="#"` dead/pending tags to live `noteShowHref`.
 
 ### 4. Concept-path and `#` hrefs are not routed — Behavior `[ ]`
 

--- a/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
+++ b/.planning/quick/012-wiki-anchor-compiled-href/PLAN.md
@@ -1,8 +1,7 @@
 # Compiled href for wiki / path-Markdown anchors
 
-**Status:** planned, not started.
+**Status:** in progress (slice 1 done).
 **Type:** ad-hoc plan (`.planning/quick/`)
-**Do not execute until the developer approves.**
 **Depends on:** Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) wiki-destination clause (compiled `href`; concept path is not a Vue location). ADR wording for this policy is already in that draft — this plan is the product change.
 
 ## Goal
@@ -11,11 +10,11 @@ Live path-Markdown anchors use the same compiled note-show `href` as live `[[wik
 
 ## Inspection
 
-Today live `[[wiki]]` compiles `href` via `noteShowHref`. Live path Markdown keeps the bundle-relative path as `href` (`/Folder/Title.md`). Unresolved wiki uses `#`; unresolved path Markdown keeps the concept path. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings, so a concept path can be fed to the router. Quill left-click `preventDefault`s, so the user-visible hole is middle-click / copy-link / open-in-new-tab, plus any leftover click that misses `data-note-id`.
+Live `[[wiki]]` and live **body** path Markdown compile `href` via `noteShowHref`. Property-field path Markdown still uses the concept path as `href`. Unresolved wiki uses `#`; unresolved path Markdown still keeps the concept path. `handleRichContentAnchorClick` still `navigateInApp(href)` for leftover non-http strings. Quill left-click `preventDefault`s; user-visible hole is middle-click / copy-link / open-in-new-tab, plus leftover click that misses `data-note-id`.
 
 `WikiLinkToken.vue` already uses named `noteShowLocation` / `href="#"`. Backend token parse is unchanged.
 
-Existing E2E `path_markdown_link.feature` follows live path Markdown but uses `following the wiki link`, which does **not** assert `href`. Wiki spelling already has `the wiki link … should open the note titled …` (`expectNoteShowHref`).
+`path_markdown_link.feature` live outline asserts `expectNoteShowHref` via `the wiki link … should open`.
 
 ## Design decisions
 
@@ -32,15 +31,15 @@ Status legend: `[ ]` planned · `[~]` in progress · `[x]` done
 
 Verify with `CURSOR_DEV=true nix develop -c pnpm frontend:test` on the specs named in the slice. Slice 1 also runs `path_markdown_link.feature` (`cypress run --spec`). No full E2E suite.
 
-### 1. Live path-Markdown in note body has a note-show href — Behavior `[ ]`
+### 1. Live path-Markdown in note body has a note-show href — Behavior `[x]`
 
 **Pre:** Note body contains a resolved path-Markdown link (wikiTitles hit).
 **Trigger:** View the note as rich content.
-**Post:** The live anchor’s `href` is `noteShowHref(id)` (same shape as live `[[wiki]]`). Stored markdown is still the path-Markdown token. Following the link still opens the target note.
+**Post:** The live anchor’s `href` is `noteShowHref(id)`. Stored markdown is still the path-Markdown token. Following the link still opens the target note.
 
-Tests first: `NoteTextContent.wikiLinks.spec.ts` (live path Markdown `href` is `/Folder/Title.md` today); `replaceWikiLinksInHtml.spec.ts` (dead→live path Markdown expected `href`). E2E: in `e2e_test/features/note_topology/path_markdown_link.feature`, the live outline uses `following the wiki link` — switch that Then to `the wiki link "<display>" should open the note titled "<target_title>"` so `expectNoteShowHref` runs (existing step; will fail until production changes). `quillHtmlToMarkdown.spec.ts`: keep inbound fixtures that still have a concept-path `href`; add or adjust that a live tag with `noteShowHref` + `data-wiki-title` still serializes to `[label](/Folder/Title.md)`.
+**Done:** `upgradePathMarkdownAnchors` emits `noteShowHref(w.noteId)` and still matches marked concept-path `<a href>` plus leftover live/dead tags whose `href` is the concept path. Serialize still uses `data-wiki-title`.
 
-Production: `upgradePathMarkdownAnchors` live `href` is `noteShowHref(w.noteId)`. Still match marked `<a href="{concept}">` and existing live/dead tags whose `href` is still the concept path. Do not change unresolved wrapping yet.
+**Learning:** leftover in-session live tags with a concept-path `href` needed an extra replace (shared `livePathMarkdownAttrs`). Slice 3 still must match `href="#"` after unresolved wrapping.
 
 ### 2. Live path-Markdown in a property field has a note-show href — Behavior `[ ]`
 
@@ -72,7 +71,6 @@ Test: `wikiLinkMarkup.spec.ts` — extend `handleRichContentAnchorClick` (concep
 
 ## Out of scope
 
-- Executing this plan until the developer approves
 - Requiring `.md` on path-Markdown (0004 tightening)
 - Changing compact `/n:id` or SPA prefixes
 - Teaching `hrefLooksLikeConceptNotePath` a `routeMetadata` denylist

--- a/e2e_test/features/note_topology/path_markdown_link.feature
+++ b/e2e_test/features/note_topology/path_markdown_link.feature
@@ -22,7 +22,7 @@ Feature: Path Markdown links in notes
     Then the note content markdown source should contain "<markdown>"
     And the note content markdown source should not contain "[[<display>]]"
     When I view the note content as rich content
-    Then following the wiki link "<display>" should open the note titled "<target_title>"
+    Then the wiki link "<display>" should open the note titled "<target_title>"
     And the note content on the current page should be "<target_content>"
 
     Examples:

--- a/frontend/src/components/form/replaceWikiLinksInHtml.ts
+++ b/frontend/src/components/form/replaceWikiLinksInHtml.ts
@@ -149,12 +149,15 @@ function upgradePathMarkdownAnchors(
     if (!isPathMarkdownWikiTitle(w)) continue
     const { target, display } = wikiTitleParts(w)
     const attrTarget = escapeHtmlAttributeValue(target)
-    const live = wikiLinkAnchorHtml({
-      href: target,
+    const livePathMarkdownAttrs = {
       className: DONUT_WIKI_LINK_CLASS,
       target,
       display,
       noteId: w.noteId,
+    }
+    const live = wikiLinkAnchorHtml({
+      href: noteShowHref(w.noteId),
+      ...livePathMarkdownAttrs,
     })
     result = result.replaceAll(`<a href="${attrTarget}">${display}</a>`, live)
     result = result.replaceAll(
@@ -164,6 +167,10 @@ function upgradePathMarkdownAnchors(
         target,
         display,
       }),
+      live
+    )
+    result = result.replaceAll(
+      wikiLinkAnchorHtml({ href: target, ...livePathMarkdownAttrs }),
       live
     )
   }

--- a/frontend/src/components/form/replaceWikiLinksInHtml.ts
+++ b/frontend/src/components/form/replaceWikiLinksInHtml.ts
@@ -22,6 +22,11 @@ import {
   wikiTitleParts,
 } from "@/utils/wikiLinkMarkup"
 
+const UNRESOLVED_WIKI_LINK_CLASSES = [
+  DEAD_WIKI_LINK_CLASS,
+  PENDING_WIKI_LINK_CLASS,
+] as const
+
 function authoredTokenFromWikiAnchor(anchor: Element): string {
   const target = anchor.getAttribute("data-wiki-title") ?? ""
   if (hrefLooksLikeConceptNotePath(target)) {
@@ -65,14 +70,13 @@ function upgradeUnresolvedWikiAnchors(
   wikiTitles: WikiTitle[]
 ): string {
   if (wikiTitles.length === 0) return html
-  const unresolvedClasses = [DEAD_WIKI_LINK_CLASS, PENDING_WIKI_LINK_CLASS]
-  if (!unresolvedClasses.some((c) => html.includes(c))) return html
+  if (!UNRESOLVED_WIKI_LINK_CLASSES.some((c) => html.includes(c))) return html
   const parsed = parseWikiHtmlFragment(html)
   if (!parsed) return html
   const { wrap } = parsed
-  const unresolvedAnchorSelector = unresolvedClasses
-    .map((c) => `a.${c}`)
-    .join(", ")
+  const unresolvedAnchorSelector = UNRESOLVED_WIKI_LINK_CLASSES.map(
+    (c) => `a.${c}`
+  ).join(", ")
 
   for (const w of wikiTitles) {
     if (isPathMarkdownWikiTitle(w)) continue
@@ -160,15 +164,20 @@ function upgradePathMarkdownAnchors(
       ...livePathMarkdownAttrs,
     })
     result = result.replaceAll(`<a href="${attrTarget}">${display}</a>`, live)
-    result = result.replaceAll(
-      wikiLinkAnchorHtml({
-        href: target,
-        className: DEAD_WIKI_LINK_CLASS,
-        target,
-        display,
-      }),
-      live
-    )
+    const leftoverUnresolvedHrefs = [target, "#"]
+    for (const leftoverHref of leftoverUnresolvedHrefs) {
+      for (const className of UNRESOLVED_WIKI_LINK_CLASSES) {
+        result = result.replaceAll(
+          wikiLinkAnchorHtml({
+            href: leftoverHref,
+            className,
+            target,
+            display,
+          }),
+          live
+        )
+      }
+    }
     result = result.replaceAll(
       wikiLinkAnchorHtml({ href: target, ...livePathMarkdownAttrs }),
       live
@@ -193,7 +202,7 @@ function markUnresolvedWikiLinks(
       if (!hrefLooksLikeConceptNotePath(href)) return full
       const token = `[${display}](${href})`
       return wikiLinkAnchorHtml({
-        href,
+        href: "#",
         className: unresolvedWikiClass(token, lastSavedTokens),
         target: href,
         display,

--- a/frontend/src/utils/propertyValueField.ts
+++ b/frontend/src/utils/propertyValueField.ts
@@ -48,7 +48,7 @@ export function propertyValuePlainToDisplayHtml(
       const { target, display } = splitAuthoredToken(occ.token)
       const noteId = noteIdForAuthoredToken(occ.token, map)
       out += wikiLinkAnchorHtml({
-        href: noteId !== undefined ? noteShowHref(noteId) : target,
+        href: noteId !== undefined ? noteShowHref(noteId) : "#",
         className:
           noteId === undefined
             ? unresolvedWikiClass(occ.token, lastSavedTokens)

--- a/frontend/src/utils/propertyValueField.ts
+++ b/frontend/src/utils/propertyValueField.ts
@@ -27,7 +27,7 @@ import {
 /**
  * Renders a YAML property scalar with clickable wiki and path-Markdown links.
  * Well-formed wiki `[[title]]` uses bracket UI; path Markdown uses the same
- * live/dead/pending wiki-link classes as body path links (plain display, path href).
+ * live/dead/pending wiki-link classes as body path links (plain display).
  */
 export function propertyValuePlainToDisplayHtml(
   plain: string,
@@ -48,7 +48,7 @@ export function propertyValuePlainToDisplayHtml(
       const { target, display } = splitAuthoredToken(occ.token)
       const noteId = noteIdForAuthoredToken(occ.token, map)
       out += wikiLinkAnchorHtml({
-        href: target,
+        href: noteId !== undefined ? noteShowHref(noteId) : target,
         className:
           noteId === undefined
             ? unresolvedWikiClass(occ.token, lastSavedTokens)

--- a/frontend/src/utils/wikiLinkMarkup.ts
+++ b/frontend/src/utils/wikiLinkMarkup.ts
@@ -149,6 +149,7 @@ export function handleRichContentAnchorClick(
     window.open(href, "_blank", "noopener,noreferrer")
     return
   }
+  if (href === "#" || hrefLooksLikeConceptNotePath(href)) return
   handlers.navigateInApp(href)
 }
 

--- a/frontend/tests/components/form/RichMarkdownEditor.propertyWikiLinks.spec.ts
+++ b/frontend/tests/components/form/RichMarkdownEditor.propertyWikiLinks.spec.ts
@@ -78,7 +78,7 @@ Body`
     const live = wrapper
       .find(propertyRowSelector("source"))
       .element.querySelector("a.donut-wiki-link") as HTMLAnchorElement
-    expect(live.getAttribute("href")).toBe("/Moon.md")
+    expect(live.getAttribute("href")).toBe(noteShowHref(42))
     expect(live.textContent).toBe("Moon")
     expect(live.querySelector(".wiki-bracket")).toBeNull()
   })

--- a/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
+++ b/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 import htmlToMarkdown from "@/components/form/quillHtmlToMarkdown"
 import { replaceWikiLinksInHtml } from "@/components/form/replaceWikiLinksInHtml"
+import { noteShowHref } from "@/routes/noteShowLocation"
 import { wikiTitleFromAuthoredToken } from "@/utils/wikiLinkMarkup"
 
 describe("quillHtmlToMarkdown", () => {
@@ -57,6 +58,7 @@ describe("quillHtmlToMarkdown", () => {
     ${"converts pending wiki anchors"}                | ${'<p><a href="#" class="pending-wiki-link" data-wiki-title="Unknown">Unknown</a></p>'}                                                                      | ${"[[Unknown]]"}
     ${"donut-wiki-link with piped wiki attrs"}        | ${'<p><a href="/n1" class="donut-wiki-link" data-wiki-title="A" data-wiki-display="B">B</a></p>'}                                                            | ${"[[A|B]]"}
     ${"path markdown donut-wiki-link keeps markdown"} | ${'<p><a href="/Folder/Title.md" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>'}      | ${"[label](/Folder/Title.md)"}
+    ${"live path markdown with noteShowHref"}         | ${`<p><a href="${noteShowHref(42)}" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>`}   | ${"[label](/Folder/Title.md)"}
     ${"path markdown without .md keeps href"}         | ${'<p><a href="/Folder/Title" class="donut-wiki-link" data-wiki-title="/Folder/Title" data-wiki-display="label">label</a></p>'}                              | ${"[label](/Folder/Title)"}
     ${"path markdown dead-wiki-link keeps markdown"}  | ${'<p><a href="/Folder/Missing.md" class="dead-wiki-link" data-wiki-title="/Folder/Missing.md" data-wiki-display="label">label</a></p>'}                     | ${"[label](/Folder/Missing.md)"}
   `("wiki links: $label", ({ html, expected }) => {

--- a/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
+++ b/frontend/tests/components/form/quillHtmlToMarkdown.spec.ts
@@ -61,6 +61,7 @@ describe("quillHtmlToMarkdown", () => {
     ${"live path markdown with noteShowHref"}         | ${`<p><a href="${noteShowHref(42)}" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>`}   | ${"[label](/Folder/Title.md)"}
     ${"path markdown without .md keeps href"}         | ${'<p><a href="/Folder/Title" class="donut-wiki-link" data-wiki-title="/Folder/Title" data-wiki-display="label">label</a></p>'}                              | ${"[label](/Folder/Title)"}
     ${"path markdown dead-wiki-link keeps markdown"}  | ${'<p><a href="/Folder/Missing.md" class="dead-wiki-link" data-wiki-title="/Folder/Missing.md" data-wiki-display="label">label</a></p>'}                     | ${"[label](/Folder/Missing.md)"}
+    ${"path markdown dead with hash href"}            | ${'<p><a href="#" class="dead-wiki-link" data-wiki-title="/Folder/Missing.md" data-wiki-display="label">label</a></p>'}                                      | ${"[label](/Folder/Missing.md)"}
   `("wiki links: $label", ({ html, expected }) => {
     expect(htmlToMarkdown(html)).toBe(expected)
   })

--- a/frontend/tests/components/form/replaceWikiLinksInHtml.spec.ts
+++ b/frontend/tests/components/form/replaceWikiLinksInHtml.spec.ts
@@ -41,16 +41,22 @@ describe("replaceWikiLinksInHtml", () => {
     )
   })
 
-  it("upgrades dead path markdown anchors to live when wikiTitles resolve", () => {
-    expect(
-      replaceWikiLinksInHtml(
-        '<p><a href="/Folder/Title.md" class="dead-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>',
-        [wikiTitleFromAuthoredToken("[label](/Folder/Title.md)", 42)]
+  it.each`
+    label                                     | html
+    ${"dead"}                                 | ${'<p><a href="/Folder/Title.md" class="dead-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
+    ${"leftover live with concept-path href"} | ${'<p><a href="/Folder/Title.md" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>'}
+  `(
+    "upgrades $label path markdown anchors to a note-show href when wikiTitles resolve",
+    ({ html }) => {
+      expect(
+        replaceWikiLinksInHtml(html, [
+          wikiTitleFromAuthoredToken("[label](/Folder/Title.md)", 42),
+        ])
+      ).toBe(
+        `<p><a href="${noteShowHref(42)}" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>`
       )
-    ).toBe(
-      '<p><a href="/Folder/Title.md" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>'
-    )
-  })
+    }
+  )
 
   it("preserves Quill hr markup without rewriting through DOMParser", () => {
     const quillHr = "<p><hr></p>"

--- a/frontend/tests/components/form/replaceWikiLinksInHtml.spec.ts
+++ b/frontend/tests/components/form/replaceWikiLinksInHtml.spec.ts
@@ -41,10 +41,21 @@ describe("replaceWikiLinksInHtml", () => {
     )
   })
 
+  it("marks leftover concept-path anchors as unresolved wiki links with hash href", () => {
+    expect(
+      replaceWikiLinksInHtml('<p><a href="/Folder/Missing.md">label</a></p>', [])
+    ).toBe(
+      '<p><a href="#" class="dead-wiki-link" data-wiki-title="/Folder/Missing.md" data-wiki-display="label">label</a></p>'
+    )
+  })
+
   it.each`
-    label                                     | html
-    ${"dead"}                                 | ${'<p><a href="/Folder/Title.md" class="dead-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
-    ${"leftover live with concept-path href"} | ${'<p><a href="/Folder/Title.md" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>'}
+    label                                         | html
+    ${"leftover dead with concept-path href"}     | ${'<p><a href="/Folder/Title.md" class="dead-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
+    ${"leftover pending with concept-path href"}  | ${'<p><a href="/Folder/Title.md" class="pending-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
+    ${"dead with hash href"}                      | ${'<p><a href="#" class="dead-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
+    ${"pending with hash href"}                   | ${'<p><a href="#" class="pending-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label">label</a></p>'}
+    ${"leftover live with concept-path href"}     | ${'<p><a href="/Folder/Title.md" class="donut-wiki-link" data-wiki-title="/Folder/Title.md" data-wiki-display="label" data-note-id="42">label</a></p>'}
   `(
     "upgrades $label path markdown anchors to a note-show href when wikiTitles resolve",
     ({ html }) => {

--- a/frontend/tests/notes/NoteTextContent.wikiLinks.spec.ts
+++ b/frontend/tests/notes/NoteTextContent.wikiLinks.spec.ts
@@ -103,7 +103,7 @@ describe("NoteTextContent wiki link display", () => {
       ".ql-editor a.donut-wiki-link"
     ) as HTMLAnchorElement
     expect(live.textContent).toContain("label")
-    expect(live.getAttribute("href")).toBe("/Folder/Title.md")
+    expect(live.getAttribute("href")).toBe(noteShowHref(targetNote.id!))
     expect(live.getAttribute("data-note-id")).toBe(String(targetNote.id))
   })
 

--- a/frontend/tests/notes/NoteTextContent.wikiLinks.spec.ts
+++ b/frontend/tests/notes/NoteTextContent.wikiLinks.spec.ts
@@ -78,6 +78,7 @@ describe("NoteTextContent wiki link display", () => {
       ".ql-editor a.dead-wiki-link"
     ) as HTMLAnchorElement
     expect(dead.textContent).toContain("label")
+    expect(dead.getAttribute("href")).toBe("#")
     expect(dead.getAttribute("data-wiki-title")).toBe("/Folder/Missing.md")
   })
 

--- a/frontend/tests/utils/propertyValueField.spec.ts
+++ b/frontend/tests/utils/propertyValueField.spec.ts
@@ -67,11 +67,9 @@ describe("propertyValueField utils", () => {
 
   it("renders unresolved path Markdown in a scalar as a dead wiki-style link", () => {
     const html = propertyValuePlainToDisplayHtml("[Moon](/Moon.md)", [])
-    expect(html).toContain('class="dead-wiki-link"')
-    expect(html).toContain('href="/Moon.md"')
-    expect(html).not.toContain("donut-wiki-link")
-    expect(html).not.toContain("wiki-bracket")
-    expect(html).not.toContain("/n")
+    expect(html).toBe(
+      '<a href="#" class="dead-wiki-link" data-wiki-title="/Moon.md" data-wiki-display="Moon">Moon</a>'
+    )
   })
 
   it("round-trips path Markdown from a field root without converting to wiki", () => {

--- a/frontend/tests/utils/propertyValueField.spec.ts
+++ b/frontend/tests/utils/propertyValueField.spec.ts
@@ -61,7 +61,7 @@ describe("propertyValueField utils", () => {
       wikiTitleFromAuthoredToken("[Moon](/Moon.md)", 42),
     ])
     expect(html).toBe(
-      '<a href="/Moon.md" class="donut-wiki-link" data-wiki-title="/Moon.md" data-wiki-display="Moon" data-note-id="42">Moon</a>'
+      `<a href="${noteShowHref(42)}" class="donut-wiki-link" data-wiki-title="/Moon.md" data-wiki-display="Moon" data-note-id="42">Moon</a>`
     )
   })
 

--- a/frontend/tests/utils/wikiLinkMarkup.spec.ts
+++ b/frontend/tests/utils/wikiLinkMarkup.spec.ts
@@ -52,6 +52,29 @@ describe("wikiLinkMarkup utils", () => {
     expect(navigated).toEqual(noteShowLocation(42))
   })
 
+  it.each([
+    { href: "#", kind: "hash" },
+    { href: "/Folder/Title.md", kind: "concept-path" },
+  ])(
+    "handleRichContentAnchorClick does not navigate leftover $kind hrefs",
+    ({ href }) => {
+      const anchor = document.createElement("a")
+      anchor.setAttribute("href", href)
+      handleRichContentAnchorClick(
+        anchor,
+        {
+          onDeadWikiLink: () => {
+            throw new Error("should not treat as dead")
+          },
+          navigateInApp: () => {
+            throw new Error("should not navigate")
+          },
+        },
+        { deadWikiLinksEnabled: true }
+      )
+    }
+  )
+
   it("markdownWikiTokenFromDeadWikiLinkPayload matches simple and piped stored tokens", () => {
     expect(
       markdownWikiTokenFromDeadWikiLinkPayload({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live path-Markdown anchors use the same compiled note-show `href` as live `[[wiki]]`. Unresolved path Markdown uses `href="#"`. Stored tokens stay ADR 0004 path Markdown (`data-wiki-title`), not SPA URLs. Leftover `#` and concept-path hrefs are not routed.

Implements the wiki-destination clause of Proposed [ADR 0005](docs/adrs/0005-web-routes.md). Does not accept that ADR.

Plan: `.planning/quick/012-wiki-anchor-compiled-href/PLAN.md` (complete)

## Slices

- **Live body:** path-Markdown in the note body uses `noteShowHref(id)`. Incoming marked/leftover concept-path `href`s still match, then compile. E2E live outline asserts `expectNoteShowHref`.
- **Live property field:** YAML property scalars (including relationship source) use `noteShowHref(id)`. Serialize still `[Moon](/Moon.md)`.
- **Unresolved:** dead/pending path Markdown uses `href="#"`. Dead→live upgrade also matches leftover hash hrefs.
- **Click leftover:** `handleRichContentAnchorClick` does not `navigateInApp` for `#` or concept-path hrefs. Live wiki with `data-note-id` still uses `noteShowLocation`. Leftover real note-show hrefs still string-push (no compact-id parser).

## Out of scope

- Requiring `.md` on path-Markdown
- Plan 011 named-route honesty
- `WikiLinkToken.vue` (already named `:to` / `href="#"`)
- Backend token parse
- Accepting ADR 0005 (human)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b657e00e-be38-4abc-8e8c-7b7a9bb89f99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b657e00e-be38-4abc-8e8c-7b7a9bb89f99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

