### PR TITLE
feat(e2e): named SPA push for logged-in Given shortcuts

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,9 +6,9 @@ current_phase: null
 current_phase_name: null
 status: ready
 stopped_at: null
-last_updated: "2026-08-30T00:19:00Z"
+last_updated: "2026-08-30T02:00:00Z"
 last_activity: 2026-08-30
-last_activity_desc: "015 SPA hydrate-after-inject shipped; 014 remaining visitNamed→push slices gated like 015"
+last_activity_desc: "014 named SPA push leftovers shipped; 013 noteProperty path still planned"
 progress:
   total_phases: 0
   completed_phases: 0
@@ -36,7 +36,7 @@ Daily probe measurement (not an ADR): [daily-probe-protocol.md](notes/daily-prob
 ## Operator Next Steps
 
 - Canonical property path (`noteProperty`, `#prop:` wiki): `.planning/quick/013-note-property-canonical-path/PLAN.md` (planned, not started). Policy already in ADR 0001 / ADR 0004 / Proposed 0005.
-- Named SPA route honesty leftovers (Given shortcuts as named `push`): `.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md` (slices 2–5 remaining). Speed gate on each `visitNamed` → `push` slice (015 formula). 011 and 015 are shipped; those PLANs are retired.
+- Named SPA route honesty leftovers (Given shortcuts as named `push`) shipped; 011 / 014 / 015 PLANs retired. Recall/epub/identify/`circleJoin`/`loginAs`/`visitHomePage` stay `visitNamed`.
 - After deploying the Flyway squash, confirm startup succeeded and `flyway_schema_history` shows the baseline repaired, the collapsed versions marked `DELETE`, and `V300000300` applied.
 
 Parked work: SEED-001, SEED-002, SEED-005, SEED-006, SEED-007, SEED-008; ADR 0002 Level 1. See [ROADMAP.md](ROADMAP.md).

--- a/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
+++ b/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
@@ -1,6 +1,6 @@
 # Named SPA route honesty cleanup
 
-**Status:** in progress (slices 1, 2, and 6 done; 3–5 remaining).
+**Status:** in progress (slices 1–3 and 6 done; 4–5 remaining).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Depends on:** shipped `.planning/quick/011-named-spa-route-honesty-follow-up/` (PLAN retired; named visit gate, `namedLocationHref`, Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) E2E table remain on `main`); shipped `.planning/quick/015-spa-hydrate-after-testability-inject/` (PLAN retired 2026-08-29)
 
@@ -8,7 +8,7 @@
 
 Close leftovers from 011: **dead E2E** and the ADR table’s **later-jump = named `push`** (slice 10 still `visitNamed`s most Given shortcuts). Operator STATE no longer points at the retired 011 PLAN (spent-plan cleanup 2026-08-29). Do not reopen unit-wiki HTML pinning, recall remount, or ADR accept.
 
-**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left settings / circles / admin `visitNamed` for this plan. Bazaar after login now `push`es (slice 2). Named `push` after login was **not slower** on 015’s timer specs or slice 2’s bazaar timer.
+**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left circles / admin `visitNamed` for this plan. Bazaar and settings Given shortcuts now `push` after login (slices 2–3). Named `push` after login was **not slower** on 015’s timer specs or slices 2–3.
 
 ## Inspection (011 on `main`)
 
@@ -23,8 +23,8 @@ Scope: 011’s route-honesty commits (unit leftovers + E2E gate + ADR rewrite), 
    | Helper | Today | After |
    |---|---|---|
    | `navigateToBazaar` | `push('bazaar')` (slice 2) | — |
-   | `visitManageAccessTokensPage` | `visitNamed('settingsAccessTokens')` | `push` |
-   | `visitRecallStatsPage` | `visitNamed('settingsRecallStats')` | `push` |
+   | `visitManageAccessTokensPage` | `push('settingsAccessTokens')` (slice 3) | — |
+   | `visitRecallStatsPage` | `push('settingsRecallStats')` (slice 3) | — |
    | `navigateToCircle` list/show | `visitNamed('circles'` / `'circleShow')` | `push` |
    | Admin tab | `visitNamed('adminDashboard', {}, { tab })` | `push` with query |
    | Join flow `circleShow` | `visitNamed` | `push` |
@@ -94,13 +94,15 @@ Deleted unused create-and-copy step, `myCirclesPage.ts`, `start.navigateToMyCirc
 
 ---
 
-### 3. Settings Given shortcuts use named push — Behavior `[ ]`
+### 3. Settings Given shortcuts use named push — Behavior `[x]`
 
-**Timing:** yes — both verify specs (two helpers; bazaar timer does not cover them). 3-run baseline at start per spec, then 3 greens each.
+`visitManageAccessTokensPage` → `push('settingsAccessTokens')`. `visitRecallStatsPage` → `push('settingsRecallStats')`. No remount marker (bazaar’s stays local). Settings tabs are not KeepAlive.
 
-**Pre:** logged-in SPA. **Trigger:** open access tokens or recall stats (existing Gherkin). **Post:** those screens as today; `visitManageAccessTokensPage` / `visitRecallStatsPage` use `push`.
+**Timing** (`stats.duration` median of 3):
+- `user_access_token.feature`: 2.568s → 2.013s (threshold 5.568s). **Pass** (faster).
+- Plan-named `recall_stats.feature` is entirely `@wip` (unrelated SDK sequencing race; out of scope). Live timer: `daily_probe.feature` (same `I visit my recall stats` step): 16.339s → 15.263s (threshold 19.339s). **Pass** (faster).
 
-**Verify:** `e2e_test/features/users/user_access_token.feature` and `e2e_test/features/recall/recall_stats.feature`. Record before/after medians in this PLAN.
+**Learning:** do not un-`@wip` `recall_stats.feature` in this plan. Later slices should pick a CI-runnable spec that actually hits the helper.
 
 ---
 

--- a/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
+++ b/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
@@ -1,6 +1,6 @@
 # Named SPA route honesty cleanup
 
-**Status:** in progress (slices 1 and 6 done; 2–5 remaining).
+**Status:** in progress (slices 1, 2, and 6 done; 3–5 remaining).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Depends on:** shipped `.planning/quick/011-named-spa-route-honesty-follow-up/` (PLAN retired; named visit gate, `namedLocationHref`, Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) E2E table remain on `main`); shipped `.planning/quick/015-spa-hydrate-after-testability-inject/` (PLAN retired 2026-08-29)
 
@@ -8,7 +8,7 @@
 
 Close leftovers from 011: **dead E2E** and the ADR table’s **later-jump = named `push`** (slice 10 still `visitNamed`s most Given shortcuts). Operator STATE no longer points at the retired 011 PLAN (spent-plan cleanup 2026-08-29). Do not reopen unit-wiki HTML pinning, recall remount, or ADR accept.
 
-**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left `bazaarPage.ts` / settings / circles / admin `visitNamed` for this plan. Named `push` after login was **not slower** on 015’s timer specs.
+**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left settings / circles / admin `visitNamed` for this plan. Bazaar after login now `push`es (slice 2). Named `push` after login was **not slower** on 015’s timer specs or slice 2’s bazaar timer.
 
 ## Inspection (011 on `main`)
 
@@ -22,7 +22,7 @@ Scope: 011’s route-honesty commits (unit leftovers + E2E gate + ADR rewrite), 
 
    | Helper | Today | After |
    |---|---|---|
-   | `navigateToBazaar` | `visitNamed('bazaar')` | `push` |
+   | `navigateToBazaar` | `push('bazaar')` (slice 2) | — |
    | `visitManageAccessTokensPage` | `visitNamed('settingsAccessTokens')` | `push` |
    | `visitRecallStatsPage` | `visitNamed('settingsRecallStats')` | `push` |
    | `navigateToCircle` list/show | `visitNamed('circles'` / `'circleShow')` | `push` |
@@ -84,13 +84,13 @@ Deleted unused create-and-copy step, `myCirclesPage.ts`, `start.navigateToMyCirc
 
 ---
 
-### 2. Bazaar after login uses named push — Behavior `[ ]`
+### 2. Bazaar after login uses named push — Behavior `[x]`
 
-**Timing:** yes — `e2e_test/features/bazaar/bazaar_subscription.feature` (3-run baseline at start, then 3 greens).
+`navigateToBazaar` uses `push('bazaar')`. After login, `__donutSpaDocumentMarker` is set on `window` in that helper and asserted to survive (no Gherkin about `window`). First load skips the marker (`push` → `visitNamed` fallback). Logged-out `browsing.feature` passed once.
 
-**Pre:** logged-in SPA (`loginAs` already `visitNamed`'d notebooks); `window` marker set. **Trigger:** visit the Bazaar (existing Given/When). **Post:** bazaar UI as today **and** the marker remains (no document remount). `navigateToBazaar` uses `push('bazaar')`. Logged-out bazaar still full-loads via `push` → `visitNamed` fallback. Bazaar-rooted `{notepath}` still catalog-walks after this helper (015).
+**Timing** (`bazaar_subscription.feature`, `stats.duration` median of 3): before 4.835s (6030, 4835, 4560 ms) → after 4.145s (4313, 3936, 4145 ms). Threshold 7.835s. **Pass** (faster). Marker stays local to bazaar — slices 3–5 do not copy it unless a remount is suspected.
 
-**Verify:** `bazaar_subscription.feature` (marker + subscribe). Once: `e2e_test/features/bazaar/browsing.feature` for logged-out remount fallback. Record before/after medians in this PLAN.
+**Learning:** no KeepAlive remount needed for bazaar; do not extract a shared marker helper for settings/circles/admin.
 
 ---
 

--- a/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
+++ b/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
@@ -1,6 +1,6 @@
 # Named SPA route honesty cleanup
 
-**Status:** in progress (slices 1–3 and 6 done; 4–5 remaining).
+**Status:** in progress (slices 1–4 and 6 done; 5 remaining).
 **Type:** ad-hoc plan (`.planning/quick/`)
 **Depends on:** shipped `.planning/quick/011-named-spa-route-honesty-follow-up/` (PLAN retired; named visit gate, `namedLocationHref`, Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) E2E table remain on `main`); shipped `.planning/quick/015-spa-hydrate-after-testability-inject/` (PLAN retired 2026-08-29)
 
@@ -8,7 +8,7 @@
 
 Close leftovers from 011: **dead E2E** and the ADR table’s **later-jump = named `push`** (slice 10 still `visitNamed`s most Given shortcuts). Operator STATE no longer points at the retired 011 PLAN (spent-plan cleanup 2026-08-29). Do not reopen unit-wiki HTML pinning, recall remount, or ADR accept.
 
-**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left circles / admin `visitNamed` for this plan. Bazaar and settings Given shortcuts now `push` after login (slices 2–3). Named `push` after login was **not slower** on 015’s timer specs or slices 2–3.
+**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left admin `visitNamed` for this plan. Bazaar, settings, and circles Given shortcuts now `push` after login (slices 2–4). Invitation join stays `visitNamed('circleJoin')`. Named `push` after login was **not slower** on 015’s timer specs or slices 2–4.
 
 ## Inspection (011 on `main`)
 
@@ -25,9 +25,9 @@ Scope: 011’s route-honesty commits (unit leftovers + E2E gate + ADR rewrite), 
    | `navigateToBazaar` | `push('bazaar')` (slice 2) | — |
    | `visitManageAccessTokensPage` | `push('settingsAccessTokens')` (slice 3) | — |
    | `visitRecallStatsPage` | `push('settingsRecallStats')` (slice 3) | — |
-   | `navigateToCircle` list/show | `visitNamed('circles'` / `'circleShow')` | `push` |
+   | `navigateToCircle` list/show | `push('circles'` / `'circleShow')` (slice 4) | — |
    | Admin tab | `visitNamed('adminDashboard', {}, { tab })` | `push` with query |
-   | Join flow `circleShow` | `visitNamed` | `push` |
+   | Join flow `circleShow` | `push` (slice 4) | — |
 
    **Stay `visitNamed`:** `loginAs` → notebooks (first load); identify; invitation `circleJoin`; `visitRecallPage`; epub `leaveEpubReadingViewAndReturn`; `visitHomePage` (only `feature_toggle.feature`, first SPA load — `push` would only fall back).
 
@@ -106,13 +106,11 @@ Deleted unused create-and-copy step, `myCirclesPage.ts`, `start.navigateToMyCirc
 
 ---
 
-### 4. Circles list and show after first load use named push — Behavior `[ ]`
+### 4. Circles list and show after first load use named push — Behavior `[x]`
 
-**Timing:** yes — `e2e_test/features/circles/notebooks_in_circles.feature` (list/show after login). 3-run baseline at start, then 3 greens.
+`navigateToCircle` list (`circles`) and show (`circleShow`) use `push`. Post-join saved invitation `circleShow` uses `push`. Invitation **join** URL stays `visitNamed('circleJoin')`. No remount marker.
 
-**Pre:** logged-in SPA. **Trigger:** open a circle (existing `navigateToCircle` / post-join `circleShow`). **Post:** circle UI as today; those jumps `push`. Invitation **join** URL stays `visitNamed('circleJoin')`.
-
-**Verify:** `notebooks_in_circles.feature` (timer). Once: `e2e_test/features/circles/creating_circles.feature` (join stays remount). Record before/after medians in this PLAN.
+**Timing** (`notebooks_in_circles.feature`, `stats.duration` median of 3): 7.274s (7323, 7274, 6818 ms) → 5.726s (5726, 5691, 5742 ms). Threshold 10.274s. **Pass** (faster). `creating_circles.feature` once: 2/2 (join remount still works).
 
 ---
 

--- a/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
+++ b/.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md
@@ -1,139 +1,28 @@
 # Named SPA route honesty cleanup
 
-**Status:** in progress (slices 1–4 and 6 done; 5 remaining).
+**Status:** shipped (2026-08-30). Plan retired — Given-shaped later jumps use named `push` in E2E helpers.
 **Type:** ad-hoc plan (`.planning/quick/`)
-**Depends on:** shipped `.planning/quick/011-named-spa-route-honesty-follow-up/` (PLAN retired; named visit gate, `namedLocationHref`, Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) E2E table remain on `main`); shipped `.planning/quick/015-spa-hydrate-after-testability-inject/` (PLAN retired 2026-08-29)
+**Depends on:** shipped 011 (named visit gate, `namedLocationHref`, Proposed [ADR 0005](../../../docs/adrs/0005-web-routes.md) E2E table); shipped 015 (identity jumps, catalog page re-enter, assimilate menu Model A)
 
-## Goal
+## Protocol (after first SPA load)
 
-Close leftovers from 011: **dead E2E** and the ADR table’s **later-jump = named `push`** (slice 10 still `visitNamed`s most Given shortcuts). Operator STATE no longer points at the retired 011 PLAN (spent-plan cleanup 2026-08-29). Do not reopen unit-wiki HTML pinning, recall remount, or ADR accept.
+| Need | Mechanism |
+|------|-----------|
+| Logged-in Given shortcut to bazaar / settings / circles / admin tab | Named `push` (`navigateToBazaar`, `visitManageAccessTokensPage`, `visitRecallStatsPage`, `navigateToCircle` list/show, post-join `circleShow`, `visitAdminDashboardTab` with `{ tab }` query) |
+| First SPA load, inbound URL, or **explicit remount** | `visitNamed` |
 
-**015 already shipped** (do not redo): Given-shaped note/notebook identity jumps; catalog listing **page re-enter** (`leaveNotebookCatalogIfAlreadyOpen` then `push('notebooks')`); assimilate menu Model A (no `route.name` → `getMenuData`). 015 left admin `visitNamed` for this plan. Bazaar, settings, and circles Given shortcuts now `push` after login (slices 2–4). Invitation join stays `visitNamed('circleJoin')`. Named `push` after login was **not slower** on 015’s timer specs or slices 2–4.
+**Stay `visitNamed`:** `loginAs` → notebooks (first load); identify; invitation `circleJoin`; `visitRecallPage` (KeepAlive); epub `leaveEpubReadingViewAndReturn`; `visitHomePage` (`feature_toggle.feature` only). Do not convert `When I visit recall` to sidebar UI. Human owns ADR 0005 accept.
 
-## Inspection (011 on `main`)
+Bazaar proving observable: `__donutSpaDocumentMarker` on `window` inside `navigateToBazaar` after login (no Gherkin about `window`). Logged-out bazaar still `push` → `visitNamed` fallback.
 
-Scope: 011’s route-honesty commits (unit leftovers + E2E gate + ADR rewrite), not later probe work. Bar: Proposed ADR 0005 E2E intent table, `unit-testing.mdc` focused assertions, post-change-refactor dead/redundant/duplication.
+## Speed gate
 
-### Sliced (meaningful)
+Median of 3 Cypress mocha `stats.duration` scores. Pass if after ≤ before + max(15% of before, 3s). Raw JSON was local-only (`/tmp/route-honesty-profile/`).
 
-1. **Dead E2E navigation leftovers.** Done in slice 1. Invitation join stays inject + `visitNamed('circleJoin')`. `visitHomePage` kept (`feature_toggle.feature`).
-
-2. **Given shortcuts still remount after first load.** ADR / `e2e-authoring.mdc`: after first SPA load, Given-shaped jumps use named `router.push`; `visitNamed` is first load, inbound URL, or **explicit remount**. Slice 10 converted leftover `cy.visit('/…')` to `visitNamed` and left them there. `push` already falls back to `visitNamed` when `@firstVisited` is not `yes`. Call sites that remount after login:
-
-   | Helper | Today | After |
-   |---|---|---|
-   | `navigateToBazaar` | `push('bazaar')` (slice 2) | — |
-   | `visitManageAccessTokensPage` | `push('settingsAccessTokens')` (slice 3) | — |
-   | `visitRecallStatsPage` | `push('settingsRecallStats')` (slice 3) | — |
-   | `navigateToCircle` list/show | `push('circles'` / `'circleShow')` (slice 4) | — |
-   | Admin tab | `visitNamed('adminDashboard', {}, { tab })` | `push` with query |
-   | Join flow `circleShow` | `push` (slice 4) | — |
-
-   **Stay `visitNamed`:** `loginAs` → notebooks (first load); identify; invitation `circleJoin`; `visitRecallPage`; epub `leaveEpubReadingViewAndReturn`; `visitHomePage` (only `feature_toggle.feature`, first SPA load — `push` would only fall back).
-
-   **`push` has no `query`.** Add optional query in the same slice that converts admin tabs — not a standalone unused parameter.
-
-3. **`.planning/STATE.md` 011 pointer** — done (spent-plan cleanup 2026-08-29). Do not resurrect the 011 diary.
-
-### Inspected and not slicing
-
-| Finding | Why not a slice |
-|---|---|
-| `jumpToFolderPage` waits outside the innermost `.then` | Cypress enqueues the wait at call time; nested `.then` commands insert **before** it. Same pattern as pre-existing `jumpToNotebookPage`. Not a race vs the old in-then wait. |
-| Wiki helper pending→live siblings only assert class | 011 slice 2: canonical live tag lives in `replaceWikiLinksInHtml` “replaces known wikilink text”. Intentional. |
-| Two Gherkin Thens share `followWikiLinkToNote` | Both phrases are used (`should open` vs `following`). Not duplicate scenarios. |
-| `routes.spec.ts` notebooks + adminDashboard query compiles | Plan asked one extra name compile; query compile is the only `namedLocationHref` + query pin. Dummy lockstep `it.each` is dummy vs production **path**, a different claim. |
-| Visit-gate `grep cy.visit(` misses `cy.visit (` | No caller; not worth a slice. |
-| EPUB `@ignore` flake (`chooseBookBlockByTitle`) | Pre-existing; 011 remount helper is not the flake. |
-| Convert `When I visit recall` to sidebar UI | KeepAlive; 011 jidoka. |
-| Ban path strings in `cy.url()` classifiers | Inbound classifiers; ADR allows them. |
-| Dummy catch-all `/` test routers | Not a second screen dialect. |
-| Accept ADR 0005 | Human. |
-| `wikiLinkMarkup.ts` at 248 lines | Under 250. |
-| Duplicate ADR vs `e2e-authoring.mdc` intent table | Each artifact stands alone; 011 kept both. |
-| Invitation does not visit a UI-copied URL | 011 slice 11 dropped `@savedInvitationCode` on purpose; inject + `visitNamed('circleJoin')` matches that decision. |
-| Convert `visitHomePage` to `push` | Only first-load `feature_toggle.feature`. |
-| Identity `jumpToNotePage` / `jumpToNotebookPage` / owned `{notepath}` | 015. Bazaar-rooted `{notepath}` still walks the bazaar catalog after `navigateToBazaar`. |
-| Catalog listing after inject | 015 page re-enter. Do **not** make `navigateToNotebooksPage` a `visitNamed`. |
-| Assimilate menu `route.name` refetch | 015 reverted. Do not bring it back. |
-
-## Design decisions
-
-- **Delete unused my-circles and reload-home E2E**, including `myCirclesPage.ts` if nothing remains. Circles list/show stay on `circlePage.ts`. Keep `visitHomePage`. Do not add “create circle in the UI” or “reload home” scenarios in this plan.
-- **One proving observable for push vs remount:** after `loginAs`, set a marker on `window` in the existing logged-in bazaar step path (do not add a Gherkin phrase about `window`). `cy.visit` remount clears it; named `push` does not. Logged-out `browsing.feature` is first load (`push` → `visitNamed` fallback) — not the proof.
-- **Optional `query` on `push`** only when converting admin tabs in the same slice.
-- **Speed gate (same as 015 / test-optimization):** every remaining slice that converts a logged-in Given shortcut from `visitNamed` to named `push` (slices 2–5). Navigation wall-clock can change; bazaar proving `push` does not cover settings/circles/admin specs.
-  - Score: Cypress mocha JSON `stats.duration` (ms → s). Median of **3** runs.
-  - Pass if after ≤ before + max(15% of before, 3s). Named `push` should be **faster or equal**.
-  - **Baseline at slice start** (current `visitNamed`), then reuse 3 consecutive greens as the after sample.
-  - Tee JSON locally (e.g. `/tmp/route-honesty-profile/`); **do not commit**.
-  - If a slice fails the gate, **revert that slice**; do not keep a slower remount-everywhere “honesty.”
-  - Timer command: `CURSOR_DEV=true nix develop -c pnpm cypress run --spec <feature> --reporter json`
-  - Do not use logged-out `browsing.feature` as a push timer (`push` → `visitNamed` fallback).
-- **STATE:** 011 pointer already dropped (spent-plan cleanup). Do not add a permanent 011 diary. Mention this cleanup plan only while it is active.
-- **Do not** convert recall remount, epub remount, identify, invitation `circleJoin`, `loginAs` notebooks, or `visitHomePage`.
-- **Do not** redo 015 catalog re-enter, identity jumps, or menu hydrate.
-
-## Slices
-
-Status legend: `[ ]` planned · `[~]` in progress · `[x]` done
-
-### 1. Remove unused my-circles and reload-home E2E — Structure `[x]`
-
-Deleted unused create-and-copy step, `myCirclesPage.ts`, `start.navigateToMyCircles`, reload-home Given, and `reloginAndEnsureHomePage`. Kept `visitHomePage`. `creating_circles.feature` and `feature_toggle.feature` passed.
-
----
-
-### 2. Bazaar after login uses named push — Behavior `[x]`
-
-`navigateToBazaar` uses `push('bazaar')`. After login, `__donutSpaDocumentMarker` is set on `window` in that helper and asserted to survive (no Gherkin about `window`). First load skips the marker (`push` → `visitNamed` fallback). Logged-out `browsing.feature` passed once.
-
-**Timing** (`bazaar_subscription.feature`, `stats.duration` median of 3): before 4.835s (6030, 4835, 4560 ms) → after 4.145s (4313, 3936, 4145 ms). Threshold 7.835s. **Pass** (faster). Marker stays local to bazaar — slices 3–5 do not copy it unless a remount is suspected.
-
-**Learning:** no KeepAlive remount needed for bazaar; do not extract a shared marker helper for settings/circles/admin.
-
----
-
-### 3. Settings Given shortcuts use named push — Behavior `[x]`
-
-`visitManageAccessTokensPage` → `push('settingsAccessTokens')`. `visitRecallStatsPage` → `push('settingsRecallStats')`. No remount marker (bazaar’s stays local). Settings tabs are not KeepAlive.
-
-**Timing** (`stats.duration` median of 3):
-- `user_access_token.feature`: 2.568s → 2.013s (threshold 5.568s). **Pass** (faster).
-- Plan-named `recall_stats.feature` is entirely `@wip` (unrelated SDK sequencing race; out of scope). Live timer: `daily_probe.feature` (same `I visit my recall stats` step): 16.339s → 15.263s (threshold 19.339s). **Pass** (faster).
-
-**Learning:** do not un-`@wip` `recall_stats.feature` in this plan. Later slices should pick a CI-runnable spec that actually hits the helper.
-
----
-
-### 4. Circles list and show after first load use named push — Behavior `[x]`
-
-`navigateToCircle` list (`circles`) and show (`circleShow`) use `push`. Post-join saved invitation `circleShow` uses `push`. Invitation **join** URL stays `visitNamed('circleJoin')`. No remount marker.
-
-**Timing** (`notebooks_in_circles.feature`, `stats.duration` median of 3): 7.274s (7323, 7274, 6818 ms) → 5.726s (5726, 5691, 5742 ms). Threshold 10.274s. **Pass** (faster). `creating_circles.feature` once: 2/2 (join remount still works).
-
----
-
-### 5. Admin dashboard tabs use named push with query — Behavior `[ ]`
-
-**Timing:** yes — `e2e_test/features/user_admin/manage_bazaar.feature`. 3-run baseline at start, then 3 greens.
-
-**Pre:** admin session, SPA already loaded. **Trigger:** open an admin tab. **Post:** that tab as today. `push(name, params, query?)`; `visitAdminDashboardTab` passes `{ tab }`. No other `push` caller required to pass query.
-
-**Verify:** `manage_bazaar.feature`. Record before/after medians in this PLAN.
-
----
-
-### 6. Operator STATE matches shipped 011 — Structure `[x]`
-
-Done in spent-plan cleanup 2026-08-29: `.planning/STATE.md` no longer links the retired 011 PLAN; this cleanup plan is listed while it is active. Do not resurrect 011 diary files.
-
-## Jidoka
-
-- Do not convert `When I visit recall` to sidebar UI.
-- Do not restore a silent `time` query cache-buster.
-- Timing fail on slices 2–5 → revert **that** slice; do not accept slower E2E for honesty.
-- If a Given shortcut **must** remount (KeepAlive / stale view), keep explicit `visitNamed` and note it next to recall/epub — do not silently remount the rest.
-- Do not “fix” catalog hydrate or identity jumps here (015). Do not overlap 015’s `navigateToNotebooksPage` re-enter.
-- Human owns ADR accept. Do not rewrite ADR 0005 unless a converted call site contradicts the intent table (it should not).
-- Live OpenAI recording E2E can flake on `main` (015); do not treat that as a 014 timing or honesty failure.
+| Spec | Before | After | Gate | Result |
+|------|--------|-------|------|--------|
+| bazaar_subscription | 4.835s | 4.145s | ≤ 7.835s | pass |
+| user_access_token | 2.568s | 2.013s | ≤ 5.568s | pass |
+| daily_probe (recall stats helper; `recall_stats.feature` is `@wip`) | 16.339s | 15.263s | ≤ 19.339s | pass |
+| notebooks_in_circles | 7.274s | 5.726s | ≤ 10.274s | pass |
+| manage_bazaar | 1.454s | 1.203s | ≤ 4.454s | pass |

--- a/e2e_test/start/pageObjects/adminPages/adminDashboardPage.ts
+++ b/e2e_test/start/pageObjects/adminPages/adminDashboardPage.ts
@@ -12,7 +12,7 @@ const ADMIN_DASHBOARD_TAB_QUERY: Record<string, string> = {
 }
 
 function visitAdminDashboardTab(tab: string) {
-  router().visitNamed('adminDashboard', {}, { tab })
+  router().push('adminDashboard', {}, { tab })
 }
 
 function removeNotebookFromBazaarTableRow(notebook: string) {

--- a/e2e_test/start/pageObjects/bazaarPage.ts
+++ b/e2e_test/start/pageObjects/bazaarPage.ts
@@ -1,6 +1,15 @@
 import { bazaarOrCircle } from './BazaarOrCircle'
 import router from '../router'
 
+const SPA_DOCUMENT_MARKER = '__donutSpaDocumentMarker'
+
+type WindowWithSpaDocumentMarker = Cypress.AUTWindow & {
+  [SPA_DOCUMENT_MARKER]?: true
+}
+
+const isSpaAlreadyLoaded = (firstVisited: unknown) =>
+  (firstVisited as { valueOf(): string }).valueOf() === 'yes'
+
 export const assumeBazaarPage = () => {
   cy.findByText('Welcome To The Bazaar')
 
@@ -8,8 +17,27 @@ export const assumeBazaarPage = () => {
 }
 
 export const navigateToBazaar = () => {
-  router().visitNamed('bazaar')
+  let expectDocumentToSurvive = false
+  cy.get('@firstVisited').then((firstVisited) => {
+    expectDocumentToSurvive = isSpaAlreadyLoaded(firstVisited)
+    if (expectDocumentToSurvive) {
+      cy.window().then((win: WindowWithSpaDocumentMarker) => {
+        win[SPA_DOCUMENT_MARKER] = true
+      })
+    }
+  })
+  router().push('bazaar')
   cy.get('h2', { timeout: 3000 }).should('contain', 'Welcome To The Bazaar')
+  cy.then(() => {
+    if (expectDocumentToSurvive) {
+      cy.window().should((win: WindowWithSpaDocumentMarker) => {
+        expect(
+          win[SPA_DOCUMENT_MARKER],
+          'Bazaar navigation after login should keep the SPA document (named push, not remount)'
+        ).to.eq(true)
+      })
+    }
+  })
 
   return assumeBazaarPage()
 }

--- a/e2e_test/start/pageObjects/circlePage.ts
+++ b/e2e_test/start/pageObjects/circlePage.ts
@@ -66,10 +66,10 @@ export const navigateToCircle = (circleName: string) => {
       | undefined
     if (aliases?.[alias]) {
       return cy.get(`@${alias}`, { log: false }).then((circleId) => {
-        router().visitNamed('circleShow', { circleId: String(circleId) })
+        router().push('circleShow', { circleId: String(circleId) })
       })
     }
-    router().visitNamed('circles')
+    router().push('circles')
     cy.findByText(circleName, { selector: 'a', timeout: 15000 })
       .should('be.visible')
       .click()

--- a/e2e_test/start/pageObjects/manageAccessTokensPage.ts
+++ b/e2e_test/start/pageObjects/manageAccessTokensPage.ts
@@ -3,7 +3,7 @@ import { submittableForm } from 'start/forms'
 import router from '../router'
 
 export const visitManageAccessTokensPage = () => {
-  router().visitNamed('settingsAccessTokens')
+  router().push('settingsAccessTokens')
   waitUntilAppIsNotBusy()
   return manageAccessTokensPage()
 }

--- a/e2e_test/start/pageObjects/recallStatsPage.ts
+++ b/e2e_test/start/pageObjects/recallStatsPage.ts
@@ -46,7 +46,7 @@ export const recallStatsPage = () => {
 }
 
 export const visitRecallStatsPage = () => {
-  router().visitNamed('settingsRecallStats')
+  router().push('settingsRecallStats')
   waitUntilAppIsNotBusy()
   return recallStatsPage()
 }

--- a/e2e_test/step_definitions/circle.ts
+++ b/e2e_test/step_definitions/circle.ts
@@ -59,7 +59,7 @@ When('I join the saved circle invitation as the logged-in user', () => {
         body: { invitationCode: code },
       }).then((response) => {
         expect(response.status, 'join circle via invitation code').to.equal(200)
-        router().visitNamed('circleShow', { circleId: response.body.id })
+        router().push('circleShow', { circleId: response.body.id })
         start.waitUntilAppIsNotBusy()
       })
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Execute `.planning/quick/014-named-spa-route-honesty-cleanup/PLAN.md`: after first SPA load, Given-shaped E2E jumps use named `router.push` instead of remounting with `visitNamed`.

## What changed
- **Bazaar:** `navigateToBazaar` → `push('bazaar')`. After login, `__donutSpaDocumentMarker` on `window` proves the document is not remounted. Logged-out `browsing.feature` still full-loads via `push` → `visitNamed` fallback.
- **Settings:** access tokens and recall stats helpers `push`.
- **Circles:** list/show and post-join `circleShow` `push`. Invitation join stays `visitNamed('circleJoin')`.
- **Admin:** `visitAdminDashboardTab` → `push('adminDashboard', {}, { tab })` (existing query arg).

## Timing (median of 3 Cypress `stats.duration`; pass if after ≤ before + max(15%, 3s))
| Spec | Before | After | Result |
|------|--------|-------|--------|
| bazaar_subscription | 4.835s | 4.145s | pass (faster) |
| user_access_token | 2.568s | 2.013s | pass (faster) |
| daily_probe (recall stats helper; `recall_stats.feature` is `@wip`) | 16.339s | 15.263s | pass (faster) |
| notebooks_in_circles | 7.274s | 5.726s | pass (faster) |
| manage_bazaar | 1.454s | 1.203s | pass (faster) |

## Stay `visitNamed` (intentional)
`loginAs` notebooks, identify, invitation `circleJoin`, `visitRecallPage` (KeepAlive), epub remount helper, `visitHomePage`. Do not convert `When I visit recall` to sidebar UI.

## Out of scope
ADR 0005 accept (human), 015 catalog/identity work, un-`@wip` of `recall_stats.feature`.

Slices 1 and 6 of the plan were already on `main`. The 014 PLAN is retired (same pattern as 015).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09876a48-cf82-4358-a0c0-196e9e9e50b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09876a48-cf82-4358-a0c0-196e9e9e50b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

